### PR TITLE
ユーザー一覧ページとその詳細ページのテンプレート作成

### DIFF
--- a/admin_view/nuxt-project/.nuxt/index.js
+++ b/admin_view/nuxt-project/.nuxt/index.js
@@ -15,8 +15,9 @@ import { createStore } from './store.js'
 
 import nuxt_plugin_plugin_8ae9aafc from 'nuxt_plugin_plugin_8ae9aafc' // Source: ./components/plugin.js (mode: 'all')
 import nuxt_plugin_plugin_7e140ea8 from 'nuxt_plugin_plugin_7e140ea8' // Source: ./vuetify/plugin.js (mode: 'all')
+import nuxt_plugin_moment_b355c800 from 'nuxt_plugin_moment_b355c800' // Source: ./moment.js (mode: 'all')
 import nuxt_plugin_axios_dd70eed0 from 'nuxt_plugin_axios_dd70eed0' // Source: ./axios.js (mode: 'all')
-import nuxt_plugin_axios_5659d192 from 'nuxt_plugin_axios_5659d192' // Source: ../plugins/axios.js (mode: 'client')
+import nuxt_plugin_fileter_2d3aa2a8 from 'nuxt_plugin_fileter_2d3aa2a8' // Source: ../plugins/fileter.js (mode: 'client')
 import nuxt_plugin_plugin_97087858 from 'nuxt_plugin_plugin_97087858' // Source: ./auth/plugin.js (mode: 'all')
 
 // Component: <ClientOnly>
@@ -207,12 +208,16 @@ async function createApp(ssrContext, config = {}) {
     await nuxt_plugin_plugin_7e140ea8(app.context, inject)
   }
 
+  if (typeof nuxt_plugin_moment_b355c800 === 'function') {
+    await nuxt_plugin_moment_b355c800(app.context, inject)
+  }
+
   if (typeof nuxt_plugin_axios_dd70eed0 === 'function') {
     await nuxt_plugin_axios_dd70eed0(app.context, inject)
   }
 
-  if (process.client && typeof nuxt_plugin_axios_5659d192 === 'function') {
-    await nuxt_plugin_axios_5659d192(app.context, inject)
+  if (process.client && typeof nuxt_plugin_fileter_2d3aa2a8 === 'function') {
+    await nuxt_plugin_fileter_2d3aa2a8(app.context, inject)
   }
 
   if (typeof nuxt_plugin_plugin_97087858 === 'function') {

--- a/admin_view/nuxt-project/.nuxt/router.js
+++ b/admin_view/nuxt-project/.nuxt/router.js
@@ -9,6 +9,8 @@ const _6faa4a12 = () => interopDefault(import('../pages/mypage.vue' /* webpackCh
 const _56ce3ea1 = () => interopDefault(import('../pages/print.vue' /* webpackChunkName: "pages/print" */))
 const _2aa33390 = () => interopDefault(import('../pages/regist_user_detail.vue' /* webpackChunkName: "pages/regist_user_detail" */))
 const _5ee1db54 = () => interopDefault(import('../pages/signup.vue' /* webpackChunkName: "pages/signup" */))
+const _123c2dff = () => interopDefault(import('../pages/users/index.vue' /* webpackChunkName: "pages/users/index" */))
+const _42a8b7b2 = () => interopDefault(import('../pages/users/_id.vue' /* webpackChunkName: "pages/users/_id" */))
 const _dc6fcb74 = () => interopDefault(import('../pages/index.vue' /* webpackChunkName: "pages/index" */))
 
 // TODO: remove in Nuxt 3
@@ -51,6 +53,14 @@ export const routerOptions = {
     path: "/signup",
     component: _5ee1db54,
     name: "signup"
+  }, {
+    path: "/users",
+    component: _123c2dff,
+    name: "users"
+  }, {
+    path: "/users/:id",
+    component: _42a8b7b2,
+    name: "users-id"
   }, {
     path: "/",
     component: _dc6fcb74,

--- a/admin_view/nuxt-project/.nuxt/routes.json
+++ b/admin_view/nuxt-project/.nuxt/routes.json
@@ -3,42 +3,63 @@
     "name": "groups",
     "path": "/groups",
     "component": "/app/nuxt-project/pages/groups.vue",
-    "chunkName": "pages/groups"
+    "chunkName": "pages/groups",
+    "_name": "_6a60f3e0"
   },
   {
     "name": "inspire",
     "path": "/inspire",
     "component": "/app/nuxt-project/pages/inspire.vue",
-    "chunkName": "pages/inspire"
+    "chunkName": "pages/inspire",
+    "_name": "_7f52cd64"
   },
   {
     "name": "mypage",
     "path": "/mypage",
     "component": "/app/nuxt-project/pages/mypage.vue",
-    "chunkName": "pages/mypage"
+    "chunkName": "pages/mypage",
+    "_name": "_6faa4a12"
   },
   {
     "name": "print",
     "path": "/print",
     "component": "/app/nuxt-project/pages/print.vue",
-    "chunkName": "pages/print"
+    "chunkName": "pages/print",
+    "_name": "_56ce3ea1"
   },
   {
     "name": "regist_user_detail",
     "path": "/regist_user_detail",
     "component": "/app/nuxt-project/pages/regist_user_detail.vue",
-    "chunkName": "pages/regist_user_detail"
+    "chunkName": "pages/regist_user_detail",
+    "_name": "_2aa33390"
   },
   {
     "name": "signup",
     "path": "/signup",
     "component": "/app/nuxt-project/pages/signup.vue",
-    "chunkName": "pages/signup"
+    "chunkName": "pages/signup",
+    "_name": "_5ee1db54"
+  },
+  {
+    "name": "users",
+    "path": "/users",
+    "component": "/app/nuxt-project/pages/users/index.vue",
+    "chunkName": "pages/users/index",
+    "_name": "_123c2dff"
+  },
+  {
+    "name": "users-id",
+    "path": "/users/:id",
+    "component": "/app/nuxt-project/pages/users/_id.vue",
+    "chunkName": "pages/users/_id",
+    "_name": "_42a8b7b2"
   },
   {
     "name": "index",
     "path": "/",
     "component": "/app/nuxt-project/pages/index.vue",
-    "chunkName": "pages/index"
+    "chunkName": "pages/index",
+    "_name": "_dc6fcb74"
   }
 ]

--- a/admin_view/nuxt-project/components/Header.vue
+++ b/admin_view/nuxt-project/components/Header.vue
@@ -67,7 +67,7 @@ export default {
       drawer: null,
       items: [
         { title: 'マイページ', icon: 'mdi-account-circle', click: '/mypage'},
-        { title: 'ユーザー一覧', icon: 'mdi-account-multiple', click: '/groups' },
+        { title: 'ユーザー一覧', icon: 'mdi-account-multiple', click: '/users' },
         { title: '参加団体一覧', icon: 'mdi-account-group', click: '/groups' },
         { title: '企画名一覧', icon: 'mdi-unfold-more-vertical', click: '/groups' },
         { title: '貸し出し物品一覧', icon: 'mdi-database', click: '/groups' },

--- a/admin_view/nuxt-project/nuxt.config.js
+++ b/admin_view/nuxt-project/nuxt.config.js
@@ -25,7 +25,10 @@ export default {
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
-    { src: '~/plugins/axios.js', ssr: false }
+    { 
+      src: '~/plugins/axios.js', ssr: false,
+      src: '~/plugins/fileter.js', ssr: false,
+    },
   ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
@@ -36,11 +39,11 @@ export default {
     // https://go.nuxtjs.dev/vuetify
     '@nuxtjs/vuetify',
   ],
-
   // Modules (https://go.nuxtjs.dev/config-modules)
   modules: [
     '@nuxtjs/axios',
-    '@nuxtjs/auth'
+    '@nuxtjs/auth',
+    ['@nuxtjs/moment', ['ja']],
   ],
 
   axios: {

--- a/admin_view/nuxt-project/package-lock.json
+++ b/admin_view/nuxt-project/package-lock.json
@@ -1484,6 +1484,17 @@
         }
       }
     },
+    "@nuxtjs/moment": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/moment/-/moment-1.6.1.tgz",
+      "integrity": "sha512-Mo2/3NQB0XryMQuNCTVnAclrDvt9I9sr6dwVm56KhYCoiWTKgQ78tDV9tmrxw7lahw1IBwyPGhw+3pwkM4phAA==",
+      "requires": {
+        "moment": "^2.25.3",
+        "moment-locales-webpack-plugin": "^1.2.0",
+        "moment-timezone": "^0.5.28",
+        "moment-timezone-data-webpack-plugin": "^1.3.0"
+      }
+    },
     "@nuxtjs/proxy": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-2.0.1.tgz",
@@ -5875,6 +5886,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -6233,6 +6249,99 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-locales-webpack-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
+      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
+      "requires": {
+        "lodash.difference": "^4.5.0"
+      }
+    },
+    "moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
+    "moment-timezone-data-webpack-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone-data-webpack-plugin/-/moment-timezone-data-webpack-plugin-1.3.0.tgz",
+      "integrity": "sha512-0V0xnHZpdHLsSerIQ2yNEPBC3uJWfU/zNT3nB0PO+tjmGHuNeUWqNDiw7ZpLo54uER6/OAE75EJ7ThmlwkGuZw==",
+      "requires": {
+        "find-cache-dir": "^3.0.0",
+        "make-dir": "^3.0.0"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "move-concurrently": {

--- a/admin_view/nuxt-project/package.json
+++ b/admin_view/nuxt-project/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@nuxtjs/auth": "^4.9.1",
+    "@nuxtjs/moment": "^1.6.1",
     "axios": "^0.20.0",
     "core-js": "^3.6.5",
+    "moment": "^2.29.1",
     "nuxt": "^2.14.6"
   },
   "devDependencies": {

--- a/admin_view/nuxt-project/pages/users/_id.vue
+++ b/admin_view/nuxt-project/pages/users/_id.vue
@@ -16,8 +16,10 @@
                 <div v-if="user.role_id == 1"><v-chip color="red" text-color="white">developer</v-chip></div>
                 <div v-if="user.role_id == 2"><v-chip color="green" text-color="white">manager</v-chip></div>
                 <div v-if="user.role_id == 3"><v-chip color="blue" text-color="white">user</v-chip></div>
+                <v-card-text>学籍番号：{{ detail.student_id }}</v-card-text>
                 <v-card-text>学年：{{ grade }}</v-card-text>
                 <v-card-text>課程：{{ department }}</v-card-text>
+                <v-card-text>電話番号：{{ detail.tel }}</v-card-text>
                 <v-card-text>登録日時：{{ user.created_at | format-date }}</v-card-text>
                 <v-card-text>編集日時：{{ user.updated_at | format-date }}</v-card-text>
               </v-col>
@@ -43,6 +45,7 @@ export default {
       role: [],
       grade: [],
       department: [],
+      detail: [],
     }
   },
   mounted() {
@@ -58,6 +61,7 @@ export default {
         this.role = response.data.role
         this.grade = response.data.grade
         this.department = response.data.department
+        this.detail = response.data.detail
       })
   }
 }

--- a/admin_view/nuxt-project/pages/users/_id.vue
+++ b/admin_view/nuxt-project/pages/users/_id.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <Header/>
+      <v-container>
+        <v-card>
+          <v-container>
+            <v-row>
+              <v-col>
+                <v-card-title><v-icon>mdi-account</v-icon>{{ user.name }}</v-card-title>
+              </v-col>
+            </v-row>
+            <v-divider></v-divider>
+            <br>
+            <v-row>
+              <v-col>
+                <div v-if="user.role_id == 1"><v-chip color="red" text-color="white">developer</v-chip></div>
+                <div v-if="user.role_id == 2"><v-chip color="green" text-color="white">manager</v-chip></div>
+                <div v-if="user.role_id == 3"><v-chip color="blue" text-color="white">user</v-chip></div>
+                <v-card-text>学年：{{ grade }}</v-card-text>
+                <v-card-text>課程：{{ department }}</v-card-text>
+                <v-card-text>登録日時：{{ user.created_at | format-date }}</v-card-text>
+                <v-card-text>編集日時：{{ user.updated_at | format-date }}</v-card-text>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card>
+        </v-col>
+      </v-container>
+  </div>
+</template>
+
+<script>
+import Header from '~/components/Header.vue'
+import axios from 'axios'
+
+export default {
+  components: {
+    Header,
+  },
+  data() {
+    return {
+      user: [],
+      role: [],
+      grade: [],
+      department: [],
+    }
+  },
+  mounted() {
+    const url = "api/v1/users/show_user_detail/" + this.$route.params.id;
+    this.$axios.get(url, {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    }
+    )
+      .then(response => {
+        this.user = response.data.user
+        this.role = response.data.role
+        this.grade = response.data.grade
+        this.department = response.data.department
+      })
+  }
+}
+</script>

--- a/admin_view/nuxt-project/pages/users/index.vue
+++ b/admin_view/nuxt-project/pages/users/index.vue
@@ -1,0 +1,101 @@
+<template>
+  <div>
+    <Header/>
+      <v-container>
+        <v-card>
+          <v-container>
+            <v-row>
+              <v-col>
+                <v-card-title><v-icon>mdi-account-multiple</v-icon>ユーザー一覧</v-card-title>
+              </v-col>
+            </v-row>
+            <v-divider></v-divider>
+            <br>
+            <v-row>
+              <v-col>
+                <template>
+                  <v-simple-table>
+                    <template v-slot:default>
+                      <thead>
+                        <tr>
+                          <th class="text-center">
+                            ID
+                          </th>
+                          <th class="text-center">
+                            名前
+                          </th>
+                          <th class="text-center">
+                            メールアドレス
+                          </th>
+                          <th class="text-center">
+                            権限
+                          </th>
+                          <th class="text-center">
+                            作成日時
+                          </th>
+                          <th class="text-center">
+                            編集日時
+                          </th>
+                          <th class="text-center">
+                            操作
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr
+                          class="text-center"
+                          v-for="user in users"
+                          :key="user.id"
+                          >
+                          <td>{{ user.id }}</td>
+                          <td>{{ user.name }}</td>
+                          <td>{{ user.email }}</td>
+                          <td v-if="user.role_id == 1"><v-chip color="red" text-color="white">developer</v-chip></td>
+                          <td v-if="user.role_id == 2"><v-chip color="green" text-color="white">manager</v-chip></td>
+                          <td v-if="user.role_id == 3"><v-chip color="blue" text-color="white">user</v-chip></td>
+                          <td>{{ user.created_at | format-date }}</td>
+                          <td>{{ user.updated_at | format-date}}</td>
+                          <td><v-btn dense rounded text color="#01579B" :to="{name:'users-id', params:{id: user.id}}">詳細</v-btn></td>
+                        </tr>
+                      </tbody>
+                    </template>
+                  </v-simple-table>
+</template>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card>
+        </v-col>
+      </v-container>
+  </div>
+</template>
+
+<script>
+import Header from '~/components/Header.vue'
+import axios from 'axios'
+
+export default {
+  components: {
+    Header,
+  },
+  data() {
+    return {
+      users: [],
+    }
+  },
+  mounted() {
+    this.$axios.get('api/v1/users/index', {
+      headers: { 
+        "Content-Type": "application/json", 
+        "access-token": localStorage.getItem('access-token'),
+        "client": localStorage.getItem('client'),
+        "uid": localStorage.getItem('uid')
+      }
+    }
+    )
+      .then(response => {
+        this.users = response.data.data
+      })
+  }
+}
+</script>

--- a/admin_view/nuxt-project/plugins/fileter.js
+++ b/admin_view/nuxt-project/plugins/fileter.js
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import moment from 'moment'
+
+Vue.filter('format-date', function (value) {
+    const date = moment(value);
+    return date.format("YYYY.MM.DD (ddd) HH:mm:ss");
+
+})

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -17,12 +17,13 @@ class Api::V1::UsersController < ApplicationController
     @role = @user.role.name
     @grade = @user.user_detail.grade.name
     @department = @user.user_detail.department.name
+    @detail = @user.user_detail
     user_detail = {
       user: @user,
       role: @role,
       grade: @grade,
       department: @department,
-      
+      detail: @detail
     }
 
     render json: user_detail

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -12,6 +12,22 @@ class Api::V1::UsersController < ApplicationController
     render json: { data: @user }
   end
 
+  def show_user_detail
+    @user = User.find(params[:id])
+    @role = @user.role.name
+    @grade = @user.user_detail.grade.name
+    @department = @user.user_detail.department.name
+    user_detail = {
+      user: @user,
+      role: @role,
+      grade: @grade,
+      department: @department,
+      
+    }
+
+    render json: user_detail
+  end
+
   def get_user_detail
     @user = current_api_user
     @role = @user.role.name

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       # resources :users
       get "users/index" => "users#index"
       get "users/show" => "users#show"
+      get "users/show_user_detail/:id" => "users#show_user_detail"
       get "users/get_user_detail" => "users#get_user_detail"
     end
   end


### PR DESCRIPTION
ユーザー一覧とユーザーの詳細のページを作成した．
![image](https://user-images.githubusercontent.com/33748835/97798058-f43f5d00-1c65-11eb-8012-fc965a6732b2.png)
テーブルの一番右の詳細を押すと以下のページに飛ぶ
![image](https://user-images.githubusercontent.com/33748835/97798063-ff928880-1c65-11eb-9225-4e69702a32e5.png)

- 必要コマンド
`docker-compose run --rm admin_view npm install`

@kugue99A はここからデザインをいい感じにしてほしい
今後はこのユーザーページをテンプレートとして，`users`のディレクトリごとコピーしたりすると一覧ページの開発は非常に楽だと思われる．