### PR TITLE
[mod] 購入品申請の追加を出来るようにした（#328）

### DIFF
--- a/admin_view/nuxt-project/pages/purchase_lists/index.vue
+++ b/admin_view/nuxt-project/pages/purchase_lists/index.vue
@@ -9,6 +9,36 @@
             <v-card-title class="font-weight-bold mt-3">
               <v-icon class="mr-5">mdi-cart</v-icon>購入品申請一覧
               <v-spacer></v-spacer>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        class="mx-2"
+                        fab
+                        text
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="openModal"
+                      >
+                        <v-icon dark>mdi-plus-circle-outline</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>購入品の追加</span>
+                  </v-tooltip>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        class="mx-2"
+                        fab
+                        text
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="reload"
+                      >
+                        <v-icon dark>mdi-reload</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>更新する</span>
+                  </v-tooltip>
               <v-tooltip top>
                 <template v-slot:activator="{ on, attrs  }">
                   <v-btn 
@@ -25,6 +55,107 @@
                 <span>印刷する</span>
               </v-tooltip>
             </v-card-title>
+
+                <v-dialog v-model="dialog" max-width="500">
+                  <v-card>
+                    <v-card-title class="headline blue-grey darken-3">
+                      <div style="color: white">
+                        <v-icon class="ma-2" dark>mdi-cart</v-icon
+                        >購入品の追加
+                      </div>
+                      <v-spacer></v-spacer>
+                      <v-btn text @click="dialog = false" fab dark>
+                        ​ <v-icon>mdi-close</v-icon>
+                      </v-btn>
+                    </v-card-title>
+                    <v-card-text>
+                      <v-row>
+                        <v-col>
+                          <v-form ref="form">
+                            <v-select
+                              label="参加団体名"
+                              v-model="Group"
+                              :items="groups"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                              @change="getPurchaseList(Group)"
+                            ></v-select>
+                            <v-select
+                              label="販売食品"
+                              v-model="foodProductId"
+                              :items="food_products"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                          <v-text-field
+                            class="body-1"
+                            label="購入品"
+                            v-model="item"
+                            background-color="white"
+                            outlined
+                            clearable
+                          >
+                          </v-text-field>
+                            <v-select
+                              label="なまもの"
+                              :items="isFresh"
+                              item-text="label"
+                              item-value="value"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              outlined
+                            ></v-select>
+                            <v-select
+                              label="開催日"
+                              v-model="fesDateId"
+                              :items="fes_dates"
+                              item-text="date"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                            <v-select
+                              label="店"
+                              v-model="shopId"
+                              :items="shops"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                            <v-card-actions>
+                              <v-btn
+                                flatk
+                                large
+                                block
+                                dark
+                                color="blue"
+                                @click="register()"
+                                >登録 ​
+                              </v-btn>
+                            </v-card-actions>
+                          </v-form>
+                        </v-col>
+                      </v-row>
+                    </v-card-text>
+                    <br />
+                  </v-card>
+                </v-dialog>
+
             <hr class="mt-n3">
             <template>
               <div class="text-center" v-if="purchase_lists.length === 0">
@@ -65,7 +196,6 @@
       </div>
     </v-col>
   </v-row>
-  </div>
 </template>
 
 <script>
@@ -73,6 +203,20 @@ export default {
   data() {
     return {
       purchase_lists: [],
+      food_products: [],
+      groups: [],
+      fes_dates: [],
+      shops: [],
+      dialog: false,
+      Group: [],
+      foodProductId: [],
+      fesDateId: [],
+      shopId: [],
+      item: [],
+      isFresh: [
+        {label: 'はい', value: 'true'},
+        {label: 'いいえ', value: 'false'}
+      ],
       headers:[
         { text: 'ID', value: 'purchase_list.id' },
         { text: '参加団体', value: 'group' },
@@ -91,12 +235,92 @@ export default {
       headers: { 
         "Content-Type": "application/json", 
       }
-    }
-    )
+    })
       .then(response => {
         this.purchase_lists = response.data
       })
   },
+
+  methods: {
+    openModal: function() {
+    this.$axios
+      .get("/groups", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.groups = response.data;
+      })
+      this.$axios
+      .get("/fes_dates", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.fes_dates = response.data;
+      })
+      this.$axios
+      .get("/shops", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.shops = response.data;
+      })
+
+      this.dialog=true;
+    },
+
+    getPurchaseList: function(groupId){
+    const url = "/api/v1/get_food_products_from_group/" + groupId;
+    this.$axios.get(url, {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.food_products = response.data
+        console.log(this.group)
+      })
+    },
+
+    reload: function () {
+      this.$axios
+        .get("/api/v1/get_purchase_lists", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.purchase_lists = response.data;
+        });
+    },
+
+    register: function () {
+      this.$axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.Group);
+      params.append("food_product_id", this.foodProductId);
+      params.append("fes_date_id", this.fesDateId);
+      params.append("shop_id", this.shopId);
+      params.append("items", this.item);
+      params.append("is_fresh", this.isFresh);
+      this.$axios.post("/purchase_lists", params).then((response) => {
+        console.log(response);
+        this.dialog = false;
+        this.reload();
+        this.Group = "";
+        this.foodProductId = "";
+        this.fesDateId = "";
+        this.shopId = "";
+        this.item = "";
+        this.isFresh = "";
+      });
+    },
+  }
 }
 </script>
 

--- a/api/app/controllers/api/v1/food_products_api_controller.rb
+++ b/api/app/controllers/api/v1/food_products_api_controller.rb
@@ -26,4 +26,9 @@ class Api::V1::FoodProductsApiController < ApplicationController
     render json: food_products_list
   end
 
+  def get_food_products_from_group
+    food_products = FoodProduct.where(group_id:params[:id])
+    render json: food_products
+  end
+
 end

--- a/api/app/controllers/fes_dates_controller.rb
+++ b/api/app/controllers/fes_dates_controller.rb
@@ -1,0 +1,37 @@
+class FesDatesController < ApplicationController
+    before_action :set_fes_date, only: [:show, :update, :destroy]
+  
+    def index
+      @fes_dates = FesDate.all
+      render json: @fes_dates
+    end
+  
+    def show
+      render json: @fes_date
+    end
+  
+    def create
+      @fes_date = FesDate.new(fes_date_params)
+      @fes_date.save
+    end
+  
+    def update
+      @fes_date.update(fes_date_params)
+    end
+  
+    def destroy
+      @fes_date.destroy
+    end
+  
+    private
+      # Use callbacks to share common setup or constraints between actions.
+      def set_fes_date
+        @fes_date = FesDate.find(params[:id])
+      end
+  
+      # Only allow a list of trusted parameters through.
+      def fes_date_params
+        params.permit(:date_num)
+      end
+  end
+  

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   resources :group_categories
   resources :user_details
   resources :shops
+  resources :fes_dates
   resources :fes_years
   namespace 'api' do
     namespace 'v1' do
@@ -85,6 +86,7 @@ Rails.application.routes.draw do
       # 販売食品周り
       get "get_food_products" => "food_products_api#get_food_products"
       get "get_food_product/:id" => "food_products_api#get_food_product"
+      get "get_food_products_from_group/:id" => "food_products_api#get_food_products_from_group"
       # 購入品周り
       get "get_purchase_lists" => "purchase_lists_api#get_purchase_lists"
       get "get_purchase_list/:id" => "purchase_lists_api#get_purchase_list"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #328 

# 概要
<!-- 開発内容の概要を記載 -->
管理者ページの購入品申請一覧ページから各項目を記入して登録ボタンを押すと追加できるようにした．
新しいAPIを作成した．
food_products_api_controller.rbに新しいAPIを追記した．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　admin_view/nuxt-project/pages/purchase_lists/index.vue
-　api/app/controllers/fes_dates_controller.rb
-　api/app/controllers/api/v1/food_products_api_controller.rb
-　api/config/routes.rb

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/purchase_lists`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者ページの購入品申請一覧画面の追加モーダルから各項目を記入して登録ボタンを押すと登録できるか

# 備考
- 新しいAPIを作成した．
→fes_dates_controller.rbでFes_Dateを取得できるようにした．
- モーダルで開催日を選択する際に日時の重複がある．
- food_products_api_controller.rbにgroup_idからGroupを選択することでそのGroupに当てはまるfood_productsを取得するapiを作成した．