### PR TITLE
[mod] 電力申請の追加を出来るようにした（#287）

### DIFF
--- a/admin_view/nuxt-project/pages/groups/index.vue
+++ b/admin_view/nuxt-project/pages/groups/index.vue
@@ -19,7 +19,7 @@
                       v-on="on"
                       @click="dialog = true"
                     >
-                      <v-icon dark>mdi-account-multiple-plus</v-icon>
+                      <v-icon dark>mdi-plus-circle-outline</v-icon>
                     </v-btn>
                   </template>
                   <span>参加団体の追加</span>

--- a/admin_view/nuxt-project/pages/place_orders/index.vue
+++ b/admin_view/nuxt-project/pages/place_orders/index.vue
@@ -20,10 +20,25 @@
                             v-on="on"
                             @click="dialog=true"
                             >
-                            <v-icon dark>mdi-map-marker-plus</v-icon>
+                            <v-icon dark>mdi-plus-circle-outline</v-icon>
                     </v-btn>
                   </template>
                   <span>会場申請の追加</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="reload"
+                    >
+                      <v-icon dark>mdi-reload</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>更新する</span>
                 </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">

--- a/admin_view/nuxt-project/pages/power_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/power_orders/_id.vue
@@ -152,14 +152,6 @@
                 :rules="[rules.required]"
               ></v-text-field>
               <v-text-field
-                label="電力"
-                v-model="power"
-                clearable
-                outlined
-                type="number"
-                :rules="[rules.required]"
-              ></v-text-field>
-              <v-text-field
                 label="電力(ワット)"
                 v-model="power"
                 clearable

--- a/admin_view/nuxt-project/pages/power_orders/index.vue
+++ b/admin_view/nuxt-project/pages/power_orders/index.vue
@@ -9,7 +9,37 @@
             <v-col cols="10">
               <v-card-title class="font-weight-bold mt-3">
                 <v-icon class="mr-5">mdi-power-plug</v-icon>電力申請一覧
-                <v-spacer></v-spacer>
+                <v-spacer></v-spacer>            
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs  }">
+                    <v-btn 
+                            class="mx-2" 
+                            fab 
+                            text
+                            v-bind="attrs"
+                            v-on="on"
+                            @click="dialog=true"
+                            >
+                            <v-icon dark>mdi-plus-circle-outline</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>電力申請の追加</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="reload"
+                    >
+                      <v-icon dark>mdi-reload</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>更新する</span>
+                </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">
                     <v-btn 
@@ -26,6 +56,101 @@
                   <span>印刷する</span>
                 </v-tooltip>
               </v-card-title>
+
+              <v-dialog v-model="dialog" max-width="500">
+                  <v-card>
+                    <v-card-title class="headline blue-grey darken-3">
+                      <div style="color: white">
+                        <v-icon class="ma-5" dark>mdi-power-plug</v-icon
+                        >電力申請の追加
+                      </div>
+                      <v-spacer></v-spacer>
+                      <v-btn text @click="dialog = false" fab dark>
+                        ​ <v-icon>mdi-close</v-icon>
+                      </v-btn>
+                    </v-card-title>
+
+                    <v-card-text>
+                      <v-row>
+                        <v-col>
+                          <v-form ref="form">
+                            <v-select
+                              label="参加団体名"
+                              v-model="Group"
+                              :items="groups"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                            <v-text-field
+                              class="body-1"
+                              label="製品名"
+                              v-model="item"
+                              background-color="white"
+                              outlined
+                              clearable
+                            >
+                            </v-text-field>
+                            <v-text-field
+                              class="body-1"
+                              label="電力（ワット）"
+                              v-model="power"
+                              background-color="white"
+                              outlined
+                              clearable
+                              type="number"
+                            >
+                            </v-text-field>
+                            <v-text-field
+                              class="body-1"
+                              label="メーカー"
+                              v-model="manufacturer"
+                              background-color="white"
+                              outlined
+                              clearable
+                            >
+                            </v-text-field>
+                            <v-text-field
+                              class="body-1"
+                              label="型番"
+                              v-model="model"
+                              background-color="white"
+                              outlined
+                              clearable
+                            >
+                            </v-text-field>
+                            <v-text-field
+                              class="body-1"
+                              label="製品URL"
+                              v-model="itemUrl"
+                              background-color="white"
+                              outlined
+                              clearable
+                            >
+                            </v-text-field>
+                            <v-card-actions>
+                              <v-btn
+                                flatk
+                                large
+                                block
+                                dark
+                                color="blue"
+                                @click="register()"
+                                >登録 ​
+                              </v-btn>
+                            </v-card-actions>
+                          </v-form>
+                        </v-col>
+                      </v-row>
+                    </v-card-text>
+                    <br />
+                  </v-card>
+                </v-dialog>
+
               <hr class="mt-n3">
               <template>
                 <div class="text-center" v-if="power_orders.length === 0">
@@ -70,6 +195,14 @@ export default {
   data() {
     return {
       power_orders: [],
+      groups: [],
+      dialog: false,
+      Group: [],
+      item: [],
+      power: [],
+      manufacturer: [],
+      model: [],
+      itemUrl: [],
       headers:[
         { text: 'ID', value: 'power_order.id' },
         { text: '参加団体', value: 'group' },
@@ -90,7 +223,50 @@ export default {
       .then(response => {
         this.power_orders = response.data
       })
+    this.$axios.get('/groups', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.groups = response.data
+      })
   },
+  
+  methods: {
+    reload: function () {
+      this.$axios
+        .get("/api/v1/get_power_orders", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.power_orders = response.data;
+        });
+    },
+    register: function () {
+      this.$axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.Group);
+      params.append("item", this.item);
+      params.append("power", this.power);
+      params.append("manufacturer", this.manufacturer);
+      params.append("model", this.model);
+      params.append("item_url", this.itemUrl);
+      this.$axios.post("/power_orders", params).then((response) => {
+        console.log(response);
+        this.dialog = false;
+        this.reload();
+        this.Group = "";
+        this.power_order.item = "";
+        this.power_order.power = "";
+        this.manufacturer = "";
+        this.model = "";
+        this.itemUrl = "";
+      });
+    },
+  }
 }
 </script>
 

--- a/admin_view/nuxt-project/pages/sub_reps/index.vue
+++ b/admin_view/nuxt-project/pages/sub_reps/index.vue
@@ -20,10 +20,25 @@
                             v-on="on"
                             @click="dialog=true"
                             >
-                            <v-icon dark>mdi-account-plus-outline</v-icon>
+                            <v-icon dark>mdi-plus-circle-outline</v-icon>
                     </v-btn>
                   </template>
                   <span>副代表の追加</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="reload"
+                    >
+                      <v-icon dark>mdi-reload</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>更新する</span>
                 </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #287

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面の電力申請画面で電力申請を追加できるようにした．
その他もろもろの修正を行った．（備考欄に記載）

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- admin_view/nuxt-project/pages/power_orders/index.vue
- admin_view/nuxt-project/pages/power_orders/_id.vue
- admin_view/nuxt-project/pages/groups/index.vue
- admin_view/nuxt-project/pages/sub_reps/index.vue
- admin_view/nuxt-project/pages/place_orders/index.vue
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost8000:power_orders/`
- `localhost8000:groups/`
- `localhost8000:sub_reps/`
- `localhost8000:place_orders/`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者画面の電力申請ページから各項目を記入して登録ボタンを押すと登録できるか

# 備考
参加団体申請，副代表申請，会場申請ページの追加ボタンを同じものに変更した．
副代表申請，会場申請ページにReloadボタンを追加した．