### PR TITLE
docker-compose.ymlに環境変数を追加して，APIのURLをここから呼び出す

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - ./view:/app
     stdin_open: true
     tty: true
+    environment:
+      - VUE_APP_URL=http://localhost
 
 volumes:
   mysql-data:

--- a/view/vue-project/src/components/SignIn.vue
+++ b/view/vue-project/src/components/SignIn.vue
@@ -39,7 +39,7 @@ export default {
       this.show = true
     },
     signIn: function() {
-      const url = 'http://localhost/api/auth/sign_in'
+      const url = process.env.VUE_APP_URL + '/api/auth/sign_in'
       var params = new URLSearchParams();
       params.append('email', this.email);
       params.append('password', this.password);

--- a/view/vue-project/src/components/SignUp.vue
+++ b/view/vue-project/src/components/SignUp.vue
@@ -41,7 +41,7 @@ export default {
       this.show = true
     },
     signUp: function() {
-      const url = 'http://localhost/api/auth'
+      const url = process.env.VUE_APP_URL + '/api/auth'
       var params = new URLSearchParams();
       params.append('name', this.name);
       params.append('email', this.email);

--- a/view/vue-project/src/views/MyPage.vue
+++ b/view/vue-project/src/views/MyPage.vue
@@ -25,7 +25,8 @@ export default {
   },
   methods: {
     signOut: function() {
-      axios.delete('http://localhost/api/auth/sign_out', {
+      const url = process.env.VUE_APP_URL + '/api/auth/sign_out'
+      axios.delete(url, {
         headers: { 
           "Content-Type": "application/json", 
           "access-token": localStorage.getItem('access-token'),
@@ -41,7 +42,7 @@ export default {
     }
   },
   mounted() {
-    const url = 'http://localhost/api/v1/users/show'
+    const url = process.env.VUE_APP_URL + '/api/v1/users/show'
     axios.get(url, {
       headers: { 
         "Content-Type": "application/json", 


### PR DESCRIPTION
# やったこと
- `docker-compose.yml`の編集
  - environment に環境変数を入れることができる
  -`VUE_APP_URL=http://localhost`

- それぞれの呼び出し部分の編集
  - `process.env.VUE_APP_URL`で呼び出すことができる

# 確認
普通に変わらずAPIを叩けたらOK（つまり前の挙動と変わらなければOK）

# なんでこんなことをやってるか
実際にデプロイするときはAPIのURLが変更されるので，すべてのコンポーネントに`http://localhost`って書いてたら全部編集しなければいけないでけど，環境変数にいれておくことで，`docker-compose.yml`だけ編集すればすべて変わる．

resolve #24 