### PR TITLE
お知らせのダイアログの表示(#168)

### DIFF
--- a/api/app/controllers/news_controller.rb
+++ b/api/app/controllers/news_controller.rb
@@ -4,7 +4,7 @@ class NewsController < ApplicationController
   # GET /news
   # GET /news.json
   def index
-    @news = News.all
+    @news = News.all.order(id: "DESC")
     render json: @news
   end
 

--- a/view/vue-project/src/components/News.vue
+++ b/view/vue-project/src/components/News.vue
@@ -24,7 +24,7 @@
               <v-icon class="pr-2" size="40">mdi-bell-outline</v-icon>
               {{ currentNews.title }}
               <v-spacer></v-spacer>
-              <v-btn text @click="dialog = false">
+              <v-btn text @click="dialog = false" fab>
                 <v-icon>mdi-close</v-icon>
               </v-btn>
             </v-card-title>
@@ -41,7 +41,8 @@
               <v-col cols="8"></v-col>
               <v-col cols="4">
                 <v-card-text>
-                  作成日時:{{ currentNews.created_at | moment }}
+                  {{ currentNews.created_at | moment }}<br>
+		  技大祭実行委員会
                 </v-card-text>
               </v-col>
             </v-row>
@@ -64,7 +65,7 @@ export default {
       news: null,
       dialog: false,
       currentNews: null,
-      times: 2,
+      times: 5,
     };
   },
 

--- a/view/vue-project/src/components/News.vue
+++ b/view/vue-project/src/components/News.vue
@@ -2,23 +2,51 @@
   <v-row>
     <v-col cols="2"></v-col>
     <v-col cols="8">
-      <v-card
-        class = "mx-auto"
-        outlined
-      >
-      <v-card-title style="background-color:#ECEFF1; font-size:30px"><v-icon class="pr-2" size="40">mdi-bell</v-icon><b>お知らせ</b></v-card-title>
-        <v-list>
-          <v-list-item 
-          v-for = "item in items"
-          :key="item.title"
-          link
-          >
-            <v-list-item-content class = "font-weight-medium">
-              <v-col cols = "2">{{item.data}}</v-col>
-              <v-col cols = "8"><v-list-item-title>{{ item.title }}</v-list-item-title></v-col>
+      <v-card class="mx-auto" outlined>
+        <v-card-title style="background-color: #eceff1; font-size: 30px">
+          <v-icon class="pr-2" size="40">mdi-bell</v-icon>
+          <b>お知らせ</b>
+        </v-card-title>
+
+        <v-list v-for="n in news" :key="n.id">
+          <v-list-item v-if="isDisplayNews(n.id)" @click.stop="onClickBtn(n)">
+            <v-list-item-content class="font-weight-medium">
+              <v-col cols="4">{{ n.created_at | moment }}</v-col>
+              <v-col cols="8">
+                <v-list-item-title>{{ n.title }}</v-list-item-title>
+              </v-col>
             </v-list-item-content>
           </v-list-item>
         </v-list>
+        <v-dialog v-model="dialog" v-if="currentNews" activator>
+          <v-card>
+            <v-card-title class="headline grey lighten-2">
+              <v-icon class="pr-2" size="40">mdi-bell-outline</v-icon>
+              {{ currentNews.title }}
+              <v-spacer></v-spacer>
+              <v-btn text @click="dialog = false">
+                <v-icon>mdi-close</v-icon>
+              </v-btn>
+            </v-card-title>
+            <v-row>
+              <v-col cols="2"></v-col>
+              <v-col cols="8">
+                <v-card-text class="body-1">
+                  {{ currentNews.body }}
+                </v-card-text>
+              </v-col>
+              <v-col cols="2"></v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="10"></v-col>
+              <v-col cols="2">
+                <v-card-text>
+                  作成日時:{{ currentNews.created_at | moment }}
+                </v-card-text>
+              </v-col>
+            </v-row>
+          </v-card>
+        </v-dialog>
       </v-card>
     </v-col>
     <v-col cols="2"></v-col>
@@ -26,16 +54,48 @@
 </template>
 
 <script>
-  export default {
-    data () {
-      return {
-        items: [
-          { data: "2020.09.20", title: "第３回参加団体説明会のお知らせ"},
-          { data: "2020.09.20", title: "マイページ更新のお知らせ"},
-          { data: "2020.09.20", title: "第２回参加団体説明会の配布資料"},
-        ],
-        right: null,
-      }
+import axios from "axios";
+import moment from "moment";
+
+export default {
+  data() {
+    return {
+      right: null,
+      news: null,
+      dialog: false,
+      currentNews: null,
+      times: 2,
+    };
+  },
+
+  mounted() {
+    const url = process.env.VUE_APP_URL + "/news";
+    axios
+      .get(url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.news = response.data;
+      });
+  },
+
+  filters: {
+    moment: function (date) {
+      return moment(date).format("YYYY/MM/DD");
     },
-  }
+  },
+
+  methods: {
+    onClickBtn(n) {
+      this.currentNews = n;
+      this.dialog = true;
+    },
+
+    isDisplayNews(id) {
+      return id > this.news.length - this.times
+    },
+  },
+};
 </script>

--- a/view/vue-project/src/components/News.vue
+++ b/view/vue-project/src/components/News.vue
@@ -38,8 +38,8 @@
               <v-col cols="2"></v-col>
             </v-row>
             <v-row>
-              <v-col cols="10"></v-col>
-              <v-col cols="2">
+              <v-col cols="8"></v-col>
+              <v-col cols="4">
                 <v-card-text>
                   作成日時:{{ currentNews.created_at | moment }}
                 </v-card-text>

--- a/view/vue-project/src/components/News.vue
+++ b/view/vue-project/src/components/News.vue
@@ -18,7 +18,7 @@
             </v-list-item-content>
           </v-list-item>
         </v-list>
-        <v-dialog v-model="dialog" v-if="currentNews" activator>
+        <v-dialog v-model="dialog" v-if="currentNews" activator max-width="1000">
           <v-card>
             <v-card-title class="headline grey lighten-2">
               <v-icon class="pr-2" size="40">mdi-bell-outline</v-icon>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #168 

# 概要
<!-- 開発内容の概要を記載 -->
localhost8080のmypageに表示されるお知らせの部分を整えた．
タイトルをクリックするとダイアログが表示されて，その中にタイトル，内容，作成日時が表示されるようにした．
表示するお知らせの数を指定できるようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- `api/app/controller/news_controller.rb`
- `view/vue-project/src/components/News.vue`

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 日付のフォーマットは整っているか
- お知らせをクリックしたら内容がダイアログで表示されるか
- `view/vue-project/src/components/News.vue` のscriptのtimesと表示されるお知らせの数が同じかどうか

# 備考
`npm install moment` で moment.js をインストールしたので，これがないとエラーが出るかもです．