### PR TITLE
[mod] 副代表の追加

### DIFF
--- a/admin_view/nuxt-project/pages/sub_reps/index.vue
+++ b/admin_view/nuxt-project/pages/sub_reps/index.vue
@@ -9,7 +9,22 @@
             <v-col cols="10">
               <v-card-title class="font-weight-bold mt-3">
                 <v-icon>mdi-account-outline</v-icon>副代表一覧
-                <v-spacer></v-spacer>
+                <v-spacer></v-spacer>               
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs  }">
+                    <v-btn 
+                            class="mx-2" 
+                            fab 
+                            text
+                            v-bind="attrs"
+                            v-on="on"
+                            @click="dialog=true"
+                            >
+                            <v-icon dark>mdi-account-plus-outline</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>副代表の追加</span>
+                </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">
                     <v-btn 
@@ -26,6 +41,113 @@
                   <span>印刷する</span>
                 </v-tooltip>
               </v-card-title>
+              <v-dialog v-model="dialog" max-width="1000">
+                <v-card>
+                  <v-card-title class="headkine grey lighten-2">
+                    <v-icon class="pr-2" size="40">mdi-account-outline</v-icon>
+                    副代表の追加 ​ <v-spacer></v-spacer>
+                    <v-btn text @click="dialog = false" fab>
+                      ​ <v-icon>mdi-close</v-icon>
+                    </v-btn>
+                  </v-card-title>
+                  <v-row>
+                    <v-col cols="1"></v-col>
+                    <v-col cols="10">
+                      <v-text-field
+                        class="body-1"
+                        label="名前"
+                        v-model="subRepName"
+                        background-color="white"
+                        outlined
+                        clearable
+                      >
+                      </v-text-field>
+                      <v-select
+                        label="参加団体名"
+                        v-model="Group"
+                        :items="groups"
+                        :menu-props="{
+                                      top: true,
+                                      offsetY: true,
+                                      }"
+                        item-text="name"
+                        item-value="id"
+                        outlined
+                      ></v-select>
+                      <v-text-field
+                        class="body-1"
+                        label="学籍番号"
+                        v-model="subRepSutudentId"
+                        :rules="[rules.min8, rules.over8]"
+                        hint="お持ちでない方：0を8桁入力"
+                        background-color="white"
+                        outlined
+                        clearable
+                      >
+                      </v-text-field>
+                      <v-select
+                        label="学科"
+                        v-model.number="subRepDepartmentId"
+                        :items="departments"
+                        :menu-props="{ top: true, offsetY: true }"
+                        item-text="name"
+                        item-value="id"
+                        background-color="white"
+                        outlined
+                        clearable
+                      >
+                      </v-select>
+                      <v-select
+                        label="学年"
+                        v-model.number="subRepGradeId"
+                        :items="grades"
+                        :menu-props="{ top: true, offsetY: true }"
+                        item-text="name"
+                        item-value="id"
+                        background-color="white"
+                        outlined
+                        clearable
+                      >
+                      </v-select>
+                      <v-text-field
+                        label="電話番号"
+                        v-model="subRepTel"
+                        :rules="[rules.min11, rules.over11]"
+                        hint="ハイフンなしで半角入力"
+                        persistent-hint
+                        counter="11"
+                        background-color="white"
+                        outlined
+                        clearable
+                      >
+                      </v-text-field>
+                      <v-text-field
+                        label="メールアドレス"
+                        v-model="subRepEmail"
+                        background-color="white"
+                        outlined
+                        clearable
+                      >
+                      </v-text-field>
+                      <v-card-actions>
+                        <v-btn
+                          flatk
+                          large
+                          block
+                          dark
+                          color="blue"
+                          @click="
+                            register();
+                          "
+                          >登録 ​
+                        </v-btn>
+                      </v-card-actions>
+                    </v-col>
+                    ​ <v-col cols="1"></v-col>
+                  </v-row>
+                  <br>
+                </v-card>
+              </v-dialog>
               <hr class="mt-n3">
               <template>
                 <v-data-table
@@ -65,7 +187,24 @@ export default {
   },
   data() {
     return {
+      rules: {
+        required: value => !!value || "入力してください",
+        min8: v => v.length >= 8 || "8桁かどうかを確認してください",
+        over8: v => v.length <= 8 || "8桁かどうかを確認してください",
+        min11: v => v.length >= 11 || "11桁かどうかを確認してください",
+        over11: v => v.length <= 11 || "11桁かどうかを確認してください",
+        max: value => value <= 1000 || "大きすぎます"
+      },
       sub_reps: [],
+      groups: [],
+      dialog: false,
+      Group: [],
+      subRepName: [],
+      subRepSutudentId: [],
+      subRepGradeId: [],
+      subRepDepartmentId: [],
+      subRepTel: [],
+      subRepEmail: [],
       headers:[
         { text: 'ID', value: 'id' },
         // { text: 'group_id', value: 'group_id' },
@@ -77,6 +216,47 @@ export default {
         // { text: '学籍番号', value: 'student_id' },
         { text: '日時', value: 'created_at' },
         { text: '編集日時', value: 'updated_at' },
+      ],
+      // 課程
+      departments: [
+        { name: "機械創造工学課程", id: 1 },
+        { name: "電気電子情報工学課程", id: 2 },
+        { name: "物質材料工学課程", id: 3 },
+        { name: "環境社会基盤工学課程", id: 4 },
+        { name: "生物機能工学課程", id: 5 },
+        { name: "情報・経営システム工学課程", id: 6 },
+        { name: "機械創造工学専攻", id: 7 },
+        { name: "電気電子情報工学専攻", id: 8 },
+        { name: "物質材料工学専攻", id: 9 },
+        { name: "環境社会基盤工学専攻", id: 10 },
+        { name: "生物機能工学専攻", id: 11 },
+        { name: "情報・経営システム工学専攻", id: 12 },
+        { name: "原子力システム安全工学専攻", id: 13 },
+        { name: "システム安全専攻", id: 14 },
+        { name: "技術科学イノベーション専攻", id: 15 },
+        { name: "情報・制御工学専攻", id: 16 },
+        { name: "材料工学専攻", id: 17 },
+        { name: "エネルギー・環境工学専攻", id: 18 },
+        { name: "生物統合工学専攻", id: 19 },
+        { name: "その他", id: 20 }
+      ],
+      // 学年
+      grades: [
+        { name: "B1 [学部1年]", id: 1 },
+        { name: "B2 [学部2年]", id: 2 },
+        { name: "B3 [学部3年]", id: 3 },
+        { name: "B4 [学部4年]", id: 4 },
+        { name: "M1 [修士1年]", id: 5 },
+        { name: "M2 [修士2年]", id: 6 },
+        { name: "D1 [博士1年]", id: 7 },
+        { name: "D2 [博士2年]", id: 8 },
+        { name: "D3 [博士3年]", id: 9 },
+        { name: "GD1 [イノベ1年]", id: 10 },
+        { name: "GD2 [イノベ2年]", id: 11 },
+        { name: "GD3 [イノベ3年]", id: 12 },
+        { name: "GD4 [イノベ4年]", id: 13 },
+        { name: "GD5 [イノベ5年]", id: 14 },
+        { name: "その他", id: 15 }
       ],
     }
   },
@@ -93,6 +273,62 @@ export default {
       .then(response => {
         this.sub_reps = response.data
       })
+
+    this.$axios.get('/groups', {
+      headers: { 
+        "Content-Type": "applicatiokn/json", 
+      }
+    })
+      .then(response => {
+        this.groups = response.data
+      })
+  },
+
+  methods: {
+    reload: function() {
+      this.$axios.get('/sub_reps', {
+      headers: { 
+        "Content-Type": "application/json", 
+      },
+    }
+    )
+      .then(response => {
+        this.sub_reps = response.data
+      })
+    },
+    adjustHeight(){
+      const textarea = this.$refs.activity
+      const resetHeight = new Promise(function(resolve) {
+        resolve(textarea.style.height = 'auto')
+      });
+      resetHeight.then(function(){
+        textarea.style.height = textarea.scrollHeight + 'px'
+      });
+    },
+    register: function() {
+      this.$axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("name", this.subRepName);
+      params.append("student_id", this.subRepSutudentId);
+      params.append('grade_id', this.subRepGradeId);
+      params.append('group_id', this.Group);
+      params.append("department_id", this.subRepDepartmentId);
+      params.append("tel", this.subRepTel);
+      params.append("email", this.subRepEmail);
+      this.$axios.post('/sub_reps', params).then(
+        (response) => {
+          console.log(response)
+          this.dialog = false;
+          this.reload();
+          this.subRepName = ''
+          this.subRepSutudentId = ''
+          this.subRepGradeId = ''
+          this.groupCategoryId = ''
+          this.subRepTel = ''
+          this.subRepEmail = ''
+        }
+      )
+    },
   },
 }
 </script>

--- a/admin_view/nuxt-project/pages/sub_reps/index.vue
+++ b/admin_view/nuxt-project/pages/sub_reps/index.vue
@@ -81,6 +81,7 @@
                         :rules="[rules.min8, rules.over8]"
                         hint="お持ちでない方：0を8桁入力"
                         background-color="white"
+                        counter="8"
                         outlined
                         clearable
                       >


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #243 

# 概要
<!-- 開発内容の概要を記載 -->
管理者ページから副代表を追加できるようにした．
名前，参加団体名，学籍番号，学科，学年，電話番号，メールアドレス　の情報を追加できるようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　/home/dodo/group-manager-2/admin_view/nuxt-project/pages/sub_reps/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/sub_reps`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 各項目を入力して登録ボタンを押すと，その情報が追加されるか．

# 備考
