### PR TITLE
[mod] 参加団体申請のダイアログのデザイン修正

### DIFF
--- a/admin_view/nuxt-project/pages/groups/_id.vue
+++ b/admin_view/nuxt-project/pages/groups/_id.vue
@@ -24,11 +24,32 @@
                 <v-card-title class="font-weight-bold mt-3">
                   {{ group.name }}
                   <v-spacer></v-spacer>
-                  <v-btn text fab @click="dialog = true"
-                    ><v-icon class="ma-5" color="#333333"
-                      >mdi-pencil</v-icon
-                    ></v-btn
-                  >
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs  }">
+                      <v-btn 
+                              text 
+                              v-bind="attrs"
+                              v-on="on"
+                              @click="edit_dialog = true" 
+                              fab>
+                        <v-icon class="ma-5">mdi-pencil</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>編集</span>
+                  </v-tooltip>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs  }">
+                      <v-btn 
+                              text 
+                              v-bind="attrs"
+                              v-on="on"
+                              @click="delete_dialog = true" 
+                      fab>
+                      <v-icon class="ma-5">mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>削除</span>
+                </v-tooltip>
                 </v-card-title>
                 <hr class="mt-n3" />
                 <v-simple-table class="my-9">
@@ -139,13 +160,13 @@
     </v-row>
 
     <!-- modal window to edit -->
-    <v-dialog v-model="dialog" width="500">
+    <v-dialog v-model="edit_dialog" width="500">
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
           <div style="color: white">
             <v-icon class="ma-5" dark>mdi-pencil</v-icon>編集
           </div><v-spacer></v-spacer>
-          <v-btn text @click="dialog = false" fab dark>
+          <v-btn text @click="edit_dialog = false" fab dark>
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
@@ -202,6 +223,65 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- 削除ダイアログ -->
+    <v-dialog
+      v-model="delete_dialog"
+      width="500"
+      >
+      <v-card>
+        <v-card-title class="headline blue-grey darken-3">
+          <div style="color:white">削除</div>
+        </v-card-title>
+
+      <v-card-title>
+        削除してよろしいですか？
+      </v-card-title>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          flat
+          color="red"
+          dark
+          @click="delete_yes"
+          >
+          はい
+        </v-btn>
+        <v-btn
+          flat
+          color="blue"
+          dark
+          @click="delete_dialog = false"
+          >
+          いいえ
+        </v-btn>
+      </v-card-actions>
+      </v-card>
+    </v-dialog> 
+
+    <!-- 編集成功SnackBar -->
+    <v-snackbar
+      v-model="success_snackbar"
+      color="blue-grey"
+      top
+      elevation="24"
+    >
+      編集しました
+
+      <template v-slot:action="{ attrs }">
+        <v-btn
+          color="white"
+          text
+          v-bind="attrs"
+          @click="snackbar = false"
+        >
+        <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </template>
+    </v-snackbar>
   </div>
 </template>
 
@@ -226,6 +306,10 @@ export default {
       groupProjectName: [],
       groupCategoryId: [],
       groupActivity: [],
+      edit_dialog: false,
+      delete_dialog: false,
+      success_snackbar: false,
+      delete_snackbar: false,
       groupCategories: [
         { id: 1, name: "模擬店(食品販売)" },
         { id: 2, name: "模擬店(物品販売)" },
@@ -261,9 +345,12 @@ export default {
         })
         .then((response) => {
           this.group = response.data;
-          this.dialog = false;
+          this.edit_dialog = false;
         });
     },
+    delete_yes: function() {
+      this.$router.push('/groups')
+    }
   },
   mounted() {
     const url = "/groups/" + this.$route.params.id;

--- a/admin_view/nuxt-project/pages/groups/_id.vue
+++ b/admin_view/nuxt-project/pages/groups/_id.vue
@@ -6,21 +6,31 @@
           <v-card-text>
             <div class="breadcrumbs">
               <ul>
-                <li><div class="breadcrumbs-item"><router-link to="/groups">参加団体一覧</router-link></div></li>
-                <li><div class="breadcrumbs-item">{{ group.name }}</div></li>
+                <li>
+                  <div class="breadcrumbs-item">
+                    <router-link to="/groups">参加団体一覧</router-link>
+                  </div>
+                </li>
+                <li>
+                  <div class="breadcrumbs-item">{{ group.name }}</div>
+                </li>
               </ul>
             </div>
           </v-card-text>
           <v-card flat>
             <v-row>
               <v-col cols="1"></v-col>
-              <v-col cols="10"> 
+              <v-col cols="10">
                 <v-card-title class="font-weight-bold mt-3">
                   {{ group.name }}
                   <v-spacer></v-spacer>
-                  <v-btn text fab @click="dialog = true"><v-icon class="ma-5" color="#333333">mdi-pencil</v-icon></v-btn>
+                  <v-btn text fab @click="dialog = true"
+                    ><v-icon class="ma-5" color="#333333"
+                      >mdi-pencil</v-icon
+                    ></v-btn
+                  >
                 </v-card-title>
-                <hr class="mt-n3">
+                <hr class="mt-n3" />
                 <v-simple-table class="my-9">
                   <template v-slot:default>
                     <tbody>
@@ -47,12 +57,48 @@
                       <tr>
                         <th>グループカテゴリ：</th>
                         <td>
-                    <v-chip v-if="group.group_category_id == 1" color="red" text-color="white" small>{{ category[0] }}</v-chip>
-                    <v-chip v-if="group.group_category_id == 2" color="pink" text-color="white" small>{{ category[1] }}</v-chip>
-                    <v-chip v-if="group.group_category_id == 3" color="blue" text-color="white" small>{{ category[2] }}</v-chip>
-                    <v-chip v-if="group.group_category_id == 4" color="green" text-color="white" small>{{ category[3] }}</v-chip>
-                    <v-chip v-if="group.group_category_id == 5" color="orange" text-color="white" small>{{ category[4] }}</v-chip>
-                    <v-chip v-if="group.group_category_id == 6" color="blue-gray" text-color="white" small>{{ category[5] }}</v-chip>
+                          <v-chip
+                            v-if="group.group_category_id == 1"
+                            color="red"
+                            text-color="white"
+                            small
+                            >{{ category[0] }}</v-chip
+                          >
+                          <v-chip
+                            v-if="group.group_category_id == 2"
+                            color="pink"
+                            text-color="white"
+                            small
+                            >{{ category[1] }}</v-chip
+                          >
+                          <v-chip
+                            v-if="group.group_category_id == 3"
+                            color="blue"
+                            text-color="white"
+                            small
+                            >{{ category[2] }}</v-chip
+                          >
+                          <v-chip
+                            v-if="group.group_category_id == 4"
+                            color="green"
+                            text-color="white"
+                            small
+                            >{{ category[3] }}</v-chip
+                          >
+                          <v-chip
+                            v-if="group.group_category_id == 5"
+                            color="orange"
+                            text-color="white"
+                            small
+                            >{{ category[4] }}</v-chip
+                          >
+                          <v-chip
+                            v-if="group.group_category_id == 6"
+                            color="blue-gray"
+                            text-color="white"
+                            small
+                            >{{ category[5] }}</v-chip
+                          >
                         </td>
                       </tr>
                       <tr>
@@ -61,11 +107,15 @@
                       </tr>
                       <tr>
                         <th>登録日時：</th>
-                        <td class="caption">{{ group.created_at | format-date }}</td>
+                        <td class="caption">
+                          {{ group.created_at | (format - date) }}
+                        </td>
                       </tr>
                       <tr>
                         <th>編集日時：</th>
-                        <td class="caption">{{ group.updated_at | format-date }}</td>
+                        <td class="caption">
+                          {{ group.updated_at | (format - date) }}
+                        </td>
                       </tr>
                     </tbody>
                   </template>
@@ -80,75 +130,83 @@
     <v-row>
       <v-col>
         <div class="card">
-        <v-btn text color="white" to="/groups"><v-icon color="#333333">mdi-arrow-left-bold</v-icon><div class="back-button">参加団体一覧に戻る</div></v-btn>
+          <v-btn text color="white" to="/groups"
+            ><v-icon color="#333333">mdi-arrow-left-bold</v-icon>
+            <div class="back-button">参加団体一覧に戻る</div></v-btn
+          >
         </div>
       </v-col>
     </v-row>
 
     <!-- modal window to edit -->
-    <v-dialog
-      v-model="dialog"
-      width="1200"
-      >
-      <v-card flat>
-        <v-row>
-          <v-col cols="2"></v-col>
-          <v-col cols="8">
-            <v-card-title class="font-weight-bold"><v-icon class="pa-2">mdi-pencil</v-icon>登録情報の編集</v-card-title>
-            <v-text-field
-              label="グループ名"
-              background-color="white"
-              outlined
-              v-model="groupName"
-              filled
-              clearable
-              ></v-text-field>
-              <v-select
-                label="カテゴリ"
-                v-model="groupCategoryId"
-                :items="groupCategories"
-                :rules="[rules.required]"
-                :menu-props="{
-                               top: true,
-                               offsetY: true,
-                               }"
-                item-text="name"
-                item-value="id"
-                outlined
+    <v-dialog v-model="dialog" width="500">
+      <v-card>
+        <v-card-title class="headline blue-grey darken-3">
+          <div style="color: white">
+            <v-icon class="ma-5" dark>mdi-pencil</v-icon>編集
+          </div><v-spacer></v-spacer>
+          <v-btn text @click="dialog = false" fab dark>
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <v-form ref="form">
+                <v-text-field
+                  label="グループ名"
+                  v-model="groupName"
+                  background-color="white"
+                  outlined
+                  filled
+                  clearable
+                ></v-text-field>
+                <v-select
+                  label="カテゴリ"
+                  v-model="groupCategoryId"
+                  :items="groupCategories"
+                  :rules="[rules.required]"
+                  :menu-props="{
+                    top: true,
+                    offsetY: true,
+                  }"
+                  item-text="name"
+                  item-value="id"
+                  outlined
                 ></v-select>
-            <v-text-field
-              label="企画名"
-              background-color="white"
-              outlined
-              v-model="groupProjectName"
-              filled
-              clearable
-              ></v-text-field>
-            <v-text-field
-              label="企画内容"
-              background-color="white"
-              outlined
-              v-model="groupActivity"
-              filled
-              clearable
-              ></v-text-field>
-          </v-col>
-          <v-col cols="2"></v-col>
-        </v-row>
-        <v-row>
-          <v-col cols=3></v-col>
-          <v-col cols=6>
-            <v-btn color="blue darken-1" block large dark @click="edit">編集</v-btn>
-          </v-col>
-          <v-col cols=3></v-col>
-        </v-row>
+                <v-text-field
+                  label="企画名"
+                  background-color="white"
+                  outlined
+                  v-model="groupProjectName"
+                  filled
+                  clearable
+                ></v-text-field>
+                <v-text-field
+                  label="企画内容"
+                  background-color="white"
+                  outlined
+                  v-model="groupActivity"
+                  filled
+                  clearable
+                ></v-text-field>
+              </v-form>
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-divider></v-divider>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="#78909C" dark @click="edit"> 編集する </v-btn>
+        </v-card-actions>
       </v-card>
     </v-dialog>
   </div>
 </template>
 
 <script>
-import axios from 'axios'
+import axios from "axios";
 
 export default {
   data() {
@@ -169,98 +227,111 @@ export default {
       groupCategoryId: [],
       groupActivity: [],
       groupCategories: [
-      { id: 1, name: '模擬店(食品販売)' },
-      { id: 2, name: '模擬店(物品販売)' },
-      { id: 3, name: 'ステージ企画' },
-      { id: 4, name: '展示・体験' },
-      { id: 5, name: '研究室公開' },
-      { id: 6, name: 'その他' }
+        { id: 1, name: "模擬店(食品販売)" },
+        { id: 2, name: "模擬店(物品販売)" },
+        { id: 3, name: "ステージ企画" },
+        { id: 4, name: "展示・体験" },
+        { id: 5, name: "研究室公開" },
+        { id: 6, name: "その他" },
       ],
       rules: {
-      required: value => !!value || '入力してください',
+        required: (value) => !!value || "入力してください",
       },
-    }
+    };
   },
   methods: {
-    edit: function() {
-    const edit_url = '/groups/' + this.group.id + '?' + 'name=' + this.groupName + '&project_name=' + this.groupProjectName + '&group_category_id=' + this.groupCategoryId + '&activity=' + this.groupActivity
-    this.$axios.put(edit_url , {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    }
-    )
-      .then(response => {
-        this.group = response.data
-        this.dialog = false
-      })
-    }
-
+    edit: function () {
+      const edit_url =
+        "/groups/" +
+        this.group.id +
+        "?" +
+        "name=" +
+        this.groupName +
+        "&project_name=" +
+        this.groupProjectName +
+        "&group_category_id=" +
+        this.groupCategoryId +
+        "&activity=" +
+        this.groupActivity;
+      this.$axios
+        .put(edit_url, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.group = response.data;
+          this.dialog = false;
+        });
+    },
   },
   mounted() {
     const url = "/groups/" + this.$route.params.id;
-    this.$axios.get(url, {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    }
-    )
-      .then(response => {
-        this.group = response.data
-        this.groupName = response.data.name
-        this.groupProjectName = response.data.project_name
-        this.groupCategoryId = response.data.group_category_id
-        this.groupActivity = response.data.activity
-        this.user_id = response.data.user_id
-        this.group_category_id = response.data.group_category_id
-        this.fes_year_id = response.data.fes_year_id
+    this.$axios
+      .get(url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
+      .then((response) => {
+        this.group = response.data;
+        this.groupName = response.data.name;
+        this.groupProjectName = response.data.project_name;
+        this.groupCategoryId = response.data.group_category_id;
+        this.groupActivity = response.data.activity;
+        this.user_id = response.data.user_id;
+        this.group_category_id = response.data.group_category_id;
+        this.fes_year_id = response.data.fes_year_id;
+      });
 
     const user_url = "api/v1/users/show_user_detail/" + this.$route.params.id;
-    this.$axios.get(user_url, {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        console.log(response)
-        this.user = response.data.user.name
+    this.$axios
+      .get(user_url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
+      .then((response) => {
+        console.log(response);
+        this.user = response.data.user.name;
+      });
 
     const category_url = "group_categories" + this.group_category_id;
-    this.$axios.get(category_url, {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        console.log(response)
-        this.group_categories = response.data
-        for (let i = 0; i < this.group_categories.length; i++) {
-          this.category.push(this.group_categories[i]['name'])
-        }
+    this.$axios
+      .get(category_url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
+      .then((response) => {
+        console.log(response);
+        this.group_categories = response.data;
+        for (let i = 0; i < this.group_categories.length; i++) {
+          this.category.push(this.group_categories[i]["name"]);
+        }
+      });
 
     const year_url = "fes_years" + this.fes_year_id;
-    this.$axios.get(year_url, {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        console.log(response)
-        this.fes_years = response.data
-        for (let i = 0; i < this.fes_years.length; i++) {
-          this.years.push(this.fes_years[i]['year_num'])
-        }
+    this.$axios
+      .get(year_url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
-  }
-}
+      .then((response) => {
+        console.log(response);
+        this.fes_years = response.data;
+        for (let i = 0; i < this.fes_years.length; i++) {
+          this.years.push(this.fes_years[i]["year_num"]);
+        }
+      });
+  },
+};
 </script>
 
 <style>
 .card {
   padding-left: 1%;
-  padding-right: 5%
+  padding-right: 5%;
 }
 </style>

--- a/admin_view/nuxt-project/pages/groups/index.vue
+++ b/admin_view/nuxt-project/pages/groups/index.vue
@@ -8,158 +8,197 @@
             <v-col cols="10">
               <v-card-title class="font-weight-bold mt-3">
                 <v-icon class="mr-5">mdi-account-group</v-icon>参加団体申請一覧
-                <v-spacer></v-spacer>                
+                <v-spacer></v-spacer>
                 <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
-                    <v-btn 
-                            class="mx-2" 
-                            fab 
-                            text
-                            v-bind="attrs"
-                            v-on="on"
-                            @click="dialog=true"
-                            >
-                            <v-icon dark>mdi-account-multiple-plus</v-icon>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="dialog = true"
+                    >
+                      <v-icon dark>mdi-account-multiple-plus</v-icon>
                     </v-btn>
                   </template>
                   <span>参加団体の追加</span>
                 </v-tooltip>
                 <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
-                    <v-btn 
-                            class="mx-2" 
-                            fab 
-                            text
-                            v-bind="attrs"
-                            v-on="on"
-                            @click="reload"
-                            >
-                            <v-icon dark>mdi-reload</v-icon>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="reload"
+                    >
+                      <v-icon dark>mdi-reload</v-icon>
                     </v-btn>
                   </template>
                   <span>更新する</span>
                 </v-tooltip>
                 <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
-                    <v-btn 
-                            class="mx-2" 
-                            fab 
-                            text
-                            v-bind="attrs"
-                            v-on="on"
-                            to="/groups/print"
-                            >
-                            <v-icon dark>mdi-printer</v-icon>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      to="/groups/print"
+                    >
+                      <v-icon dark>mdi-printer</v-icon>
                     </v-btn>
                   </template>
                   <span>印刷する</span>
                 </v-tooltip>
               </v-card-title>
-              <v-dialog v-model="dialog" max-width="1000">
+              <v-dialog v-model="dialog" max-width="500">
                 <v-card>
-                  <v-card-title class="headkine grey lighten-2">
-                    <v-icon class="pr-2" size="40">mdi-account-group</v-icon>
-                    参加団体の追加 ​ <v-spacer></v-spacer>
-                    <v-btn text @click="dialog = false" fab>
+                  <v-card-title class="headline blue-grey darken-3">
+                    <div style="color: white">
+                      <v-icon class="ma-5" dark>mdi-account-group</v-icon
+                      >参加団体の追加
+                    </div>
+                    <v-spacer></v-spacer>
+                    <v-btn text @click="dialog = false" fab dark>
                       ​ <v-icon>mdi-close</v-icon>
                     </v-btn>
                   </v-card-title>
-                  <v-row>
-                    <v-col cols="1"></v-col>
-                    <v-col cols="10">
-                      <v-text-field
-                        class="body-1"
-                        label="団体名"
-                        v-model="groupName"
-                        background-color="white"
-                        outlined
-                        clearable
-                      >
-                      </v-text-field>
-                      <v-select
-                        label="カテゴリ"
-                        v-model="groupCategoryId"
-                        :items="groupCategories"
-                        item-text="name"
-                        item-value="id"
-                        outlined
-                      ></v-select>
-                      <v-textarea
-                        class="body-1"
-                        label="企画名"
-                        v-model="projectName"
-                        background-color="white"
-                        outlined
-                        height="100"
-                        clearable
-                      >
-                      </v-textarea>
-                      <v-text-field
-                        label="活動内容"
-                        v-model="activity"
-                        @keydown="adjustHeight"
-                        background-color="white"
-                        outlined
-                        clearable
-                      >
-                      </v-text-field>
-                      <v-card-actions>
-                        <v-btn
-                          flatk
-                          large
-                          block
-                          dark
-                          color="blue"
-                          @click="
-                            register();
-                          "
-                          >登録 ​
-                        </v-btn>
-                      </v-card-actions>
-                    </v-col>
-                    ​ <v-col cols="1"></v-col>
-                  </v-row>
-                  <br>
+
+                  <v-card-text>
+                    <v-row>
+                      <v-col>
+                        <v-form ref="form">
+                          <v-text-field
+                            class="body-1"
+                            label="団体名"
+                            v-model="groupName"
+                            background-color="white"
+                            outlined
+                            clearable
+                          >
+                          </v-text-field>
+                          <v-select
+                            label="カテゴリ"
+                            v-model="groupCategoryId"
+                            :items="groupCategories"
+                            item-text="name"
+                            item-value="id"
+                            outlined
+                          ></v-select>
+                          <v-textarea
+                            class="body-1"
+                            label="企画名"
+                            v-model="projectName"
+                            background-color="white"
+                            outlined
+                            height="100"
+                            clearable
+                          >
+                          </v-textarea>
+                          <v-text-field
+                            label="活動内容"
+                            v-model="activity"
+                            @keydown="adjustHeight"
+                            background-color="white"
+                            outlined
+                            clearable
+                          >
+                          </v-text-field>
+                          <v-card-actions>
+                            <v-btn
+                              flatk
+                              large
+                              block
+                              dark
+                              color="blue"
+                              @click="register()"
+                              >登録 ​
+                            </v-btn>
+                          </v-card-actions>
+                        </v-form>
+                      </v-col>
+                    </v-row>
+                  </v-card-text>
+                  <br />
                 </v-card>
               </v-dialog>
-              <hr class="mt-n3">
+              <hr class="mt-n3" />
               <template>
                 <div class="text-center" v-if="groups.length === 0">
-                  <br><br>
+                  <br /><br />
                   <v-progress-circular
                     indeterminate
                     color="#009688"
-                    ></v-progress-circular>
-                  <br><br>
+                  ></v-progress-circular>
+                  <br /><br />
                 </div>
                 <div v-else>
-                <v-data-table
-                  :headers="headers"
-                  :items="groups"
-                  class="elevation-0 my-9"
-                  @click:row="
-                              (data) =>
-                              $router.push({ path: `/groups/${data.id}`})
-                              "
+                  <v-data-table
+                    :headers="headers"
+                    :items="groups"
+                    class="elevation-0 my-9"
+                    @click:row="
+                      (data) => $router.push({ path: `/groups/${data.id}` })
+                    "
                   >
-                  <template v-slot:item.group_category_id="{ item }">
-                    <v-chip v-if="item.group_category_id == 1" color="red" text-color="white" small>{{ category[0] }}</v-chip>
-                    <v-chip v-if="item.group_category_id == 2" color="pink" text-color="white" small>{{ category[1] }}</v-chip>
-                    <v-chip v-if="item.group_category_id == 3" color="blue" text-color="white" small>{{ category[2] }}</v-chip>
-                    <v-chip v-if="item.group_category_id == 4" color="green" text-color="white" small>{{ category[3] }}</v-chip>
-                    <v-chip v-if="item.group_category_id == 5" color="orange" text-color="white" small>{{ category[4] }}</v-chip>
-                    <v-chip v-if="item.group_category_id == 6" color="blue-gray" text-color="white" small>{{ category[5] }}</v-chip>
-                  </template>
-                  <template v-slot:item.fes_year_id="{ item }">
-                    {{ years[item.fes_year_id] }}
-                  </template>
-                  <template v-slot:item.created_at="{ item }">
-                    {{ item.created_at | format-date }}
-                  </template>
-                  <template v-slot:item.updated_at="{ item }">
-                    {{ item.updated_at | format-date }}
-                  </template>
-                </v-data-table>                      
+                    <template v-slot:item.group_category_id="{ item }">
+                      <v-chip
+                        v-if="item.group_category_id == 1"
+                        color="red"
+                        text-color="white"
+                        small
+                        >{{ category[0] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category_id == 2"
+                        color="pink"
+                        text-color="white"
+                        small
+                        >{{ category[1] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category_id == 3"
+                        color="blue"
+                        text-color="white"
+                        small
+                        >{{ category[2] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category_id == 4"
+                        color="green"
+                        text-color="white"
+                        small
+                        >{{ category[3] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category_id == 5"
+                        color="orange"
+                        text-color="white"
+                        small
+                        >{{ category[4] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category_id == 6"
+                        color="blue-gray"
+                        text-color="white"
+                        small
+                        >{{ category[5] }}</v-chip
+                      >
+                    </template>
+                    <template v-slot:item.fes_year_id="{ item }">
+                      {{ years[item.fes_year_id] }}
+                    </template>
+                    <template v-slot:item.created_at="{ item }">
+                      {{ item.created_at | (format - date) }}
+                    </template>
+                    <template v-slot:item.updated_at="{ item }">
+                      {{ item.updated_at | (format - date) }}
+                    </template>
+                  </v-data-table>
                 </div>
               </template>
             </v-col>
@@ -188,127 +227,130 @@ export default {
       user: [],
       dialog: false,
       groupCategories: [
-      { id: 1, name: '模擬店(食品販売)' },
-      { id: 2, name: '模擬店(物品販売)' },
-      { id: 3, name: 'ステージ企画' },
-      { id: 4, name: '展示・体験' },
-      { id: 5, name: '研究室公開' },
-      { id: 6, name: 'その他' }
+        { id: 1, name: "模擬店(食品販売)" },
+        { id: 2, name: "模擬店(物品販売)" },
+        { id: 3, name: "ステージ企画" },
+        { id: 4, name: "展示・体験" },
+        { id: 5, name: "研究室公開" },
+        { id: 6, name: "その他" },
       ],
-      headers:[
-        { text: 'ID', value: 'id' },
+      headers: [
+        { text: "ID", value: "id" },
         // { text: 'USER_ID', value: 'user_id' },
-        { text: 'グループ名', value: 'name' },
-        { text: '企画名', value: 'project_name' },          
+        { text: "グループ名", value: "name" },
+        { text: "企画名", value: "project_name" },
         // { text: '活動内容', value: 'activity' },
-        { text: 'グループカテゴリ', value: 'group_category_id' },
-        { text: '開催年', value: 'fes_year_id' },
-        { text: '日時', value: 'created_at' },
-        { text: '編集日時', value: 'updated_at' },
+        { text: "グループカテゴリ", value: "group_category_id" },
+        { text: "開催年", value: "fes_year_id" },
+        { text: "日時", value: "created_at" },
+        { text: "編集日時", value: "updated_at" },
       ],
-    }
+    };
   },
   mounted() {
-      const url = '/api/v1/current_user/show'
-      this.$axios.get(url, {
-        headers:{
-        "Content-Type": "application/json",
-        "access-token": localStorage.getItem('access-token'),
-        "client": localStorage.getItem('client'),
-        "uid": localStorage.getItem('uid')
-        }
-      }).then(
+    const url = "/api/v1/current_user/show";
+    this.$axios
+      .get(url, {
+        headers: {
+          "Content-Type": "application/json",
+          "access-token": localStorage.getItem("access-token"),
+          client: localStorage.getItem("client"),
+          uid: localStorage.getItem("uid"),
+        },
+      })
+      .then(
         (response) => {
-          this.user = response.data.data
+          this.user = response.data.data;
         },
         (error) => {
-          console.error(error)
+          console.error(error);
           return error;
         }
-      )
-    this.$axios.get('/groups', {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        this.groups = response.data
+      );
+    this.$axios
+      .get("/groups", {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
+      .then((response) => {
+        this.groups = response.data;
+      });
 
-    this.$axios.get('/group_categories', {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        this.group_categories = response.data
+    this.$axios
+      .get("/group_categories", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.group_categories = response.data;
         for (let i = 0; i < this.group_categories.length; i++) {
-          this.category.push(this.group_categories[i]['name'])
+          this.category.push(this.group_categories[i]["name"]);
         }
-      })
+      });
 
-    this.$axios.get('/fes_years', {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        this.fes_years = response.data
-        for (let i = 0; i < this.fes_years.length; i++) {
-          this.years.push(this.fes_years[i]['year_num'])
-        }
+    this.$axios
+      .get("/fes_years", {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
+      .then((response) => {
+        this.fes_years = response.data;
+        for (let i = 0; i < this.fes_years.length; i++) {
+          this.years.push(this.fes_years[i]["year_num"]);
+        }
+      });
   },
   methods: {
-    reload: function() {
-      this.$axios.get('/groups', {
-      headers: { 
-        "Content-Type": "application/json", 
-      },
-    }
-    )
-      .then(response => {
-        this.groups = response.data
-      })
+    reload: function () {
+      this.$axios
+        .get("/groups", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.groups = response.data;
+        });
     },
-    adjustHeight(){
-      const textarea = this.$refs.activity
-      const resetHeight = new Promise(function(resolve) {
-        resolve(textarea.style.height = 'auto')
+    adjustHeight() {
+      const textarea = this.$refs.activity;
+      const resetHeight = new Promise(function (resolve) {
+        resolve((textarea.style.height = "auto"));
       });
-      resetHeight.then(function(){
-        textarea.style.height = textarea.scrollHeight + 'px'
+      resetHeight.then(function () {
+        textarea.style.height = textarea.scrollHeight + "px";
       });
     },
-    register: function() {
+    register: function () {
       this.$axios.defaults.headers.common["Content-Type"] = "application/json";
       var params = new URLSearchParams();
       params.append("user_id", this.user.id);
       params.append("name", this.groupName);
       params.append("project_name", this.projectName);
-      params.append('activity', this.activity);
+      params.append("activity", this.activity);
       params.append("group_category_id", this.groupCategoryId);
       params.append("fes_year_id", this.fesYearId);
-      this.$axios.post('/groups', params).then(
-        (response) => {
-          console.log(response)
-          this.dialog = false;
-          this.reload();
-          this.groupName = ''
-          this.projectName = ''
-          this.activity = ''
-          this.groupCategoryId = ''
-          this.fesYearId = ''
-        }
-      )
+      this.$axios.post("/groups", params).then((response) => {
+        console.log(response);
+        this.dialog = false;
+        this.reload();
+        this.groupName = "";
+        this.projectName = "";
+        this.activity = "";
+        this.groupCategoryId = "";
+        this.fesYearId = "";
+      });
     },
-  }
-}
+  },
+};
 </script>
 
 <style>
 .card {
   padding-left: 1%;
-  padding-right: 5%
+  padding-right: 5%;
 }
 </style>

--- a/admin_view/nuxt-project/pages/place_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/place_orders/_id.vue
@@ -3,99 +3,115 @@
     <v-row>
       <v-col>
         <div class="card">
-        <v-card-text>
-          <div class="breadcrumbs">
-            <ul>
-              <li><div class="breadcrumbs-item"><router-link to="/place_orders">会場申請一覧</router-link></div></li>
-              <li><div class="breadcrumbs-item">{{ group }}</div></li>
-            </ul>
-          </div>
-        </v-card-text>
+          <v-card-text>
+            <div class="breadcrumbs">
+              <ul>
+                <li>
+                  <div class="breadcrumbs-item">
+                    <router-link to="/place_orders">会場申請一覧</router-link>
+                  </div>
+                </li>
+                <li>
+                  <div class="breadcrumbs-item">{{ group }}</div>
+                </li>
+              </ul>
+            </div>
+          </v-card-text>
         </div>
       </v-col>
     </v-row>
     <v-row>
       <v-col>
         <div class="card">
-        <v-card flat>
-          <v-row>
-            <v-col cols="1"></v-col>
-            <v-col cols="10"> 
-              <v-card-title class="font-weight-bold mt-3">
-                {{ group }}
-                <v-spacer></v-spacer>
-                <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
-                    <v-btn 
-                      text 
-                      v-bind="attrs"
-                      v-on="on"
-                      @click="edit_dialog_open" 
-                      fab>
-                      <v-icon class="ma-5">mdi-pencil</v-icon>
-                    </v-btn>
+          <v-card flat>
+            <v-row>
+              <v-col cols="1"></v-col>
+              <v-col cols="10">
+                <v-card-title class="font-weight-bold mt-3">
+                  {{ group }}
+                  <v-spacer></v-spacer>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        text
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="edit_dialog_open"
+                        fab
+                      >
+                        <v-icon class="ma-5">mdi-pencil</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>編集</span>
+                  </v-tooltip>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        text
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="delete_dialog = true"
+                        fab
+                      >
+                        <v-icon class="ma-5">mdi-delete</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>削除</span>
+                  </v-tooltip>
+                </v-card-title>
+                <hr class="mt-n3" />
+                <v-simple-table class="my-9">
+                  <template v-slot:default>
+                    <tbody>
+                      <tr>
+                        <th>ID：</th>
+                        <td class="caption">{{ place_order.id }}</td>
+                      </tr>
+                      <tr>
+                        <th>参加団体：</th>
+                        <td class="caption">{{ group }}</td>
+                      </tr>
+                      <tr>
+                        <th>第一希望：</th>
+                        <td class="caption">{{ first }}</td>
+                      </tr>
+                      <tr>
+                        <th>第二希望：</th>
+                        <td class="caption">{{ second }}</td>
+                      </tr>
+                      <tr>
+                        <th>第三希望：</th>
+                        <td class="caption">{{ third }}</td>
+                      </tr>
+                      <tr>
+                        <th>備考：</th>
+                        <td class="caption">{{ place_order.remark }}</td>
+                      </tr>
+                      <tr>
+                        <th>登録日時：</th>
+                        <td class="caption">
+                          {{ place_order.created_at | (format - date) }}
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>編集日時：</th>
+                        <td class="caption">
+                          {{ place_order.updated_at | (format - date) }}
+                        </td>
+                        <td v-if="rights == 1">
+                          <v-icon color="#E91E63">mdi-pencil</v-icon>
+                        </td>
+                        <td v-if="rights == 2">
+                          <v-icon color="#E91E63">mdi-eye</v-icon>
+                        </td>
+                      </tr>
+                    </tbody>
                   </template>
-                  <span>編集</span>
-                </v-tooltip>
-                <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
-                    <v-btn 
-                      text 
-                      v-bind="attrs"
-                      v-on="on"
-                      @click="delete_dialog = true" 
-                      fab>
-                      <v-icon class="ma-5">mdi-delete</v-icon>
-                    </v-btn>
-                  </template>
-                  <span>削除</span>
-                </v-tooltip>
-              </v-card-title>
-              <hr class="mt-n3">
-              <v-simple-table class="my-9">
-                <template v-slot:default>
-                  <tbody>
-                    <tr>
-                      <th>ID：</th>
-                      <td class="caption">{{ place_order.id }}</td>
-                    </tr>
-                    <tr>
-                      <th>参加団体：</th>
-                      <td class="caption">{{ group }}</td>
-                    </tr>
-                    <tr>
-                      <th>第一希望：</th>
-                      <td class="caption">{{ first }}</td>
-                    </tr>
-                    <tr>
-                      <th>第二希望：</th>
-                      <td class="caption">{{ second }}</td>
-                    </tr>
-                    <tr>
-                      <th>第三希望：</th>
-                      <td class="caption">{{ third }}</td>
-                    </tr>
-                    <tr>
-                      <th>備考：</th>
-                      <td class="caption">{{ place_order.remark }}</td>
-                    </tr>
-                    <tr>
-                      <th>登録日時：</th>
-                      <td class="caption">{{ place_order.created_at | format-date }}</td>
-                    </tr>
-                    <tr>
-                      <th>編集日時：</th>
-                      <td class="caption">{{ place_order.updated_at | format-date }}</td>
-                      <td v-if="rights == 1"><v-icon color="#E91E63">mdi-pencil</v-icon></td>
-                      <td v-if="rights == 2"><v-icon color="#E91E63">mdi-eye</v-icon></td>
-                    </tr>
-                  </tbody>
-                </template>
-              </v-simple-table>
-            </v-col>
-            <v-col cols="1"></v-col>
-          </v-row>
-        </v-card>
+                </v-simple-table>
+              </v-col>
+              <v-col cols="1"></v-col>
+            </v-row>
+          </v-card>
         </div>
       </v-col>
     </v-row>
@@ -103,164 +119,138 @@
     <v-row>
       <v-col>
         <div class="card">
-        <v-btn text color="white" to="/place_orders"><v-icon color="#333333">mdi-arrow-left-bold</v-icon><div class="back-button">会場申請一覧に戻る</div></v-btn>
+          <v-btn text color="white" to="/place_orders"
+            ><v-icon color="#333333">mdi-arrow-left-bold</v-icon>
+            <div class="back-button">会場申請一覧に戻る</div></v-btn
+          >
         </div>
       </v-col>
     </v-row>
 
     <!-- 編集ダイアログ -->
-    <v-dialog
-      v-model="edit_dialog"
-      width="500"
-      >
+    <v-dialog v-model="edit_dialog" width="500">
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
-          <div style="color:white">
+          <div style="color: white">
             <v-icon class="ma-5" dark>mdi-pencil</v-icon>編集
           </div>
+          <v-spacer></v-spacer>
+          <v-btn text @click="edit_dialog = false" fab dark>
+            ​ <v-icon>mdi-close</v-icon>
+          </v-btn>
         </v-card-title>
 
-      <v-card-text>
-        <v-row>
-          <v-col>
-            <v-form ref="form">
-              <v-select
-                label="参加団体"
-                v-model="group_id"
-                :items="group_list"
-                item-text="name"
-                item-value="id"
-                text
-                outlined
-                clearable
-                :rules="[rules.required]"
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <v-form ref="form">
+                <v-select
+                  label="参加団体"
+                  v-model="group_id"
+                  :items="group_list"
+                  item-text="name"
+                  item-value="id"
+                  text
+                  outlined
+                  clearable
+                  :rules="[rules.required]"
                 />
-              <v-select
-                label="第一希望"
-                v-model="first_id"
-                :items="places"
-                item-text="name"
-                item-value="id"
-                text
-                outlined
-                clearable
-                :rules="[rules.required]"
+                <v-select
+                  label="第一希望"
+                  v-model="first_id"
+                  :items="places"
+                  item-text="name"
+                  item-value="id"
+                  text
+                  outlined
+                  clearable
+                  :rules="[rules.required]"
                 />
-              <v-select
-                label="第二希望希望"
-                v-model="second_id"
-                :items="places"
-                item-text="name"
-                item-value="id"
-                text
-                outlined
-                clearable
-                :rules="[rules.required]"
+                <v-select
+                  label="第二希望希望"
+                  v-model="second_id"
+                  :items="places"
+                  item-text="name"
+                  item-value="id"
+                  text
+                  outlined
+                  clearable
+                  :rules="[rules.required]"
                 />
-              <v-select
-                label="第三希望希望"
-                v-model="third_id"
-                :items="places"
-                item-text="name"
-                item-value="id"
-                text
-                outlined
-                clearable
-                :rules="[rules.required]"
+                <v-select
+                  label="第三希望希望"
+                  v-model="third_id"
+                  :items="places"
+                  item-text="name"
+                  item-value="id"
+                  text
+                  outlined
+                  clearable
+                  :rules="[rules.required]"
                 />
-              <v-textarea
-                label="備考"
-                v-model="remark"
-                clearable
-                outlined
-                :rules="[rules.required]"
-              ></v-textarea>
-            </v-form>
-          </v-col>
-        </v-row>
-      </v-card-text>
+                <v-textarea
+                  label="備考"
+                  v-model="remark"
+                  clearable
+                  outlined
+                  :rules="[rules.required]"
+                ></v-textarea>
+              </v-form>
+            </v-col>
+          </v-row>
+        </v-card-text>
 
-      <v-divider></v-divider>
+        <v-divider></v-divider>
 
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn
-          color="#78909C"
-          dark
-          @click="edit"
-          >
-          編集する
-        </v-btn>
-      </v-card-actions>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="#78909C" dark @click="edit"> 編集する </v-btn>
+        </v-card-actions>
       </v-card>
-    </v-dialog> 
+    </v-dialog>
 
     <!-- 削除ダイアログ -->
-    <v-dialog
-      v-model="delete_dialog"
-      width="500"
-      >
+    <v-dialog v-model="delete_dialog" width="500">
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
-          <div style="color:white">
+          <div style="color: white">
             <v-icon class="ma-5" dark>mdi-delete</v-icon>削除
           </div>
+          <v-spacer></v-spacer>
+          <v-btn text @click="delete_dialog = false" fab dark>
+            ​ <v-icon>mdi-close</v-icon>
+          </v-btn>
         </v-card-title>
 
-      <v-card-title>
-        削除してよろしいですか？
-      </v-card-title>
+        <v-card-title> 削除してよろしいですか？ </v-card-title>
 
-      <v-divider></v-divider>
+        <v-divider></v-divider>
 
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn
-          flat
-          color="red"
-          dark
-          @click="delete_yes"
-          >
-          はい
-        </v-btn>
-        <v-btn
-          flat
-          color="blue"
-          dark
-          @click="delete_dialog = false"
-          >
-          いいえ
-        </v-btn>
-      </v-card-actions>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn flat color="red" dark @click="delete_yes"> はい </v-btn>
+          <v-btn flat color="blue" dark @click="delete_dialog = false">
+            いいえ
+          </v-btn>
+        </v-card-actions>
       </v-card>
-    </v-dialog> 
+    </v-dialog>
 
     <!-- 編集成功SnackBar -->
-    <v-snackbar
-      v-model="success_snackbar"
-      color="blue-grey"
-      top
-      elevation="24"
-    >
+    <v-snackbar v-model="success_snackbar" color="blue-grey" top elevation="24">
       編集しました
 
       <template v-slot:action="{ attrs }">
-        <v-btn
-          color="white"
-          text
-          v-bind="attrs"
-          @click="snackbar = false"
-        >
-        <v-icon>mdi-close</v-icon>
+        <v-btn color="white" text v-bind="attrs" @click="snackbar = false">
+          <v-icon>mdi-close</v-icon>
         </v-btn>
       </template>
     </v-snackbar>
-
   </div>
 </template>
 
 <script>
-import axios from 'axios'
+import axios from "axios";
 
 export default {
   data() {
@@ -284,94 +274,111 @@ export default {
       success_snackbar: false,
       delete_snackbar: false,
       rules: {
-        required: value => !!value || '入力してください',
+        required: (value) => !!value || "入力してください",
       },
-    }
+    };
   },
   mounted() {
     const url = "/api/v1/get_place_order/" + this.$route.params.id;
-    this.$axios.get(url, {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    }
-    )
-      .then(response => {
-        this.place_order = response.data.place_order
-        this.group_id = response.data.place_order.group_id
-        this.group = response.data.group
-        this.first = response.data.first
-        this.second = response.data.second
-        this.third = response.data.third
-        this.first_id = response.data.place_order.first
-        this.second_id = response.data.place_order.second
-        this.third_id = response.data.place_order.third
-        this.remark = response.data.place_order.remark
+    this.$axios
+      .get(url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
+      .then((response) => {
+        this.place_order = response.data.place_order;
+        this.group_id = response.data.place_order.group_id;
+        this.group = response.data.group;
+        this.first = response.data.first;
+        this.second = response.data.second;
+        this.third = response.data.third;
+        this.first_id = response.data.place_order.first;
+        this.second_id = response.data.place_order.second;
+        this.third_id = response.data.place_order.third;
+        this.remark = response.data.place_order.remark;
+      });
   },
   methods: {
-    reload: function(){
+    reload: function () {
       const url = "/api/v1/get_place_order/" + this.$route.params.id;
-      this.$axios.get(url, {
-        headers: { 
-          "Content-Type": "application/json", 
-        }
-      }
-      )
-        .then(response => {
-          this.place_order = response.data.place_order
-          this.group_id = response.data.place_order.group_id
-          this.group = response.data.group
-          this.first = response.data.first
-          this.second = response.data.second
-          this.third = response.data.third
-          this.first_id = response.data.place_order.first
-          this.second_id = response.data.place_order.second
-          this.third_id = response.data.place_order.third
-          this.remark = response.data.place_order.remark
+      this.$axios
+        .get(url, {
+          headers: {
+            "Content-Type": "application/json",
+          },
         })
+        .then((response) => {
+          this.place_order = response.data.place_order;
+          this.group_id = response.data.place_order.group_id;
+          this.group = response.data.group;
+          this.first = response.data.first;
+          this.second = response.data.second;
+          this.third = response.data.third;
+          this.first_id = response.data.place_order.first;
+          this.second_id = response.data.place_order.second;
+          this.third_id = response.data.place_order.third;
+          this.remark = response.data.place_order.remark;
+        });
     },
-    edit_dialog_open: function() {
-      this.$axios.get('/places', {
-        headers: { 
-          "Content-Type": "application/json", 
-        }
-      })
-        .then(response => {
-          this.places = response.data
+    edit_dialog_open: function () {
+      this.$axios
+        .get("/places", {
+          headers: {
+            "Content-Type": "application/json",
+          },
         })
-      this.$axios.get('/groups', {
-        headers: { 
-          "Content-Type": "application/json", 
-        }
-      }).then(response => {
-        this.group_list = response.data
-      })
-      this.edit_dialog = true
+        .then((response) => {
+          this.places = response.data;
+        });
+      this.$axios
+        .get("/groups", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.group_list = response.data;
+        });
+      this.edit_dialog = true;
     },
-    edit: function() {
-      const edit_url = '/place_orders/' + this.place_order.id + '?group_id=' + this.group_id + '&first=' + this.first_id + '&second=' + this.second_id + '&third=' + this.third_id + '&remark=' + this.remark
-      console.log(edit_url)
-      this.$axios.put(edit_url , {
-        headers: { 
-          "Content-Type": "application/json", 
-        }
-      }).then(response => {
-        this.reload()
-        this.edit_dialog = false
-        this.success_snackbar = true
-      })
+    edit: function () {
+      const edit_url =
+        "/place_orders/" +
+        this.place_order.id +
+        "?group_id=" +
+        this.group_id +
+        "&first=" +
+        this.first_id +
+        "&second=" +
+        this.second_id +
+        "&third=" +
+        this.third_id +
+        "&remark=" +
+        this.remark;
+      console.log(edit_url);
+      this.$axios
+        .put(edit_url, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.reload();
+          this.edit_dialog = false;
+          this.success_snackbar = true;
+        });
     },
-    delete_yes: function() {
-      this.$router.push('/place_orders')
-    }
-  }
-}
+    delete_yes: function () {
+      this.$router.push("/place_orders");
+    },
+  },
+};
 </script>
 <style>
 .card {
   padding-left: 1%;
-  padding-right: 5%
+  padding-right: 5%;
 }
 </style>
   

--- a/admin_view/nuxt-project/pages/place_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/place_orders/_id.vue
@@ -115,7 +115,9 @@
       >
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
-          <div style="color:white">編集</div>
+          <div style="color:white">
+            <v-icon class="ma-5" dark>mdi-pencil</v-icon>編集
+          </div>
         </v-card-title>
 
       <v-card-text>
@@ -200,7 +202,9 @@
       >
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
-          <div style="color:white">削除</div>
+          <div style="color:white">
+            <v-icon class="ma-5" dark>mdi-delete</v-icon>削除
+          </div>
         </v-card-title>
 
       <v-card-title>

--- a/api/app/controllers/rental_orders_controller.rb
+++ b/api/app/controllers/rental_orders_controller.rb
@@ -19,18 +19,22 @@ class RentalOrdersController < ApplicationController
   def create
     @rental_order = RentalOrder.new(rental_order_params)
     @rental_order.save
+    render json: @rental_order
   end
 
   # PATCH/PUT /rental_orders/1
   # PATCH/PUT /rental_orders/1.json
   def update
     @rental_order.update(rental_order_params)
+    render json: @rental_order
   end
 
   # DELETE /rental_orders/1
   # DELETE /rental_orders/1.json
   def destroy
     @rental_order.destroy
+    @rental_orders = RentalOrder.all
+    render json: @rental_orders
   end
 
   private


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #272 

# 概要
<!-- 開発内容の概要を記載 -->
参加団体申請のダイアログのデザインを会場申請のダイアログのデザインと統合した．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　/home/dodo/group-manager-2/admin_view/nuxt-project/pages/groups/index.vue
-　/home/dodo/group-manager-2/admin_view/nuxt-project/pages/groups/_id.vue
-　/home/dodo/group-manager-2/admin_view/nuxt-project/pages/place_orders/_id.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/groups`
- `localhost:8000/place_orders`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者ページの参加団体のダイアログのデザインが変更されているか
- 管理者ページの電力申請のダイアログのデザインが変更されているか（編集，削除のアイコンが追加されているか）

# 備考
