### PR TITLE
[mod] 使用可能物品の追加機能を実装した(#350)

### DIFF
--- a/admin_view/nuxt-project/pages/places/_id.vue
+++ b/admin_view/nuxt-project/pages/places/_id.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <div v-if="place.length===0">
+          <NoData/>
+    </div>
+    <div v-else>  
     <v-row>
       <v-col>
         <div class="card">
@@ -25,7 +29,32 @@
                 <v-card-title class="font-weight-bold mt-3">
                   {{ place.name }}
                   <v-spacer></v-spacer>
-                  <v-btn text @click="dialog = true"><v-icon class="ma-5" color="#E040FB">mdi-pencil</v-icon></v-btn>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs  }">
+                      <v-btn 
+                      text 
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="edit_dialog_open" 
+                      fab>
+                      <v-icon class="ma-5">mdi-pencil</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>編集</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs  }">
+                    <v-btn 
+                      text 
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="delete_dialog = true" 
+                      fab>
+                      <v-icon class="ma-5">mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>削除</span>
+                </v-tooltip>
                 </v-card-title>
                 <hr class="mt-n3" />
                 <v-simple-table class="my-9">
@@ -118,84 +147,126 @@
       <v-col></v-col>
     </v-row>
 
-    </v-col>
-    <v-col cols="1"></v-col>
-    </v-row>
-    <!-- modal window to edit -->
-    <v-dialog v-model="dialog" width="1200">
+   <!-- 編集ダイアログ -->
+
+    <v-dialog
+      v-model="edit_dialog"
+      width="500"
+      >
       <v-card>
+        <v-card-title class="headline blue-grey darken-3">
+          <div style="color: white">
+            <v-icon class="ma-5" dark>mdi-pencil</v-icon>編集
+          </div>
+          <v-spacer></v-spacer>
+          <v-btn text @click="edit_dialog = false" fab dark>
+            ​ <v-icon>mdi-close</v-icon>
+          </v-btn>
+      </v-card-title>
+
+      <v-card-text>
         <v-row>
-          <v-col cols="2"></v-col>
-          <v-col cols="8">
-            <v-card-title class="font-weight-bold"
-                          ><v-icon class="pa-2">mdi-pencil</v-icon>登録情報の編集</v-card-title>
-            <v-text-field
-              label="氏名"
-              background-color="white"
-              outlined
-              v-model="student_id"
-              filled
-              clearable
-              ></v-text-field>
-            <v-select
-              label="権限"
-              ref="groupCategory"
-              v-model="groupCategoryId"
-              :menu-props="{
-                             top: true,
-                             offsetY: true,
-                             }"
-              item-text="name"
-              item-value="id"
-              outlined
-              ></v-select>
-            <v-text-field
-              label="学籍番号８桁"
-              background-color="white"
-              outlined
-              v-model="student_id"
-              counter="8"
-              filled
-              clearable
-              ></v-text-field>
-            <v-text-field
-              label="課程（専攻）"
-              background-color="white"
-              outlined
-              v-model="student_id"
-              filled
-              clearable
-              ></v-text-field>
-            <v-text-field
-              label="団体"
-              background-color="white"
-              outlined
-              v-model="student_id"
-              filled
-              clearable
-              ></v-text-field>
-            <v-text-field
-              label="電話番号"
-              background-color="white"
-              outlined
-              v-model="student_id"
-              filled
-              clearable
-              ></v-text-field>
-            <v-btn color="blue darken-1" block dark @click="submit"
-                   >登録</v-btn>
-            <v-btn color="blue darken-1" text block @click="cancel">リセット</v-btn>
+          <v-col>
+            <v-form ref="form">
+                <v-text-field
+                label="名前"
+                v-model="name"
+                clearable
+                outlined
+                :rules="[rules.required]"
+                />
+            </v-form>
           </v-col>
-          <v-col cols="2"></v-col>
         </v-row>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="#78909C"
+          dark
+          @click="edit"
+          >
+          編集する
+        </v-btn>
+      </v-card-actions>
       </v-card>
-    </v-dialog>
-        </div>
+    </v-dialog> 
+
+    <!-- 削除ダイアログ -->
+    <v-dialog
+      v-model="delete_dialog"
+      width="500"
+      >
+      <v-card>
+        <v-card-title class="headline blue-grey darken-3">
+          <div style="color: white">
+            <v-icon class="ma-5" dark>mdi-delete</v-icon>削除
+          </div>
+          <v-spacer></v-spacer>
+          <v-btn text @click="delete_dialog = false" fab dark>
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+
+      <v-card-title>
+        削除してよろしいですか？
+      </v-card-title>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          flat
+          color="red"
+          dark
+          @click="delete_yes"
+          >
+          はい
+        </v-btn>
+        <v-btn
+          flat
+          color="blue"
+          dark
+          @click="delete_dialog = false"
+          >
+          いいえ
+        </v-btn>
+      </v-card-actions>
+      </v-card>
+    </v-dialog> 
+
+    <!-- 編集成功SnackBar -->
+    <v-snackbar
+      v-model="success_snackbar"
+      color="blue-grey"
+      top
+      elevation="24"
+    >
+      編集しました
+
+      <template v-slot:action="{ attrs }">
+        <v-btn
+          color="white"
+          text
+          v-bind="attrs"
+          @click="snackbar = false"
+        >
+        <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </template>
+    </v-snackbar> 
+    </div>
+    </div>
 </template>
 
 <script>
 import axios from "axios";
 import { mapState } from "vuex";
+import NoData from "../../components/NoData.vue" ;
 
 export default {
   fetch({ store }) {
@@ -204,11 +275,19 @@ export default {
   computed: {
     ...mapState(["rights"]),
   },
+  components :{
+    NoData
+  },
   data() {
     return {
       place: [],
+      id: [],
       expand: false,
-      dialog: false,
+      edit_dialog: false,
+      delete_dialog: false,
+       rules: {
+        required: value => !!value || "入力してください"
+      }
     };
   },
   mounted() {
@@ -221,7 +300,48 @@ export default {
       })
       .then((response) => {
         this.place = response.data
+        this.id = response.data.id
+        this.name = response.data.name
       })
+  },
+  methods: {
+    reload: function(){
+      console.log("reload")
+      const url = "/places/" + this.$route.params.id;
+      this.$axios.get(url, {
+        headers: { 
+          "Content-Type": "application/json", 
+        }
+      }
+      )
+        .then(response => {
+        this.place = response.data
+        this.id = response.data.id
+        this.name = response.data.name
+        })
+    },
+    edit_dialog_open: function() {
+      this.edit_dialog = true
+    },
+    edit: function() {
+      const edit_url = '/places/' + this.id + '?name=' + this.name 
+      console.log(edit_url)
+      this.$axios.put(edit_url , {
+        headers: { 
+          "Content-Type": "application/json", 
+        }
+      }).then(response => {
+        console.log(response)
+        this.reload()
+        this.edit_dialog = false
+        this.success_snackbar = true
+      })
+    },
+    delete_yes: function() {
+      const url = "/places/" + this.$route.params.id;
+      this.$axios.delete(url)
+      this.$router.push('/places')
+    }
   }
 }
 </script>

--- a/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
@@ -86,7 +86,7 @@
                             outlined
                           ></v-select>
                           <v-select
-                            label="参加団体名"
+                            label="グループカテゴリー"
                             v-model="groupCategoryId"
                             :items="group_categories"
                             :menu-props="{
@@ -189,12 +189,12 @@
                       v-slot:item.rental_item_allow_list.created_at="{ item }"
                     >
                       {{
-                        item.rental_item_allow_list.created_at | (format - date)
+                        item.rental_item_allow_list.created_at | format-date
                       }}
                     </template>
                     <template v-slot:item.updated_at="{ item }">
                       {{
-                        item.rental_item_allow_list.updated_at | (format - date)
+                        item.rental_item_allow_list.updated_at | format-date
                       }}
                     </template>
                   </v-data-table>

--- a/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
@@ -9,6 +9,36 @@
             <v-card-title class="font-weight-bold mt-3">
               <v-icon class="mr-5">mdi-table-furniture</v-icon>使用可能物品一覧
               <v-spacer></v-spacer>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="open_add_dialog"
+                    >
+                      <v-icon dark>mdi-plus-circle-outline</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>使用可能物品の追加</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="reload"
+                    >
+                      <v-icon dark>mdi-reload</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>更新する</span>
+                </v-tooltip>
               <v-tooltip top>
                 <template v-slot:activator="{ on, attrs  }">
                   <v-btn 
@@ -25,6 +55,66 @@
                 <span>印刷する</span>
               </v-tooltip>
             </v-card-title>
+
+                <v-dialog v-model="dialog" max-width="500">
+                  <v-card>
+                    <v-card-title class="headline blue-grey darken-3">
+                      <div style="color: white">
+                        <v-icon class="ma-2" dark>mdi-table-furniture</v-icon
+                        >使用可能物品の追加
+                      </div>
+                      <v-spacer></v-spacer>
+                      <v-btn text @click="dialog = false" fab dark>
+                        ​ <v-icon>mdi-close</v-icon>
+                      </v-btn>
+                    </v-card-title>
+                    <v-card-text>
+                      <v-row>
+                        <v-col>
+                          <v-form ref="form">
+                            <v-select
+                              label="物品"
+                              v-model="rentalItemId"
+                              :items="rental_items"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                            <v-select
+                              label="参加団体名"
+                              v-model="groupCategoryId"
+                              :items="group_categories"
+                              :menu-props="{
+                                top: true,
+                                offsetY: true,
+                              }"
+                              item-text="name"
+                              item-value="id"
+                              outlined
+                            ></v-select>
+                            <v-card-actions>
+                              <v-btn
+                                flatk
+                                large
+                                block
+                                dark
+                                color="blue"
+                                @click="register()"
+                                >登録 ​
+                              </v-btn>
+                            </v-card-actions>
+                          </v-form>
+                        </v-col>
+                      </v-row>
+                    </v-card-text>
+                    <br />
+                  </v-card>
+                </v-dialog>
+
             <hr class="mt-n3">
             <template>
               <div class="text-center" v-if="rental_item_allow_list.length === 0">
@@ -69,7 +159,6 @@
       </div>
     </v-col>
   </v-row>
-  </div>
 </template>
 
 <script>
@@ -77,7 +166,11 @@ export default {
   data() {
     return {
       rental_item_allow_list: [],
+      rental_items: [],
       group_categories: [],
+      dialog: false,
+      rentalItemId: [],
+      groupCategoryId: [],
       category: [],
       headers:[
         { text: 'ID', value: 'rental_item_allow_list.id' },
@@ -109,6 +202,59 @@ export default {
         this.rental_item_allow_list = response.data
       })
   },
+
+  methods: {
+    open_add_dialog: function (){
+      const url = "/api/v1/get_rental_item_allow_lists";
+      this.$axios
+        .get(url, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then(
+          (response) => {
+            this.rental_item_allow_list = response.data;
+          },
+          (error) => {
+            console.error(error);
+            return error;
+          }
+        );
+      this.$axios.get('/rental_items', {
+        headers: { 
+          "Content-Type": "application/json", 
+        }
+      }).then(response => {
+        this.rental_items = response.data
+      })
+        this.dialog = true
+    },
+    reload: function () {
+      this.$axios
+        .get("/api/v1/get_rental_item_allow_lists", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.rental_item_allow_list = response.data;
+        });
+    },
+    register: function () {
+      this.$axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("rental_item_id", this.rentalItemId);
+      params.append("group_category_id", this.groupCategoryId);
+      this.$axios.post("/rental_item_allow_lists", params).then((response) => {
+        console.log(response);
+        this.dialog = false;
+        this.reload();
+        this.rentalItemId = "";
+        this.groupCategoryId = "";
+      });
+    },
+  }
 }
 </script>
 

--- a/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
@@ -2,13 +2,14 @@
   <v-row>
     <v-col>
       <div class="card">
-      <v-card flat>
-        <v-row>
-          <v-col cols="1"></v-col>
-          <v-col cols="10">
-            <v-card-title class="font-weight-bold mt-3">
-              <v-icon class="mr-5">mdi-table-furniture</v-icon>使用可能物品一覧
-              <v-spacer></v-spacer>
+        <v-card flat>
+          <v-row>
+            <v-col cols="1"></v-col>
+            <v-col cols="10">
+              <v-card-title class="font-weight-bold mt-3">
+                <v-icon class="mr-5">mdi-table-furniture</v-icon
+                >使用可能物品一覧
+                <v-spacer></v-spacer>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs }">
                     <v-btn
@@ -39,123 +40,170 @@
                   </template>
                   <span>更新する</span>
                 </v-tooltip>
-              <v-tooltip top>
-                <template v-slot:activator="{ on, attrs  }">
-                  <v-btn 
-                          class="mx-2" 
-                          fab 
-                          text
-                          v-bind="attrs"
-                          v-on="on"
-                          to="/users/print"
-                          >
-                          <v-icon dark>mdi-printer</v-icon>
-                  </v-btn>
-                </template>
-                <span>印刷する</span>
-              </v-tooltip>
-            </v-card-title>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      class="mx-2"
+                      fab
+                      text
+                      v-bind="attrs"
+                      v-on="on"
+                      to="/users/print"
+                    >
+                      <v-icon dark>mdi-printer</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>印刷する</span>
+                </v-tooltip>
+              </v-card-title>
 
-                <v-dialog v-model="dialog" max-width="500">
-                  <v-card>
-                    <v-card-title class="headline blue-grey darken-3">
-                      <div style="color: white">
-                        <v-icon class="ma-2" dark>mdi-table-furniture</v-icon
-                        >使用可能物品の追加
-                      </div>
-                      <v-spacer></v-spacer>
-                      <v-btn text @click="dialog = false" fab dark>
-                        ​ <v-icon>mdi-close</v-icon>
-                      </v-btn>
-                    </v-card-title>
-                    <v-card-text>
-                      <v-row>
-                        <v-col>
-                          <v-form ref="form">
-                            <v-select
-                              label="物品"
-                              v-model="rentalItemId"
-                              :items="rental_items"
-                              :menu-props="{
-                                top: true,
-                                offsetY: true,
-                              }"
-                              item-text="name"
-                              item-value="id"
-                              outlined
-                            ></v-select>
-                            <v-select
-                              label="参加団体名"
-                              v-model="groupCategoryId"
-                              :items="group_categories"
-                              :menu-props="{
-                                top: true,
-                                offsetY: true,
-                              }"
-                              item-text="name"
-                              item-value="id"
-                              outlined
-                            ></v-select>
-                            <v-card-actions>
-                              <v-btn
-                                flatk
-                                large
-                                block
-                                dark
-                                color="blue"
-                                @click="register()"
-                                >登録 ​
-                              </v-btn>
-                            </v-card-actions>
-                          </v-form>
-                        </v-col>
-                      </v-row>
-                    </v-card-text>
-                    <br />
-                  </v-card>
-                </v-dialog>
+              <v-dialog v-model="dialog" max-width="500">
+                <v-card>
+                  <v-card-title class="headline blue-grey darken-3">
+                    <div style="color: white">
+                      <v-icon class="ma-2" dark>mdi-table-furniture</v-icon
+                      >使用可能物品の追加
+                    </div>
+                    <v-spacer></v-spacer>
+                    <v-btn text @click="dialog = false" fab dark>
+                      ​ <v-icon>mdi-close</v-icon>
+                    </v-btn>
+                  </v-card-title>
+                  <v-card-text>
+                    <v-row>
+                      <v-col>
+                        <v-form ref="form">
+                          <v-select
+                            label="物品"
+                            v-model="rentalItemId"
+                            :items="rental_items"
+                            :menu-props="{
+                              top: true,
+                              offsetY: true,
+                            }"
+                            item-text="name"
+                            item-value="id"
+                            outlined
+                          ></v-select>
+                          <v-select
+                            label="参加団体名"
+                            v-model="groupCategoryId"
+                            :items="group_categories"
+                            :menu-props="{
+                              top: true,
+                              offsetY: true,
+                            }"
+                            item-text="name"
+                            item-value="id"
+                            outlined
+                          ></v-select>
+                          <v-card-actions>
+                            <v-btn
+                              flatk
+                              large
+                              block
+                              dark
+                              color="blue"
+                              @click="register()"
+                              >登録 ​
+                            </v-btn>
+                          </v-card-actions>
+                        </v-form>
+                      </v-col>
+                    </v-row>
+                  </v-card-text>
+                  <br />
+                </v-card>
+              </v-dialog>
 
-            <hr class="mt-n3">
-            <template>
-              <div class="text-center" v-if="rental_item_allow_list.length === 0">
-                <br><br>
-                <v-progress-circular
-                  indeterminate
-                  color="#009688"
+              <hr class="mt-n3" />
+              <template>
+                <div
+                  class="text-center"
+                  v-if="rental_item_allow_list.length === 0"
+                >
+                  <br /><br />
+                  <v-progress-circular
+                    indeterminate
+                    color="#009688"
                   ></v-progress-circular>
-                <br><br>
-              </div>
-              <div v-else>
-                <v-data-table
-                  :headers="headers"
-                  :items="rental_item_allow_list"
-                  class="elevation-0 my-9"
-                  @click:row="
-                              (data) =>
-                              $router.push({ path: `/rental_item_allow_lists/${data.rental_item_allow_list.id}`})
-                              "
+                  <br /><br />
+                </div>
+                <div v-else>
+                  <v-data-table
+                    :headers="headers"
+                    :items="rental_item_allow_list"
+                    class="elevation-0 my-9"
+                    @click:row="
+                      (data) =>
+                        $router.push({
+                          path: `/rental_item_allow_lists/${data.rental_item_allow_list.id}`,
+                        })
+                    "
                   >
-                  <template v-slot:item.group_category.id="{ item }">
-                    <v-chip v-if="item.group_category.id == 1" color="red" text-color="white" small>{{ category[0] }}</v-chip>
-                    <v-chip v-if="item.group_category.id == 2" color="pink" text-color="white" small>{{ category[1] }}</v-chip>
-                    <v-chip v-if="item.group_category.id == 3" color="blue" text-color="white" small>{{ category[2] }}</v-chip>
-                    <v-chip v-if="item.group_category.id == 4" color="green" text-color="white" small>{{ category[3] }}</v-chip>
-                    <v-chip v-if="item.group_category.id == 5" color="orange" text-color="white" small>{{ category[4] }}</v-chip>
-                    <v-chip v-if="item.group_category.id == 6" color="blue-gray" text-color="white" small>{{ category[5] }}</v-chip>
-                  </template>
-                  <template v-slot:item.rental_item_allow_list.created_at="{ item }">
-                    {{ item.rental_item_allow_list.created_at | format-date }}
-                  </template>
-                  <template v-slot:item.updated_at="{ item }">
-                    {{ item.rental_item_allow_list.updated_at | format-date }}
-                  </template>
-                </v-data-table>                      
-              </div>
-            </template>
-          </v-col>
-          <v-col cols="1"></v-col>
-        </v-row>
-      </v-card>
+                    <template v-slot:item.group_category.id="{ item }">
+                      <v-chip
+                        v-if="item.group_category.id == 1"
+                        color="red"
+                        text-color="white"
+                        small
+                        >{{ category[0] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category.id == 2"
+                        color="pink"
+                        text-color="white"
+                        small
+                        >{{ category[1] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category.id == 3"
+                        color="blue"
+                        text-color="white"
+                        small
+                        >{{ category[2] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category.id == 4"
+                        color="green"
+                        text-color="white"
+                        small
+                        >{{ category[3] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category.id == 5"
+                        color="orange"
+                        text-color="white"
+                        small
+                        >{{ category[4] }}</v-chip
+                      >
+                      <v-chip
+                        v-if="item.group_category.id == 6"
+                        color="blue-gray"
+                        text-color="white"
+                        small
+                        >{{ category[5] }}</v-chip
+                      >
+                    </template>
+                    <template
+                      v-slot:item.rental_item_allow_list.created_at="{ item }"
+                    >
+                      {{
+                        item.rental_item_allow_list.created_at | (format - date)
+                      }}
+                    </template>
+                    <template v-slot:item.updated_at="{ item }">
+                      {{
+                        item.rental_item_allow_list.updated_at | (format - date)
+                      }}
+                    </template>
+                  </v-data-table>
+                </div>
+              </template>
+            </v-col>
+            <v-col cols="1"></v-col>
+          </v-row>
+        </v-card>
       </div>
     </v-col>
   </v-row>
@@ -172,39 +220,41 @@ export default {
       rentalItemId: [],
       groupCategoryId: [],
       category: [],
-      headers:[
-        { text: 'ID', value: 'rental_item_allow_list.id' },
-        { text: '物品', value: 'item' },
-        { text: 'グループカテゴリー', value: 'group_category.id' },
-        { text: '日時', value: 'rental_item_allow_list.created_at' },
-        { text: '編集日時', value: 'rental_item_allow_list.updated_at' },
+      headers: [
+        { text: "ID", value: "rental_item_allow_list.id" },
+        { text: "物品", value: "item" },
+        { text: "グループカテゴリー", value: "group_category.id" },
+        { text: "日時", value: "rental_item_allow_list.created_at" },
+        { text: "編集日時", value: "rental_item_allow_list.updated_at" },
       ],
-    }
+    };
   },
   mounted() {
-    this.$axios.get('/group_categories', {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        this.group_categories = response.data
+    this.$axios
+      .get("/group_categories", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.group_categories = response.data;
         for (let i = 0; i < this.group_categories.length; i++) {
-          this.category.push(this.group_categories[i]['name'])
+          this.category.push(this.group_categories[i]["name"]);
         }
+      });
+    this.$axios
+      .get("/api/v1/get_rental_item_allow_lists", {
+        headers: {
+          "Content-Type": "application/json",
+        },
       })
-    this.$axios.get('/api/v1/get_rental_item_allow_lists', {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        this.rental_item_allow_list = response.data
-      })
+      .then((response) => {
+        this.rental_item_allow_list = response.data;
+      });
   },
 
   methods: {
-    open_add_dialog: function (){
+    open_add_dialog: function () {
       const url = "/api/v1/get_rental_item_allow_lists";
       this.$axios
         .get(url, {
@@ -221,14 +271,16 @@ export default {
             return error;
           }
         );
-      this.$axios.get('/rental_items', {
-        headers: { 
-          "Content-Type": "application/json", 
-        }
-      }).then(response => {
-        this.rental_items = response.data
-      })
-        this.dialog = true
+      this.$axios
+        .get("/rental_items", {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => {
+          this.rental_items = response.data;
+        });
+      this.dialog = true;
     },
     reload: function () {
       this.$axios
@@ -254,13 +306,13 @@ export default {
         this.groupCategoryId = "";
       });
     },
-  }
-}
+  },
+};
 </script>
 
 <style>
 .card {
   padding-left: 1%;
-  padding-right: 5%
+  padding-right: 5%;
 }
 </style>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #350 

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面の使用可能物品の追加機能を実装した．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8000/rental_item_allow_lists`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者ページから使用可能物品の追加ができるか

# 備考
ダイアログを開くためのmethodsを作成した．
今までは`@click="dialog = true"`にしてたが，open_add_dialogというメソッドを作成して，その中で必要なAPIの呼び出しとダイアログを開く処理を実装した．