### PR TITLE
SignUpとSignInの表示の変更 #46

### DIFF
--- a/admin_view/nuxt-project/.nuxt/routes.json
+++ b/admin_view/nuxt-project/.nuxt/routes.json
@@ -1,9 +1,0 @@
-[
-  {
-    "name": "index",
-    "path": "/",
-    "component": "/app/nuxt-project/pages/index.vue",
-    "chunkName": "pages/index",
-    "_name": "_dc6fcb74"
-  }
-]

--- a/admin_view/nuxt-project/.nuxt/routes.json
+++ b/admin_view/nuxt-project/.nuxt/routes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "index",
+    "path": "/",
+    "component": "/app/nuxt-project/pages/index.vue",
+    "chunkName": "pages/index",
+    "_name": "_dc6fcb74"
+  }
+]

--- a/view/vue-project/src/components/SignIn.vue
+++ b/view/vue-project/src/components/SignIn.vue
@@ -45,12 +45,8 @@
 
 <script>
 import axios from 'axios'
-import Signup from './SignUp'
 export default {
   name: 'SignIn',
-  components: {
-    Signup
-  },
   data () {
     return {
       show_pass: true,
@@ -69,7 +65,6 @@ export default {
       }
     }
   },
-  props: ['clickSignup'],
   computed: {
     form () {
       return {
@@ -114,7 +109,7 @@ export default {
           this.$router.push('MyPage')
         },
         (error) => {
-          this.message = 'login ni sippai simasita'
+          this.message = 'ログインに失敗しました。' + error
           return error
         }
       )},

--- a/view/vue-project/src/components/SignIn.vue
+++ b/view/vue-project/src/components/SignIn.vue
@@ -1,66 +1,84 @@
  <template>
-  <v-row justify="center">
-    <v-dialog v-model="show" max-width="600px" dark>
-      <v-card>
-        <v-card-title>
-          <span class="headline">ログイン</span>
-        </v-card-title>
-        <v-card-text>
-          <v-container>
-            <v-form  ref="form">
-              <v-text-field
-                label="メールアドレス"
-                ref="email"
-                v-model="email"
-                :rules="[rules.requied]"
-                required
-              ></v-text-field>
-              <v-text-field
-                label="パスワード"
-                v-model="password"
-                ref="password"
-                :append-icon="show_pass ? 'mdi-eye-off' : 'mdi-eye'"
-                :rules="[rules.required, rules.min]"
-                :type="show_pass ? 'password' : 'text'"
-                hint="8 characters"
-                counter
-                @click:append="show_pass = !show_pass"
-                required
-              ></v-text-field>
-            </v-form>
-          </v-container>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn color="blue darken-1" text @click="cancel">キャンセル</v-btn>
-          <v-btn color="blue darken-1" @click="submit">ログイン</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </v-row>
+    <v-row justify="center">
+      <v-col cols="1"></v-col>
+      <v-col cols="10">
+        <v-card>
+          <v-card-title>
+            <span class="headline">ログイン</span>
+          </v-card-title>
+          <v-card-text>
+            <v-container>
+              <v-form  ref="form">
+                <p v-bind:style="warnStyle"> {{ getMessage }} </p>
+                <v-text-field
+                  label="メールアドレス"
+                  ref="email"
+                  v-model="email"
+                  :rules="[rules.requied, rules.email]"
+                  required
+                ></v-text-field>
+                <v-text-field
+                  label="パスワード"
+                  v-model="password"
+                  ref="password"
+                  :append-icon="show_pass ? 'mdi-eye-off' : 'mdi-eye'"
+                  :rules="[rules.required, rules.min]"
+                  :type="show_pass ? 'password' : 'text'"
+                  hint="8文字以上"
+                  counter
+                  @click:append="show_pass = !show_pass"
+                  required
+                ></v-text-field>
+              </v-form>
+            </v-container>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn color="blue darken-1" text @click="cancel">キャンセル</v-btn>
+            <v-btn color="blue darken-1" @click="submit">ログイン</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+      <v-col cols="1"></v-col>
+    </v-row>
 </template>
 
 <script>
 import axios from 'axios'
+import Signup from './SignUp'
 export default {
   name: 'SignIn',
+  components: {
+    Signup
+  },
   data () {
     return {
-      show: false,
       show_pass: true,
       formHasErrors: false,
       rules: {
         requied: value => !!value || '入力してください',
         min: v => v.length >= 8 || '８文字未満です',
+        email: v => {
+          const pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+          return pattern.test(v) || '適切なメールアドレスではありません。'
+        }
       },
+      message: '',
+      warnStyle: {
+        color: 'red',
+      }
     }
   },
+  props: ['clickSignup'],
   computed: {
     form () {
       return {
         email: null,
         password: null,
       }
+    },
+    getMessage () {
+      return this.message
     }
   },
   methods: {
@@ -96,12 +114,12 @@ export default {
           this.$router.push('MyPage')
         },
         (error) => {
+          this.message = 'login ni sippai simasita'
           return error
         }
-        )
-      this.show = false
-    }
+      )},
   }
 }
+
 </script>
 

--- a/view/vue-project/src/components/SignUp.vue
+++ b/view/vue-project/src/components/SignUp.vue
@@ -1,6 +1,7 @@
  <template>
   <v-row justify="center">
-    <v-dialog v-model="show" max-width="600px" dark>
+    <v-col cols="1"></v-col>
+    <v-col cols="10">
       <v-card>
         <v-card-title>
           <span class="headline">新規登録</span>
@@ -19,7 +20,7 @@
                 label="メールアドレス"
                 ref="email"
                 v-model="email"
-                :rules="[rules.requied]"
+                :rules="[rules.requied, rules.email]"
                 required
               ></v-text-field>
               <v-text-field
@@ -29,7 +30,7 @@
                 :append-icon="show_pass ? 'mdi-eye-off' : 'mdi-eye'"
                 :rules="[rules.requied, rules.min]"
                 :type="show_pass ? 'password' : 'text'"
-                hint="8 characters"
+                hint="8文字以上"
                 counter
                 @click:append="show_pass = !show_pass"
                 required
@@ -41,7 +42,7 @@
                 :append-icon="show_pass_confirmation ? 'mdi-eye' : 'mdi-eye-off'"
                 :rules="[rules.requied, rules.min, rules.match]"
                 :type="show_pass_confirmation ? 'password' : 'text'"
-                hint="8 characters"
+                hint="8文字以上"
                 counter
                 @click:append="show_pass_confirmation = !show_pass_confirmation"
                 required
@@ -51,11 +52,12 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="blue darken-1" text @click="cancel">Close</v-btn>
-          <v-btn color="blue darken-1" text @click="submit">Sign Up</v-btn>
+          <v-btn color="blue darken-1" text @click="cancel">キャンセル</v-btn>
+          <v-btn color="blue darken-1" @click="submit">登録</v-btn>
         </v-card-actions>
       </v-card>
-    </v-dialog>
+    </v-col>
+    <v-col cols="1"></v-col>
   </v-row>
 </template>
 
@@ -65,7 +67,6 @@ export default {
   name: 'SignUp',
   data () {
     return {
-      show: false,
       show_pass: true,
       show_pass_confirmation: true,
       formHasErrors: false,
@@ -73,6 +74,10 @@ export default {
         requied: value => !!value || '入力してください',
         min: v => v.length >= 8 || '８文字未満です',
         match: v => v === this.password || 'パスワードと再確認パスワードが一致していません',
+        email: v => {
+          const pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+          return pattern.test(v) || '適切なメールアドレスではありません'
+        },
       },
     }
   },

--- a/view/vue-project/src/views/Welcome.vue
+++ b/view/vue-project/src/views/Welcome.vue
@@ -6,36 +6,42 @@
         <v-container>
           <v-row>
           <v-col cols="3"></v-col>
-            <v-col cols="6">
-              <v-sheet>NUT festival<br>~飛翔~</v-sheet>
-            </v-col>
-            <v-col cols="3"></v-col>
+          <v-col cols="6">
+            <v-sheet>NUT festival<br>~飛翔~</v-sheet>
+          </v-col>
+          <v-col cols="3"></v-col>
           </v-row>
         </v-container>
       </div>
-      <br><br>
       <v-row>
-        <v-col cols="3"></v-col>
-        <v-col cols="6">
+        <v-col cols="1"></v-col>
+        <v-col cols="5">
           <div class="text-center">
-            <v-btn depressed color="#5C6BC0" dark @click="onClickSignUp">新規登録</v-btn>
-            <Signup ref="signup"/> 
-          </div>
-          <br>
-          <div class="text-center">
-            <v-btn depressed color="#5C6BC0" dark @click="onClickSignIn">ログイン</v-btn>
-            <Signin ref="signin"/> 
-            <br>
+            <img :src="iconImage">
           </div>
         </v-col>
-        <v-col cols="3"></v-col>
+        <v-col cols="5">
+          <v-card class="card-color">
+            <br>
+            <div class="text-center" v-show="show">
+              <Signup />
+              <a @click="toggle_show">ログインはこちら</a>
+            </div>
+            <div class="text-center" v-show="!show">
+              <Signin />
+              <a @click="toggle_show">新規登録はこちら</a>
+            </div>
+            <br>
+          </v-card>
+        </v-col>
+        <v-col cols="1"></v-col>
       </v-row>
     </div>
   </div>
 </template>
 
 <script>
-import AssetsImage from "../assets/welcome.png"
+import IconImage from "../assets/logo.png"
 import Signup from '../components/SignUp.vue'
 import Signin from '../components/SignIn.vue'
 export default {
@@ -44,12 +50,15 @@ export default {
     Signup,
     Signin
   },
+  data() {
+    return {
+      show: true,
+      iconImage: IconImage,
+    }
+  },
   methods: {
-    onClickSignUp() {
-      this.$refs.signup.open();
-    },
-    onClickSignIn() {
-      this.$refs.signin.open();
+    toggle_show() {
+      this.show = !this.show
     }
   }
 }
@@ -76,5 +85,10 @@ v-sheet{
 .text-label{
   font-size: 45px;
   text-align: center;
+}
+
+.card-color {
+  background-color: rgba(255,255,255,0.5) !important;
+  border-color: white !important;
 }
 </style>


### PR DESCRIPTION
# 目的
- SignUpとSignInをWelcomeページで表示する。

# 実装の概要
- dialog部分を削除
- リンクからSignUpとSignInの表示を`v-show`で制御
- ロゴなどを置くような場所を配置

# レビューしてほしいところ
- ログインに失敗したとき画像のように`ログインに失敗しました。`に続いてエラーコードが表示される。
- 新規登録画面では下に`ログインはこちら`が表示されていてクリックするとログイン画面が表示される。
- ログイン画面では下に`新規登録はこちら`が表示されていてクリックするとログイン画面が表示される。
- 画像のように左側にVue.jsのアイコンが表示されている。
![2020-10-06 22 00 05 localhost d855ff6394de](https://user-images.githubusercontent.com/39459987/95204640-564fa280-081f-11eb-8907-8c1b62d5b640.png)
