### PR TITLE
電力登録ページ

### DIFF
--- a/admin_view/nuxt-project/pages/users/index.vue
+++ b/admin_view/nuxt-project/pages/users/index.vue
@@ -18,26 +18,8 @@
                     <template v-slot:default>
                       <thead>
                         <tr>
-                          <th class="text-center">
-                            ID
-                          </th>
-                          <th class="text-center">
-                            名前
-                          </th>
-                          <th class="text-center">
-                            メールアドレス
-                          </th>
-                          <th class="text-center">
-                            権限
-                          </th>
-                          <th class="text-center">
-                            作成日時
-                          </th>
-                          <th class="text-center">
-                            編集日時
-                          </th>
-                          <th class="text-center">
-                            操作
+                          <th v-for="(header, i) in headers" :key="i" class="text-center">
+                            {{ header.text }}
                           </th>
                         </tr>
                       </thead>
@@ -81,6 +63,29 @@ export default {
   data() {
     return {
       users: [],
+      headers: [
+        {
+          text: 'ID'
+        },
+        {
+          text: '名前'
+        },
+        {
+          text: 'メールアドレス'
+        },
+        {
+          text: '権限'
+        },
+        {
+          text: '作成日時'
+        },
+        {
+          text: '編集日時'
+        },
+        {
+          text: '操作'
+        },
+      ],
     }
   },
   mounted() {

--- a/view/vue-project/src/router/index.js
+++ b/view/vue-project/src/router/index.js
@@ -7,6 +7,7 @@ import MyPage from '../views/MyPage.vue'
 import RegisterUserDetail from '../views/RegisterUserDetail.vue'
 import RegistSubRep from '../views/RegistSubRep.vue'
 import RegisterGroup from '../views/RegisterGroup.vue'
+import RegisterPowerOrder from '../views/RegisterPowerOrder.vue'
 
 Vue.use(VueRouter)
 
@@ -41,6 +42,11 @@ Vue.use(VueRouter)
     name: 'RegisterGroup',
     component: RegisterGroup
   },
+  {
+    path: '/register_power_order',
+    name: 'RegisterPowerOrder',
+    component: RegisterPowerOrder
+  }
 ]
 
 const router = new VueRouter({

--- a/view/vue-project/src/views/RegisterPowerOrder.vue
+++ b/view/vue-project/src/views/RegisterPowerOrder.vue
@@ -1,0 +1,190 @@
+<template>
+  <v-row justify="center">
+    <v-col cols="2"></v-col>
+    <v-col cols="8">
+      <v-card>
+        <v-container class="justify-content-center">
+          <v-row>
+            <v-col cols="2"></v-col>
+            <v-col cols="8" align="center">
+              <v-card-title class="justify-center">
+                <h1>電力登録</h1>
+              </v-card-title>
+              <v-card-text>
+                <v-form ref="form">
+                  <v-select
+                    label="団体"
+                    ref="group"
+                    v-model="groupId"
+                    :rules="[rules.required]"
+                    :items="group"
+                    :menu-props="{
+                      top: true,
+                      offsetY: true,
+                    }"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                  ></v-select>
+                  <v-text-field
+                    label="製品名"
+                    ref="item"
+                    v-model="item"
+                    :rules="[rules.required]"
+                    text
+                    outlined
+                    required
+                  ></v-text-field>
+                  <v-text-field
+                    label="電力量"
+                    ref="power"
+                    v-model="power"
+                    type="number"
+                    :rules="[rules.required,
+                      rules.max]"
+                    text
+                    outlined
+                    required
+                  ></v-text-field>
+                  <v-text-field
+                    label="メーカー"
+                    ref="manufacturer"
+                    v-model="manufacturer"
+                    :rules="[rules.required]"
+                    text
+                    outlined
+                    required
+                  ></v-text-field>
+                  <v-text-field
+                    label="型番"
+                    ref="model"
+                    v-model="model"
+                    :rules="[rules.required]"
+                    text
+                    outlined
+                    required
+                  ></v-text-field>
+                  <v-text-field
+                    label="製品URL"
+                    ref="itemUrl"
+                    v-model="itemUrl"
+                    :rules="[rules.required]"
+                    text
+                    outlined
+                    required
+                  ></v-text-field>
+                </v-form>
+              </v-card-text>
+              <v-card-action>
+                <v-btn color="blue darken-1" block @click="submit">登録</v-btn>
+                <v-btn color="blue darken-1" text block @click="cancel">リセット</v-btn>
+              </v-card-action>
+            </v-col>
+            <v-col cols="2"></v-col>
+          </v-row>
+        </v-container>
+      </v-card>
+    </v-col>
+    <v-col cols="2"></v-col>
+  </v-row>
+</template>
+
+<script>
+
+import axios from 'axios'
+export default {
+  data () {
+    return {
+      rules: {
+        required: value => !!value || '入力してください',
+        max: value => value <= 1000 || '大きすぎます',
+      },
+      group: [],
+    }
+    },
+    computed: {
+    form () {
+      return {
+        item: null,
+        power: null,
+        manufacturer: null,
+        model: null,
+        itemUrl: null,
+        groupId: null
+      }
+    },
+  },
+  methods: {
+    cancel: function() {
+      this.$refs.form.reset();
+    },
+    submit: function() {
+      if ( !this.$refs.form.validate() ) return;
+
+      const url = process.env.VUE_APP_URL + '/power_orders'
+      let params = new URLSearchParams();
+      params.append('group_id', this.groupId);
+      params.append('item', this.item);
+      params.append('power', this.power);
+      params.append('manufacturer', this.manufacturer);
+      params.append('model', this.model);
+      params.append('item_url', this.itemUrl);
+
+      axios.defaults.headers.common['Content-Type'] = 'application/json';
+      axios.post(url, params).then(
+        (response) => {
+          console.log('response:', response)
+          this.$router.push('MyPage')
+        },
+        (error) => {
+          console.log('登録できませんでした')
+          return error;
+        }
+      )
+    },
+  },
+
+  mounted() {
+    const url = process.env.VUE_APP_URL + '/api/v1/users/show'
+    axios.get(url, {
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": localStorage.getItem('access-token'),
+        "client": localStorage.getItem('client'),
+        "uid": localStorage.getItem('uid')
+      }
+    }).then(
+      (response) => {
+        this.user = response.data.data
+        console.log(this.user)
+        console.log(this.user.id)
+      },
+      (error) => {
+        console.error(error)
+        return error;
+      }
+    )
+    const groupUrl = process.env.VUE_APP_URL + '/api/v1/current_user/groups'
+    axios.get(groupUrl, {
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": localStorage.getItem('access-token'),
+        "client": localStorage.getItem('client'),
+        "uid": localStorage.getItem('uid')
+      }
+    }).then(
+      (response) => {
+        for(let i=0;i<response.data.length;i++){
+          this.group.push(response.data[i])
+        }
+        console.log(this.group)
+      },
+      (error) => {
+        console.error(error)
+        return error;
+      }
+    )
+  },
+}
+
+</script>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #99

# 概要
<!-- 開発内容の概要を記載 -->
`/api/v1/current_user/groups`からユーザーの持ってるグループ一覧をとってきてフォームから選択できるようにした。
その他必要なフォームを作成。

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- view/view_project/src/views/RegisterPowerOrder.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:3000/register_power_order`
![2020-11-10 19 47 08 localhost 9eee5a74826a](https://user-images.githubusercontent.com/39459987/98664364-a1fceb00-238d-11eb-82c9-5f1561713679.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- すべて入力して登録できるか。`http://localhost/power_orders`で確認できる。
- 入力をやめたときや、入力しないまま送信ボタンを押したときにvalidateで赤くなって送信されない。
- リセットを押したらvalidateと文字すべて消える。
- groupを複数持っていた時に表示されるか。

# 備考
- `localshost:3000/register_group`でgroup登録できます。
- urlなどvalidateかけられるところがいくつかある。
- 電力は一応max1000になっている。
- 