### PR TITLE
パスワードの可視化ボタンの修正

### DIFF
--- a/view/vue-project/src/components/SignUp.vue
+++ b/view/vue-project/src/components/SignUp.vue
@@ -39,7 +39,7 @@
                 label="パスワードの再入力"
                 ref="password_confirmation"
                 v-model="password_confirmation"
-                :append-icon="show_pass_confirmation ? 'mdi-eye' : 'mdi-eye-off'"
+                :append-icon="show_pass_confirmation ? 'mdi-eye-off' : 'mdi-eye'"
                 :rules="[rules.requied, rules.min, rules.match]"
                 :type="show_pass_confirmation ? 'password' : 'text'"
                 hint="8文字以上"


### PR DESCRIPTION
resolve #46 

# 目的
- 新規登録のパスワード入力、再確認フォームの右の目のアイコンが正しく表示されること

# 実装の概要
- 間違っていた再確認フォームでの表示画像を修正

# レビューしてほしいところ
- パスワード入力の際に目のマークに斜線が入っているときには'・'でパスワードが隠されていること。
- 目のマークに斜線が入っていないときには文字が可視化されていること。