### PR TITLE
PowerOrderのカラムの変更の確認

### DIFF
--- a/api/app/controllers/power_orders_controller.rb
+++ b/api/app/controllers/power_orders_controller.rb
@@ -50,7 +50,7 @@ class PowerOrdersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def power_order_params
-      #params.require(:power_order).permit(:group_id, :item, :power, :manufacturer, :model)
-      params.permit(:group_id, :item, :power, :manufacturer, :model)
+      #params.require(:power_order).permit(:group_id, :item, :power, :manufacturer, :model, :item_url)
+      params.permit(:group_id, :item, :power, :manufacturer, :model, :item_url)
     end
 end

--- a/api/app/controllers/power_orders_controller.rb
+++ b/api/app/controllers/power_orders_controller.rb
@@ -50,7 +50,7 @@ class PowerOrdersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def power_order_params
-      #params.require(:power_order).permit(:group_id, :item, :power, :manufacture, :model)
-      params.permit(:group_id, :item, :power, :manufacture, :model)
+      #params.require(:power_order).permit(:group_id, :item, :power, :manufacturer, :model)
+      params.permit(:group_id, :item, :power, :manufacturer, :model)
     end
 end

--- a/api/db/fixtures/power_order.rb
+++ b/api/db/fixtures/power_order.rb
@@ -3,6 +3,7 @@ PowerOrder.seed( :id,
                 item: "nutfes-sample",
                 power: 0,
                 manufacturer: "nutfes",
-                model: "nutfes"
+                model: "nutfes",
+                item_url: "https://nutfes.net"
     }
 )

--- a/api/db/fixtures/power_order.rb
+++ b/api/db/fixtures/power_order.rb
@@ -2,7 +2,7 @@ PowerOrder.seed( :id,
     { id: 1 ,   group_id: 1,
                 item: "nutfes-sample",
                 power: 0,
-                manufacture: "nutfes",
+                manufacturer: "nutfes",
                 model: "nutfes"
     }
 )

--- a/api/db/migrate/20201020111348_rename_manufacture_column_to_power_orders.rb
+++ b/api/db/migrate/20201020111348_rename_manufacture_column_to_power_orders.rb
@@ -1,0 +1,5 @@
+class RenameManufactureColumnToPowerOrders < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :power_orders, :manufacture, :manufacturer
+  end
+end

--- a/api/db/migrate/20201020114034_add_item_url_to_power_orders.rb
+++ b/api/db/migrate/20201020114034_add_item_url_to_power_orders.rb
@@ -1,0 +1,5 @@
+class AddItemUrlToPowerOrders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :power_orders, :item_url, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_06_080344) do
+ActiveRecord::Schema.define(version: 2020_10_20_111348) do
 
   create_table "assign_group_places", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "place_order_id"
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 2020_10_06_080344) do
     t.integer "group_id"
     t.string "item"
     t.integer "power"
-    t.string "manufacture"
+    t.string "manufacturer"
     t.string "model"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_20_111348) do
+ActiveRecord::Schema.define(version: 2020_10_20_114034) do
 
   create_table "assign_group_places", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "place_order_id"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2020_10_20_111348) do
     t.string "model"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "item_url"
   end
 
   create_table "roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
resolve #73 
# やったこと
PowerOrderのmanufactureのカラム名をmanufacturerに変更．
あと，item_urlカラムを追加．

# 確認してほしいこと
```
rails db:migrate
rails db:seed_fu
```
をしたあと，
```
localhost/power_orders
```
でそれぞれのカラムの変更がなされているかどうか．