### PR TITLE
パスワードの可視化ボタン表示の修正

### DIFF
--- a/view/vue-project/src/components/SignIn.vue
+++ b/view/vue-project/src/components/SignIn.vue
@@ -9,7 +9,7 @@
           <v-card-text>
             <v-container>
               <v-form  ref="form">
-                <p v-bind:style="warnStyle"> {{ getMessage }} </p>
+                <p v-bind:style="warnStyle" v-html="getMessage"></p>
                 <v-text-field
                   label="メールアドレス"
                   ref="email"
@@ -45,6 +45,7 @@
 
 <script>
 import axios from 'axios'
+import colors from 'vuetify/lib/util/colors'
 export default {
   name: 'SignIn',
   data () {
@@ -61,7 +62,7 @@ export default {
       },
       message: '',
       warnStyle: {
-        color: 'red',
+        color: '#F44336'
       }
     }
   },
@@ -109,7 +110,7 @@ export default {
           this.$router.push('MyPage')
         },
         (error) => {
-          this.message = 'ログインに失敗しました。' + error
+          this.message = 'ログインに失敗しました。<br>Failed to SignIn'
           return error
         }
       )},

--- a/view/vue-project/src/components/SignUp.vue
+++ b/view/vue-project/src/components/SignUp.vue
@@ -9,6 +9,8 @@
         <v-card-text>
           <v-container>
             <v-form ref="form">
+              <p v-bind:style="warnStyle" v-html="getMessage"></p>
+
               <v-text-field
                 label="フルネーム"
                 ref="name"
@@ -63,6 +65,7 @@
 
 <script>
 import axios from 'axios'
+import colors from 'vuetify/lib/util/colors'
 export default {
   name: 'SignUp',
   data () {
@@ -79,6 +82,10 @@ export default {
           return pattern.test(v) || '適切なメールアドレスではありません'
         },
       },
+      message: '',
+      warnStyle: {
+        color: '#F44336'
+      }
     }
   },
   computed: {
@@ -89,6 +96,9 @@ export default {
         password: null,
         password_confirmation: null,
       }
+    },
+    getMessage () {
+      return this.message
     }
   },
   methods: {
@@ -126,6 +136,10 @@ export default {
           localStorage.setItem('uid', response.headers['uid'])
           localStorage.setItem('token-type', response.headers['token-type'])
           this.$router.push('MyPage')
+        },
+        (error) => {
+          this.message = '登録に失敗しました。<br>Failed to SignUp'
+          return error
         }
       )
     }

--- a/view/vue-project/src/components/SignUp.vue
+++ b/view/vue-project/src/components/SignUp.vue
@@ -39,7 +39,7 @@
                 label="パスワードの再入力"
                 ref="password_confirmation"
                 v-model="password_confirmation"
-                :append-icon="show_pass_confirmation ? 'mdi-eye' : 'mdi-eye-off'"
+                :append-icon="show_pass_confirmation ? 'mdi-eye-off' : 'mdi-eye'"
                 :rules="[rules.requied, rules.min, rules.match]"
                 :type="show_pass_confirmation ? 'password' : 'text'"
                 hint="8文字以上"


### PR DESCRIPTION
resolve #57

# 目的
- 新規登録のパスワード入力、再確認フォームの右の目のアイコンが正しく表示されること

# 実装の概要
- 間違っていた再確認フォームでの表示画像を修正

# レビューしてほしいところ
- パスワード入力の際に目のマークに斜線が入っているときには'・'でパスワードが隠されていること。
- 目のマークに斜線が入っていないときには文字が可視化されていること。
- 新規登録とログインで間違えたときにエラーメッセージがフォーム上部に表示されている。