### PR TITLE
[mod] 販売食品を追加できるようにした．（#326）

### DIFF
--- a/admin_view/nuxt-project/pages/food_products/index.vue
+++ b/admin_view/nuxt-project/pages/food_products/index.vue
@@ -8,7 +8,37 @@
             <v-col cols="10">
               <v-card-title class="font-weight-bold mt-3">
                 <v-icon class="mr-5">mdi-baguette</v-icon>販売食品申請一覧
-                <v-spacer></v-spacer>
+                <v-spacer></v-spacer>             
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs  }">
+                    <v-btn 
+                            class="mx-2" 
+                            fab 
+                            text
+                            v-bind="attrs"
+                            v-on="on"
+                            @click="dialog=true"
+                            >
+                            <v-icon dark>mdi-plus-circle-outline</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>販売食品の追加</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="reload"
+                    >
+                      <v-icon dark>mdi-reload</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>更新する</span>
+                </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">
                     <v-btn 
@@ -25,6 +55,96 @@
                   <span>印刷する</span>
                 </v-tooltip>
               </v-card-title>
+
+                <v-dialog v-model="dialog" max-width="500">
+                  <v-card>
+                    <v-card-title class="headline blue-grey darken-3">
+                      <div style="color: white">
+                        <v-icon class="ma-5" dark>mdi-baguette</v-icon
+                        >販売食品の追加
+                      </div>
+                      <v-spacer></v-spacer>
+                      <v-btn text @click="dialog = false" fab dark>
+                        ​ <v-icon>mdi-close</v-icon>
+                      </v-btn>
+                    </v-card-title>
+
+                    <v-card-text>
+                      <v-row>
+                        <v-col>
+                          <v-form ref="form">
+                            <v-select
+                              label="参加団体名"
+                              v-model="Group"
+                              :items="groups"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                            <v-text-field
+                              class="body-1"
+                              label="販売食品名"
+                              v-model="productName"
+                              background-color="white"
+                              outlined
+                              clearable
+                            >
+                            </v-text-field>
+                            <v-select
+                              class="body-1"
+                              label="調理の有無"
+                              v-model="isCooking"
+                              :items="cooking_available"
+                              item-text="label"
+                              item-value="value"
+                              background-color="white"
+                              outlined
+                              clearable
+                            >
+                            </v-select>
+                            <v-text-field
+                              class="body-1"
+                              label="1日目の個数"
+                              v-model="firstDayNum"
+                              background-color="white"
+                              outlined
+                              clearable
+                              type="number"
+                            >
+                            </v-text-field>
+                            <v-text-field
+                              class="body-1"
+                              label="2日目の個数"
+                              v-model="secondDayNum"
+                              background-color="white"
+                              outlined
+                              clearable
+                              type="number"
+                            >
+                            </v-text-field>
+                            <v-card-actions>
+                              <v-btn
+                                flatk
+                                large
+                                block
+                                dark
+                                color="blue"
+                                @click="register()"
+                                >登録
+                              </v-btn>
+                            </v-card-actions>
+                          </v-form>
+                        </v-col>
+                      </v-row>
+                    </v-card-text>
+                    <br />
+                  </v-card>
+                </v-dialog>
+
               <hr class="mt-n3">
               <template>
                 <div class="text-center" v-if="food_products.length === 0">
@@ -65,7 +185,6 @@
       </div>
     </v-col>
   </v-row>
-  </div>
 </template>
 
 <script>
@@ -73,6 +192,13 @@ export default {
   data() {
     return {
       food_products: [],
+      groups: [],
+      dialog: false,
+      Group: [],
+      productName: [],
+      isCooking: [],
+      firstDayNum: [],
+      secondDayNum: [],
       headers:[
         { text: 'ID', value: 'food_product.id' },
         { text: 'group_id', value: 'group' },
@@ -82,6 +208,10 @@ export default {
         { text: '調理の有無', value: 'food_product.is_cooking' },
         { text: '日時', value: 'food_product.created_at' },
         { text: '編集日時', value: 'food_product.updated_at' },
+      ],
+      cooking_available:[
+        {label:"する",value:true},
+        {label:"しない",value:false}
       ],
     }
   },
@@ -95,7 +225,48 @@ export default {
       .then(response => {
         this.food_products = response.data
       })
+    this.$axios.get('/groups', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.groups = response.data
+      })
   },
+
+  methods: {
+    reload: function () {
+      this.$axios
+        .get("/api/v1/get_food_products", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.food_products = response.data;
+        });
+    },
+    register: function () {
+      this.$axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.Group);
+      params.append("name", this.productName);
+      params.append("is_cooking", this.isCooking);
+      params.append("first_day_num", this.firstDayNum);
+      params.append("second_day_num", this.secondDayNum);
+      this.$axios.post("/food_products", params).then((response) => {
+        console.log(response);
+        this.dialog = false;
+        this.reload();
+        this.Group = "";
+        this.productName = "";
+        this.isCooking = "";
+        this.firstDayNum = "";
+        this.secondDayNum = "";
+      });
+    },
+  }
 }
 </script>
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #326 

# 概要
<!-- 開発内容の概要を記載 -->
管理者ページから販売食品一覧を追加できるようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　admin_view/nuxt-project/pages/food_products/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/food_products`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者ページの販売食品一覧で各項目を記入して登録ボタンを押すと追加できるか．