### PR TITLE
Groupモデルの追加

### DIFF
--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -1,0 +1,53 @@
+class GroupsController < ApplicationController
+  before_action :set_group, only: [:show, :update, :destroy]
+
+  # GET /groups
+  # GET /groups.json
+  def index
+    @groups = Group.all
+  end
+
+  # GET /groups/1
+  # GET /groups/1.json
+  def show
+  end
+
+  # POST /groups
+  # POST /groups.json
+  def create
+    @group = Group.new(group_params)
+
+    if @group.save
+      render :show, status: :created, location: @group
+    else
+      render json: @group.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /groups/1
+  # PATCH/PUT /groups/1.json
+  def update
+    if @group.update(group_params)
+      render :show, status: :ok, location: @group
+    else
+      render json: @group.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /groups/1
+  # DELETE /groups/1.json
+  def destroy
+    @group.destroy
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_group
+      @group = Group.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def group_params
+      params.require(:group).permit(:name, :group_category_id, :user_id, :activity, :fes_year_id)
+    end
+end

--- a/api/app/models/fes_year.rb
+++ b/api/app/models/fes_year.rb
@@ -1,0 +1,3 @@
+class FesYear < ApplicationRecord
+    has_many :groups
+end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -1,0 +1,3 @@
+class Group < ApplicationRecord
+    belongs_to :user
+end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -1,3 +1,4 @@
 class Group < ApplicationRecord
     belongs_to :user
+    belongs_to :fes_year
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
   belongs_to :role
   has_one :user_detail, dependent: :destroy
+  has_many :groups
 end

--- a/api/app/views/groups/_group.json.jbuilder
+++ b/api/app/views/groups/_group.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! group, :id, :name, :group_category_id, :user_id, :activity, :fes_year_id, :created_at, :updated_at
+json.url group_url(group, format: :json)

--- a/api/app/views/groups/index.json.jbuilder
+++ b/api/app/views/groups/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @groups, partial: "groups/group", as: :group

--- a/api/app/views/groups/show.json.jbuilder
+++ b/api/app/views/groups/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "groups/group", group: @group

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :groups
   resources :user_details
   namespace 'api' do
     namespace 'v1' do

--- a/api/db/fixtures/fes_year.rb
+++ b/api/db/fixtures/fes_year.rb
@@ -1,0 +1,7 @@
+FesYear.seed( :id,
+{ id: 1, year_num: 2020  },
+{ id: 2, year_num: 2021  },
+{ id: 3, year_num: 2022  },
+{ id: 4, year_num: 2023  },
+{ id: 5, year_num: 2024  },
+)

--- a/api/db/migrate/20200825101151_create_groups.rb
+++ b/api/db/migrate/20200825101151_create_groups.rb
@@ -1,0 +1,13 @@
+class CreateGroups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.integer :group_category_id
+      t.integer :user_id
+      t.text :activity
+      t.integer :fes_year_id
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/migrate/20200827071957_create_fes_years.rb
+++ b/api/db/migrate/20200827071957_create_fes_years.rb
@@ -1,0 +1,9 @@
+class CreateFesYears < ActiveRecord::Migration[6.0]
+  def change
+    create_table :fes_years do |t|
+      t.integer :year_num
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_183322) do
+ActiveRecord::Schema.define(version: 2020_08_25_101151) do
 
   create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(version: 2020_08_19_183322) do
 
   create_table "grades", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.integer "group_category_id"
+    t.string "user_id"
+    t.text "activity"
+    t.integer "fes_year_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_101151) do
+ActiveRecord::Schema.define(version: 2020_08_27_071957) do
 
   create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "fes_years", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "year_num"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -27,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_08_25_101151) do
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.integer "group_category_id"
-    t.string "user_id"
+    t.integer "user_id"
     t.text "activity"
     t.integer "fes_year_id"
     t.datetime "created_at", precision: 6, null: false

--- a/api/test/controllers/groups_controller_test.rb
+++ b/api/test/controllers/groups_controller_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @group = groups(:one)
+  end
+
+  test "should get index" do
+    get groups_url, as: :json
+    assert_response :success
+  end
+
+  test "should create group" do
+    assert_difference('Group.count') do
+      post groups_url, params: { group: { activity: @group.activity, fes_year_id: @group.fes_year_id, group_category_id: @group.group_category_id, name: @group.name, user_id: @group.user_id } }, as: :json
+    end
+
+    assert_response 201
+  end
+
+  test "should show group" do
+    get group_url(@group), as: :json
+    assert_response :success
+  end
+
+  test "should update group" do
+    patch group_url(@group), params: { group: { activity: @group.activity, fes_year_id: @group.fes_year_id, group_category_id: @group.group_category_id, name: @group.name, user_id: @group.user_id } }, as: :json
+    assert_response 200
+  end
+
+  test "should destroy group" do
+    assert_difference('Group.count', -1) do
+      delete group_url(@group), as: :json
+    end
+
+    assert_response 204
+  end
+end

--- a/api/test/fixtures/fes_years.yml
+++ b/api/test/fixtures/fes_years.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  fes_year: 
+
+two:
+  fes_year: 

--- a/api/test/fixtures/groups.yml
+++ b/api/test/fixtures/groups.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  group_category_id: 1
+  user_id: MyString
+  activity: MyText
+  fes_year_id: 1
+
+two:
+  name: MyString
+  group_category_id: 1
+  user_id: MyString
+  activity: MyText
+  fes_year_id: 1

--- a/api/test/models/fes_year_test.rb
+++ b/api/test/models/fes_year_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FesYearTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/api/test/models/group_test.rb
+++ b/api/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# やったこと
## Groupモデルの追加
ユーザーに対して一対多の関係（一人のユーザーに対して多数のグループを持つ）のgroupモデルを追加．

# 確認してほしいこと
以下のコマンドを実行してエラーがでないかどうか．
## ターミナル
- `docker-compose run api rails db:migrate`
- `docker-compose run api rails c`でrailsコンソールを立ち上げる．

## railsコンソール
- `Group.create(name:'***', group_category_id:*, user_id:*, activity:'***', fes_year_id:*)` でgroup登録．
name,activityは適当に文字を入れてもらえればok.
user_idはすでに登録してあるuser_idを入れる．
group_category_id,fes_year_idもまだ存在しないので適当に数字を入れてもらえればok．
sample: `Group.create(name:'nutfes', group_category_id:1, user_id:1, activity:'testです', fes_year_id:1)`
- `Group.all` で登録したgroup情報が表示されるかを確認．
- `Group.find(Group idを入力).user` でuser情報が表示されるかを確認．
sample: `Group.find(1).user`
- `User.find(登録したuser_id).groups` でuserが持つgroup情報が表示されるかを確認．
sample: `User.find(1).groups`

以上のことの確認をお願いします．
