### PR TITLE
[mod] 使用可能会場を追加できるようにした（#337）

### DIFF
--- a/api/app/controllers/place_allow_lists_controller.rb
+++ b/api/app/controllers/place_allow_lists_controller.rb
@@ -19,18 +19,22 @@ class PlaceAllowListsController < ApplicationController
   def create
     @place_allow_list = PlaceAllowList.new(place_allow_list_params)
     @place_allow_list.save
+    render json: @place_allow_list
   end
 
   # PATCH/PUT /place_allow_lists/1
   # PATCH/PUT /place_allow_lists/1.json
   def update
     @place_allow_list.update(place_allow_list_params)
+    render json: @place_allow_list
   end
 
   # DELETE /place_allow_lists/1
   # DELETE /place_allow_lists/1.json
   def destroy
     @place_allow_list.destroy
+    @place_allow_lists = PlaceAllowList.all
+    render json: @place_allow_lists
   end
 
   private


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #337

# 概要
<!-- 開発内容の概要を記載 -->
管理者ページの使用可能会場を追加できるようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　admin_view/nuxt-project/pages/place_allow_lists/index.vue
-　api/app/controllers/place_allow_lists_controller.rb

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/place_allow_lists`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者ページの使用可能会場一覧ページの追加モーダルで各項目を記入して登録ボタンを押すと登録できるか．

# 備考
api/app/controllers/place_allow_lists_controller.rbのdestroy, create, updateにrender jsonを追加した．