### PR TITLE
お知らせを追加できるようにした

### DIFF
--- a/admin_view/nuxt-project/pages/news/index.vue
+++ b/admin_view/nuxt-project/pages/news/index.vue
@@ -43,7 +43,7 @@
               <v-dialog v-model="dialog" max-width="1000">
                 <v-card>
                   <v-card-title class="headkine grey lighten-2">
-                    <v-icon class="pr-2" size="40">mdi-bell-puls-outline</v-icon>
+                    <v-icon class="pr-2" size="40">mdi-bell-plus-outline</v-icon>
                     お知らせの追加 ​ <v-spacer></v-spacer>
                     <v-btn text @click="dialog = false" fab>
                       ​ <v-icon>mdi-close</v-icon>
@@ -72,6 +72,7 @@
                         label="内容"
                         background-color="white"
                         outlined
+                        height="100"
                         v-model="body"
                         clearable
                       >
@@ -169,6 +170,18 @@ export default {
       params.append("title", this.title);
       params.append("body", this.body);
       this.$axios.post('/news', params)
+    },
+    reload: function() {
+      this.$axios.get('/news', {
+      headers: { 
+        "Content-Type": "application/json", 
+        dialog: false,
+      },
+    }
+    )
+      .then(response => {
+        this.news = response.data
+      })
     }
   }
 }

--- a/admin_view/nuxt-project/pages/news/index.vue
+++ b/admin_view/nuxt-project/pages/news/index.vue
@@ -32,14 +32,78 @@
                             text
                             v-bind="attrs"
                             v-on="on"
-                            to="/groups/print"
+                            @click="dialog=true"
                             >
-                            <v-icon dark>mdi-printer</v-icon>
+                            <v-icon dark>mdi-bell-plus-outline</v-icon>
                     </v-btn>
                   </template>
-                  <span>印刷する</span>
+                  <span>お知らせの追加</span>
                 </v-tooltip>
               </v-card-title>
+              <v-dialog v-model="dialog" max-width="1000">
+                <v-card>
+                  <v-card-title class="headkine grey lighten-2">
+                    <v-icon class="pr-2" size="40">mdi-bell-puls-outline</v-icon>
+                    お知らせの追加 ​ <v-spacer></v-spacer>
+                    <v-btn text @click="dialog = false" fab>
+                      ​ <v-icon>mdi-close</v-icon>
+                    </v-btn>
+                  </v-card-title>
+                  <v-row>
+                    <v-col cols="1"></v-col>
+                    <v-col cols="10">
+                      <v-text-field
+                        class="body-1"
+                        label="タイトル"
+                        background-color="white"
+                        outlined
+                        v-model="title"
+                        clearable
+                      >
+                      </v-text-field>
+                    </v-col>
+                    <v-col cols="1"></v-col>
+                  </v-row>
+                  <v-row>
+                    ​ <v-col cols="1"></v-col>
+                    <v-col cols="10">
+                      <v-text-field
+                        class="body-1"
+                        label="内容"
+                        background-color="white"
+                        outlined
+                        v-model="body"
+                        clearable
+                      >
+                      </v-text-field>
+                    </v-col>
+                    ​ <v-col cols="1"></v-col>
+                  </v-row>
+                  <v-row>
+                    ​ <v-col cols="1"></v-col>
+                    <v-col cols="10">
+                      <v-card-actions>
+                        <v-btn
+                          flatk
+                          large
+                          block
+                          dark
+                          color="blue"
+                          @click="
+                            register();
+                            dialog = false;
+                            reload;
+                          "
+                          >登録 ​
+                        </v-btn>
+                      </v-card-actions>
+                    </v-col>
+                    ​ <v-col cols="1"></v-col>
+                  </v-row>
+                  <br>
+                </v-card>
+              </v-dialog>
+
               <hr class="mt-n3">
               <template>
                 <v-data-table
@@ -74,6 +138,9 @@ export default {
   data() {
     return {
       news: [],
+      title:[],
+      body:[],
+      dialog:false,
       headers:[
         { text: 'ID', value: 'id' },
         { text: 'タイトル', value: 'title' },
@@ -86,12 +153,23 @@ export default {
     this.$axios.get('/news', {
       headers: { 
         "Content-Type": "application/json", 
-      }
+        dialog: false,
+      },
     }
     )
       .then(response => {
         this.news = response.data
       })
+  },
+
+  methods:{
+    register: function() {
+      this.$axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("title", this.title);
+      params.append("body", this.body);
+      this.$axios.post('/news', params)
+    }
   }
 }
 </script>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #208

# 概要
<!-- 開発内容の概要を記載 -->
`localhost:8000/news` のv-cardの右上にお知らせを追加する用のボタンを作成した．
タイトルと内容を記入してお知らせを追加できるようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- admin_view/nuxt-project/pages/news/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/news`
スクリーンショット
![スクリーンショット 2021-02-20 224139](https://user-images.githubusercontent.com/71711872/108597637-5a92eb80-73cd-11eb-90cf-749a14569fa3.png)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- ニュースが追加されるか

# 備考
タイトルと内容に入力する文字数がテキストボックスの横幅を超えたら改行されるようにしようとしていたのですが，実装できなかったのでそのままPushしました．