### PR TITLE
物品登録画面の追加

### DIFF
--- a/view/vue-project/src/components/RentalCard.vue
+++ b/view/vue-project/src/components/RentalCard.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-container class="justify-content-center">
+    <v-row>
+      <v-col cols=12>
+        <v-form ref="form">
+          <v-select
+            label="物品"
+            ref="rentalItem"
+            v-model="item"
+            :items="itemCategories"
+            :rules="rules.required"
+            item-text="name"
+            item-value="id"
+            text
+            outlined
+           />
+          <v-text-field
+            label="数"
+            ref="rentalNum"
+            v-model="itemNum"
+            :rules="rules.required"
+            type="number"
+            text
+            outlined
+          />
+        </v-form>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import axios from "axios";
+export default {
+  props: { groupId: Number },
+  data() {
+    return {
+      itemCategories: [
+        { id: 1, name: "机"},
+        { id: 2, name: "長机"},
+        { id: 3, name: "木の椅子"},
+        { id: 4, name: "パイプ椅子"},
+        { id: 5, name: "パーテーション"},
+        { id: 6, name: "掲示板"},
+        { id: 7, name: "暗幕"},
+        { id: 8, name: "マイク"},
+        { id: 9, name: "椅子"},
+        { id: 10, name: "テント"},
+        { id: 11, name: "パーテーション足"},
+      ],
+      rules: {
+        required: value => !!value || "入力してください"
+      },
+      valid: false
+    }
+  },
+  computed: {
+    form() {
+      return {
+        item: "",
+        itemNum: ""
+      }
+    }
+  },
+  methods: {
+    validate() {
+      if (this.$refs.form.validate()) {
+        return false;
+      }
+      valid = false;
+      return true;
+    },
+    submit() {
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      const url = process.env.VUE_APP_URL + "/rental_orders";
+      var params = new URLSearchParams();
+      params.append("group_id", this.groupId);
+      params.append("rental_item_id", this.item);
+      params.append("num", this.itemNum);
+      console.log(params);
+
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      axios.post(url, params).then(
+        response => {
+          console.log("副代表登録");
+          console.log(response)
+        },
+        error => {
+          return error;
+        }
+      );
+    }
+  },
+  mounted() {}
+}
+</script>

--- a/view/vue-project/src/components/RentalCard.vue
+++ b/view/vue-project/src/components/RentalCard.vue
@@ -7,7 +7,7 @@
             label="物品"
             ref="rentalItem"
             v-model="item"
-            :items="itemCategories"
+            :items="itemList"
             :rules="rules.required"
             item-text="name"
             item-value="id"
@@ -48,6 +48,9 @@ export default {
         { id: 10, name: "テント"},
         { id: 11, name: "パーテーション足"},
       ],
+      itemList: [],
+      itemAllowList: [],
+      groupCategoryId: localStorage.getItem("group_category_id"),
       rules: {
         required: value => !!value || "入力してください"
       },
@@ -91,6 +94,30 @@ export default {
       );
     }
   },
-  mounted() {}
+  mounted() {
+    const allowListUrl = process.env.VUE_APP_URL + '/rental_item_allow_lists';
+    axios.get(allowListUrl, {
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": localStorage.getItem("access-token"),
+        client: localStorage.getItem("client"),
+        uid: localStorage.getItem("uid")
+      }
+    })
+    .then(
+      response => {
+        for(let i=0; i<response.data.length; i++){
+          this.itemAllowList.push(response.data[i])
+          if (response.data[i].group_category_id == this.groupCategoryId) {
+            this.itemList.push(this.itemCategories[response.data[i].rental_item_id - 1]);
+            console.log(response.data[i].rental_item_id)
+          }
+        }
+        console.log(this.itemList)
+      }, error => {
+        console.error(error)
+      }
+    )
+  }
 }
 </script>

--- a/view/vue-project/src/views/group.vue
+++ b/view/vue-project/src/views/group.vue
@@ -144,6 +144,7 @@ export default {
         (response) => {
           console.log('response:', response.data.id)
           localStorage.setItem('group_id', response.data.id)
+          localStorage.setItem('group_category_id', this.groupCategoryId)
           this.$router.push('regist_shop')
         },
         (error) => {

--- a/view/vue-project/src/views/regist_shop.vue
+++ b/view/vue-project/src/views/regist_shop.vue
@@ -520,6 +520,12 @@ export default {
   },
   methods: {
     submit: function() {
+
+      if (localStorage.getItem("group_category_id") == null) {
+        console.log("can't group_category_id");
+        return;
+      }
+
       // 副代表登録
       axios.defaults.headers.common["Content-Type"] = "application/json";
       const subRepUrl = process.env.VUE_APP_URL + "/sub_reps";

--- a/view/vue-project/src/views/regist_shop.vue
+++ b/view/vue-project/src/views/regist_shop.vue
@@ -243,7 +243,7 @@
                           >
                             <PowerCard
                               :groupId="groupId"
-                              ref="child"
+                              ref="powerChild"
                               :key="powerStep"
                             />
                             <v-row>
@@ -316,7 +316,77 @@
                   <v-card class="mb-12" flat>
                     <v-card-title>物品登録</v-card-title>
                     <v-divider></v-divider>
-                    <v-card-text> </v-card-text>
+                    <v-card-text>
+                      <v-select
+                        v-model="rentalSteps"
+                        :items="[1, 2, 3, 4, 5, 6]"
+                        label="登録物品数"
+                        outlined />
+                      <v-stepper
+                        class="stepper"
+                        v-model="e3"
+                      >
+                        <v-stepper-header class="stepper">
+                          <template v-for="rentalStep in rentalSteps">
+                            <v-stepper-step
+                              :key="`${rentalStep}-step`"
+                              :complete="e3 > rentalStep"
+                              :step="rentalStep"
+                            >
+                              {{ rentalStep }}
+                            </v-stepper-step>
+                            <v-divider
+                              v-if="rentalStep !== rentalSteps"
+                              :key="rentalStep"></v-divider>
+                          </template>
+                        </v-stepper-header>
+                        <v-stepper-items>
+                          <v-stepper-content
+                            v-for="rentalStep in rentalSteps"
+                            :key="`${rentalStep}-content`"
+                            :step="rentalStep"
+                          >
+                            <RentalCard
+                              ref="rentalChild"
+                              :groupId="groupId"
+                              :key="rentalStep"
+                            />
+                            <v-row>
+                              <v-col cols="4" />
+                              <v-col cols="4">
+                                <v-btn
+                                  block
+                                  height="50"
+                                  outlined
+                                  color="primary"
+                                  @click="e3 += 1"
+                                  v-show="rentalSteps != rentalStep"
+                                >
+                                  {{ rentalStep + 1}}
+                                  個目の物品へ
+                                </v-btn>
+                              </v-col>
+                              <v-col cols="4" />
+                            </v-row>
+                            <v-row>
+                              <v-col cols="4" />
+                              <v-col cols="4">
+                                <v-btn
+                                  height="50"
+                                  block
+                                  text
+                                  @click="e3 -= 1"
+                                  v-show="rentalStep != 1"
+                                >
+                                  戻る
+                                </v-btn>
+                              </v-col>
+                              <v-col cols="4" />
+                            </v-row>
+                          </v-stepper-content>
+                        </v-stepper-items>
+                      </v-stepper>
+                    </v-card-text>
                   </v-card>
                 </v-col>
                 <v-col cols="1"></v-col>
@@ -355,15 +425,18 @@
 import axios from "axios";
 import Header from "@/components/Header.vue";
 import PowerCard from "../components/PowerCard";
+import RentalCard from "@/components/RentalCard";
 export default {
   components: {
     Header,
-    PowerCard
+    PowerCard,
+    RentalCard
   },
   data() {
     return {
       e1: 1,
       e2: 1,
+      e3: 1,
       rules: {
         required: value => !!value || "入力してください",
         min8: v => v.length >= 8 || "8桁かどうかを確認してください",
@@ -432,7 +505,10 @@ export default {
       power: [], // 電力量
       powerManufacturer: [], // メーカー
       powerModel: [], // 型番
-      powerItemUrl: [] // 製品URL
+      powerItemUrl: [], // 製品URL
+
+      // 物品申請
+      rentalSteps: 2,
     };
   },
   watch: {
@@ -483,7 +559,12 @@ export default {
       );
       // 電力申請
       for (let i = 0; i < this.powerSteps; i++) {
-        this.$refs.child[i].submit();
+        this.$refs.powerChild[i].submit();
+      }
+
+      // 物品登録
+      for (let i = 0; i < this.rentalSteps; i++) {
+        this.$refs.rentalChild[i].submit();
       }
       this.$router.push("MyPage");
     },


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #140

# 概要
<!-- 開発内容の概要を記載 -->
`regist_shop.vue` に物品登録を追加
団体登録時にlocalStrageにgroup_category_idを追加するよう修正

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- view/vue-project/src/components/RentalCard.vue
- view/vue-project/src/views/group.vue
- view/vue-project/src/views/regist_shop.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8080/regist_shop`
スクリーンショット
![2021-02-03 22 43 04 localhost f4854e6bcb14](https://user-images.githubusercontent.com/39459987/106755804-e4bf1e00-6671-11eb-939b-32347648e82d.png)
# テスト項目
<!-- テストしてほしい内容を記載 -->
- 物品を複数個登録できるか
- group_categoryによって表示される物品が変更されるか
