### PR TITLE
販売食品情報追加機能の実装 Dev/issue369

### DIFF
--- a/view/vue-project/src/components/AddModal/FoodProduct.vue
+++ b/view/vue-project/src/components/AddModal/FoodProduct.vue
@@ -1,0 +1,6 @@
+<template>
+
+</template>
+<script>
+
+</script>

--- a/view/vue-project/src/components/AddModal/FoodProduct.vue
+++ b/view/vue-project/src/components/AddModal/FoodProduct.vue
@@ -1,0 +1,139 @@
+<template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color:#ECEFF1; font-size:30px">
+        <v-icon class="pr-3" size="35">mdi-map-marker</v-icon><b>販売食品情報追加</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay=false"><v-icon>mdi-close</v-icon></v-btn>
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols="2"></v-col>
+          <v-col cols="8" align="center">
+            <v-card-text>
+              <v-form ref="form">
+                <v-text-field
+                    class="body-1"
+                    label="販売食品名"
+                    v-model="productName"
+                    background-color="white"
+                    outlined
+                    clearable
+                    >
+                </v-text-field>
+                <v-select
+                    class="body-1"
+                    label="調理の有無"
+                    v-model="isCooking"
+                    :items="cooking_available"
+                    item-text="label"
+                    item-value="value"
+                    background-color="white"
+                    outlined
+                    clearable
+                    >
+                </v-select>
+                <v-text-field
+                    class="body-1"
+                    label="1日目の個数"
+                    v-model="firstDayNum"
+                    background-color="white"
+                    outlined
+                    clearable
+                    type="number"
+                    >
+                </v-text-field>
+                <v-text-field
+                    class="body-1"
+                    label="2日目の個数"
+                    v-model="secondDayNum"
+                    background-color="white"
+                    outlined
+                    clearable
+                    type="number"
+                    >
+                </v-text-field>
+              </v-form>
+            </v-card-text>
+            <v-row>
+              <v-col cols=4></v-col>
+                <v-col cols=4>
+                  <v-btn color="blue darken-1" large block dark @click="register">編集する</v-btn>
+                </v-col>
+                <v-col cols=4></v-col>
+            </v-row>
+          </v-col>
+          <v-col cols="2"></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+
+</template>
+<script>
+import axios from 'axios'
+export default {
+   props: {
+    groupId: Number,
+  },
+  data () {
+    return {
+      isDisplay: false,
+      food_products: [],
+      groups: [],
+      dialog: false,
+      Group: [],
+      productName: [],
+      isCooking: [],
+      firstDayNum: [],
+      secondDayNum: [],
+      cooking_available:[
+        {label:"する",value:true},
+        {label:"しない",value:false}
+      ],
+    }
+  },
+  mounted() {
+    axios.get(process.env.VUE_APP_URL + '/api/v1/get_food_products', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    }
+    )
+      .then(response => {
+        this.food_products = response.data
+      })
+  },
+  methods: {
+    reload: function () {
+      axios.get(process.env.VUE_APP_URL + "/api/v1/get_food_products", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((response) => {
+          this.food_products = response.data;
+        });
+    },
+    register: function () {
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.groupId);
+      params.append("name", this.productName);
+      params.append("is_cooking", this.isCooking);
+      params.append("first_day_num", this.firstDayNum);
+      params.append("second_day_num", this.secondDayNum);
+      axios.post(process.env.VUE_APP_URL + "/food_products", params).then((response) => {
+        console.log(response);
+        this.isDisplay = false;
+        this.$emit('reload')
+        this.Group = "";
+        this.productName = "";
+        this.isCooking = "";
+        this.firstDayNum = "";
+        this.secondDayNum = "";
+      });
+    },
+  }
+}
+</script>

--- a/view/vue-project/src/components/AddModal/FoodProduct.vue
+++ b/view/vue-project/src/components/AddModal/FoodProduct.vue
@@ -1,6 +1,159 @@
 <template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color:#ECEFF1; font-size:30px">
+        <v-icon class="pr-3" size="35">mdi-map-marker</v-icon><b>販売食品情報追加</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay=false"><v-icon>mdi-close</v-icon></v-btn>
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols="2"></v-col>
+          <v-col cols="8" align="center">
+            <v-card-text>
+              <v-form ref="form">
+                <v-select
+                    label="参加団体名"
+                    v-model="Group"
+                    :items="groups"
+                    :menu-props="{
+                                 top: true,
+                                 offsetY: true,
+                                 }"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                    ></v-select>
+                <v-text-field
+                    class="body-1"
+                    label="販売食品名"
+                    v-model="productName"
+                    background-color="white"
+                    outlined
+                    clearable
+                    >
+                </v-text-field>
+                <v-select
+                    class="body-1"
+                    label="調理の有無"
+                    v-model="isCooking"
+                    :items="cooking_available"
+                    item-text="label"
+                    item-value="value"
+                    background-color="white"
+                    outlined
+                    clearable
+                    >
+                </v-select>
+                <v-text-field
+                    class="body-1"
+                    label="1日目の個数"
+                    v-model="firstDayNum"
+                    background-color="white"
+                    outlined
+                    clearable
+                    type="number"
+                    >
+                </v-text-field>
+                <v-text-field
+                    class="body-1"
+                    label="2日目の個数"
+                    v-model="secondDayNum"
+                    background-color="white"
+                    outlined
+                    clearable
+                    type="number"
+                    >
+                </v-text-field>
+              </v-form>
+            </v-card-text>
+            <v-row>
+              <v-col cols=4></v-col>
+                <v-col cols=4>
+                  <v-btn color="blue darken-1" large block dark @click="register">編集する</v-btn>
+                </v-col>
+                <v-col cols=4></v-col>
+            </v-row>
+          </v-col>
+          <v-col cols="2"></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
 
 </template>
 <script>
-
+import axios from 'axios'
+export default {
+   props: {
+    groupId: Number,
+  },
+  data () {
+    return {
+      isDisplay: false,
+      food_products: [],
+      groups: [],
+      dialog: false,
+      Group: [],
+      productName: [],
+      isCooking: [],
+      firstDayNum: [],
+      secondDayNum: [],
+      cooking_available:[
+        {label:"する",value:true},
+        {label:"しない",value:false}
+      ],
+    }
+  },
+  mounted() {
+    axios.get(process.env.VUE_APP_URL + '/api/v1/get_food_products', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    }
+    )
+      .then(response => {
+        this.food_products = response.data
+      })
+    axios.get(process.env.VUE_APP_URL + '/groups', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.groups = response.data
+      })
+  },
+  methods: {
+    reload: function () {
+      axios.get(process.env.VUE_APP_URL + "/api/v1/get_food_products", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((response) => {
+          this.food_products = response.data;
+        });
+    },
+    register: function () {
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.groupId);
+      params.append("name", this.productName);
+      params.append("is_cooking", this.isCooking);
+      params.append("first_day_num", this.firstDayNum);
+      params.append("second_day_num", this.secondDayNum);
+      axios.post(process.env.VUE_APP_URL + "/food_products", params).then((response) => {
+        console.log(response);
+        this.isDisplay = false;
+        this.$emit('reload')
+        this.Group = "";
+        this.productName = "";
+        this.isCooking = "";
+        this.firstDayNum = "";
+        this.secondDayNum = "";
+      });
+    },
+  }
+}
 </script>

--- a/view/vue-project/src/components/AddModal/PurchaseList.vue
+++ b/view/vue-project/src/components/AddModal/PurchaseList.vue
@@ -1,0 +1,169 @@
+<template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color:#ECEFF1; font-size:30px">
+        <v-icon class="pr-3" size="35">mdi-map-marker</v-icon><b>購入品情報追加</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay=false"><v-icon>mdi-close</v-icon></v-btn>
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols="2"></v-col>
+          <v-col cols="8" align="center">
+            <v-card-text>
+              <v-form ref="form">
+                <v-select
+                    label="参加団体名"
+                    v-model="Group"
+                    :items="groups"
+                    :menu-props="{
+                                 top: true,
+                                 offsetY: true,
+                                 }"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                    @change="getPurchaseList(Group)"
+                    ></v-select>
+                <v-select
+                    label="販売食品"
+                    v-model="foodProductId"
+                    :items="food_products"
+                    :menu-props="{
+                                 top: true,
+                                 offsetY: true,
+                                 }"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                    ></v-select>
+                <v-text-field
+                    class="body-1"
+                    label="購入品"
+                    v-model="item"
+                    background-color="white"
+                    outlined
+                    clearable
+                    >
+                </v-text-field>
+                  <v-select
+                      label="なまもの"
+                      :items="isFresh"
+                      item-text="label"
+                      item-value="value"
+                      :menu-props="{
+                                   top: true,
+                                   offsetY: true,
+                                   }"
+                      outlined
+                      ></v-select>
+                  <v-select
+                      label="開催日"
+                      v-model="fesDateId"
+                      :items="fes_dates"
+                      item-text="date"
+                      item-value="id"
+                      outlined
+                      ></v-select>
+                  <v-select
+                      label="店"
+                      v-model="shopId"
+                      :items="shops"
+                      :menu-props="{
+                                   top: true,
+                                   offsetY: true,
+                                   }"
+                      item-text="name"
+                      item-value="id"
+                      outlined
+                      ></v-select>
+              </v-form>
+
+            </v-card-text>
+            <v-row>
+              <v-col cols=4></v-col>
+                <v-col cols=4>
+                  <v-btn color="blue darken-1" large block dark @click="register">編集する</v-btn>
+                </v-col>
+                <v-col cols=4></v-col>
+            </v-row>
+          </v-col>
+          <v-col cols="2"></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from 'axios'
+export default {
+   props: {
+    groupId: Number,
+  },
+  data () {
+    return {
+      purchase_lists: [],
+      food_products: [],
+      groups: [],
+      fes_dates: [],
+      shops: [],
+      Group: [],
+      foodProductId: [],
+      fesDateId: [],
+      shopId: [],
+      item: [],
+      isFresh: [
+        {label: 'はい', value: 'true'},
+        {label: 'いいえ', value: 'false'}
+      ],
+      isDisplay: false,
+      dialog: false,
+    }
+  },
+  methods: {
+    getPurchaseList: function(groupId){
+    axios.get(process.env.VUE_APP_URL + "/api/v1/get_food_products_from_group/" + groupId, {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.food_products = response.data
+      })
+    },
+    reload: function () {
+      axios.get(process.env.VUE_APP_URL + "/api/v1/get_purhcase_lists", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((response) => {
+          this.purhcase_list = response.data;
+        });
+    },
+    register: function () {
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.Group);
+      params.append("food_product_id", this.foodProductId);
+      params.append("fes_date_id", this.fesDateId);
+      params.append("shop_id", this.shopId);
+      params.append("items", this.item);
+      params.append("is_fresh", this.isFresh);
+      axios.post(process.env.VUE_APP_URL + "/purchase_lists", params).then((response) => {
+        console.log(response);
+        this.isDisplay = false;
+        this.$emit('reload')
+        this.$emit('openPurchaseSnackbar')
+        this.Group = "";
+        this.foodProductId = "";
+        this.fesDateId = "";
+        this.shopId = "";
+        this.item = "";
+        this.isFresh = "";
+      });
+    },
+  },
+}
+

--- a/view/vue-project/src/components/AddModal/PurchaseList.vue
+++ b/view/vue-project/src/components/AddModal/PurchaseList.vue
@@ -1,0 +1,143 @@
+<template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color:#ECEFF1; font-size:30px">
+        <v-icon class="pr-3" size="35">mdi-map-marker</v-icon><b>購入品情報追加</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay=false"><v-icon>mdi-close</v-icon></v-btn>
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols="2"></v-col>
+          <v-col cols="8" align="center">
+            <v-card-text>
+              <v-form ref="form">
+                <v-select
+                    label="販売食品"
+                    v-model="foodProductId"
+                    :items="food_products"
+                    :menu-props="{
+                      top: true,
+                      offsetY: true,
+                    }"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                    ></v-select>
+                <v-text-field
+                    class="body-1"
+                    label="購入品"
+                    v-model="item"
+                    background-color="white"
+                    outlined
+                    clearable
+                    >
+                </v-text-field>
+                  <v-select
+                      label="なまもの"
+                      :items="isFresh"
+                      item-text="label"
+                      item-value="value"
+                      :menu-props="{
+                                   top: true,
+                                   offsetY: true,
+                                   }"
+                      outlined
+                      ></v-select>
+                  <v-select
+                      label="開催日"
+                      v-model="fesDateId"
+                      :items="fes_dates"
+                      item-text="date"
+                      item-value="id"
+                      outlined
+                      ></v-select>
+                  <v-select
+                      label="店"
+                      v-model="shopId"
+                      :items="shops"
+                      :menu-props="{
+                                   top: true,
+                                   offsetY: true,
+                                   }"
+                      item-text="name"
+                      item-value="id"
+                      outlined
+                      ></v-select>
+              </v-form>
+
+            </v-card-text>
+            <v-row>
+              <v-col cols=4></v-col>
+                <v-col cols=4>
+                  <v-btn color="blue darken-1" large block dark @click="register">編集する</v-btn>
+                </v-col>
+                <v-col cols=4></v-col>
+            </v-row>
+          </v-col>
+          <v-col cols="2"></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from 'axios'
+export default {
+   props: {
+    groupId: Number,
+  },
+  data () {
+    return {
+      isDisplay: true,
+      purchase_lists: [],
+      food_products: [],
+      groups: [],
+      fes_dates: [],
+      shops: [],
+      foodProductId: [],
+      fesDateId: [],
+      shopId: [],
+      item: [],
+      isFresh: [
+        {label: 'はい', value: 'true'},
+        {label: 'いいえ', value: 'false'}
+      ],
+    }
+  },
+  methods: {
+    reload: function () {
+      axios.get(process.env.VUE_APP_URL + "/api/v1/get_purhcase_lists", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((response) => {
+          this.purhcase_list = response.data;
+        });
+    },
+    register: function () {
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      var params = new URLSearchParams();
+      params.append("group_id", this.groupId);
+      params.append("food_product_id", this.foodProductId);
+      params.append("fes_date_id", this.fesDateId);
+      params.append("shop_id", this.shopId);
+      params.append("items", this.item);
+      params.append("is_fresh", this.isFresh);
+      axios.post(process.env.VUE_APP_URL + "/purchase_lists", params).then((response) => {
+        console.log(response);
+        this.isDisplay = false;
+        this.$emit('reload')
+        this.$emit('openPurchaseSnackbar')
+        this.foodProductId = "";
+        this.fesDateId = "";
+        this.shopId = "";
+        this.item = "";
+        this.isFresh = "";
+      });
+    },
+  },
+}
+

--- a/view/vue-project/src/components/EditModal/stage_order.vue
+++ b/view/vue-project/src/components/EditModal/stage_order.vue
@@ -1,0 +1,208 @@
+<template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color:#ECEFF1; font-size:30px">
+        <v-icon class="pr-3" size="35">mdi-account-single</v-icon><b>ステージ利用申請を修正する</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay=false"><v-icon>mdi-close</v-icon></v-btn>
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols=2></v-col>
+          <v-col cols=8>
+            <v-form ref="form">
+              <v-select
+                label="天気"
+                v-model="isSunny"
+                :items="is_sunny_list"
+                item-text="label"
+                item-value="value"
+                text
+                outlined
+                clearable
+                />
+                <v-select
+                  label="第一希望"
+                  v-model="stageFirst"
+                  :items="stages_list"
+                  item-text="name"
+                  item-value="id"
+                  text
+                  outlined
+                  clearable
+                  />
+                  <v-select
+                    label="第二希望"
+                    v-model="stageSecond"
+                    :items="stages_list"
+                    item-text="name"
+                    item-value="id"
+                    text
+                    outlined
+                    clearable
+                    />
+                    <v-radio-group v-model="radioGroup">
+                      <v-radio
+                        label="時間幅で修正"
+                        :value="1"
+                        ></v-radio>
+                      <v-radio
+                        label="時刻で修正"
+                        :value="2"
+                        ></v-radio>
+                    </v-radio-group>
+                    <div v-if="radioGroup === 1">
+                      <v-select
+                        label="使用時間"
+                        v-model="useTimeInterval"
+                        :items="time_interval"
+                        text
+                        outlined
+                        clearable
+                        />
+                        <v-select
+                          label="準備時間"
+                          v-model="prepareTimeInterval"
+                          :items="time_interval"
+                          text
+                          outlined
+                          clearable
+                          />
+                          <v-select
+                            label="掃除時間"
+                              v-model="cleanupTimeInterval"
+                            :items="time_interval"
+                            text
+                            outlined
+                            clearable
+                            />
+                    </div>
+
+                    <div v-if="radioGroup === 2">
+                      <v-select
+                        label="準備開始時刻"
+                        v-model="prepareStartTime"
+                        :items="time_range"
+                        text
+                        outlined
+                        clearable
+                        />
+                        <v-select
+                          label="パフォーマンス開始時刻"
+                          v-model="performanceStartTime"
+                          :items="time_range"
+                          text
+                          outlined
+                          clearable
+                          />
+                          <v-select
+                            label="パフォーマンス終了時刻"
+                            v-model="performanceEndTime"
+                            :items="time_range"
+                            text
+                            outlined
+                            clearable
+                            />
+                            <v-select
+                              label="掃除終了時刻"
+                              v-model="cleanupEndTime"
+                              :items="time_range"
+                              text
+                              outlined
+                              clearable
+                              />
+                    </div>
+            </v-form>
+            <br>
+          </v-col>
+          <v-col cols=2></v-col>
+        </v-row>
+        <v-row>
+          <v-col cols=4></v-col>
+            <v-col cols=4>
+            <v-btn color="blue darken-1" large block dark @click="edit">編集する</v-btn>
+            </v-col>
+            <v-col cols=4></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from 'axios'
+export default {
+  props: {
+    id: Number,
+    groupId: Number,
+    isSunny: Boolean,
+    fesDataId: Number,
+    stageFirst: Number,
+    stageSecond: Number,
+    useTimeInterval: String,
+    prepareTimeInterval: String,
+    cleanupTimeInterval: String,
+    prepareStartTime: String,
+    performanceStartTime: String,
+    performanceEndTime: String,
+    cleanupEndTime: String,
+  },
+  data () {
+    return {
+      isDisplay: false,
+      is_sunny_list: [
+        {label:"晴れ",value:true},
+        {label:"雨",value:false}
+      ],
+      stages_list: [],
+      radioGroup: 1,
+      time_interval: ["5分", "10分", "15分", "20分", "25分", "30分", "35分", "40分", "45分", "50分", "55分", "60分", "65分", "70分", "75分", "80分", "90分", "95分", "100分", "105分", "110分", "115分", "120分"],
+      hour_range: ["9", "10", "11", "12", "13", "14", "15", "16", "17", "00"],
+      minute_range: ["00", "05", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55"],
+      time_range: [],
+    }
+  },
+  computed: {
+    form () {
+      return {
+      }
+    },
+  },
+  methods: {
+    edit: function() {
+      if ( !this.$refs.form.validate() ) return;
+
+      const url = process.env.VUE_APP_URL + '/employees' + '/' + this.id + '?group_id=' + this.groupId + '&name=' + this.name + '&student_id=' + this.studentId
+      axios.defaults.headers.common['Content-Type'] = 'application/json';
+      axios.put(url).then(
+        (response) => {
+          this.isDisplay = false
+          this.$emit('openEmployeeSnackbar')
+          this.$emit('reload')
+        },
+        (error) => {
+          return error;
+        }
+      )
+    },
+    set_time_range: function(){
+      for(var hour of this.hour_range){
+        for(var minute of this.minute_range){
+          this.time_range.push(hour+":"+minute)
+        }
+      }
+    },
+  },
+  mounted() {
+    axios.get(process.env.VUE_APP_URL + '/stages', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.stages_list = response.data
+      })
+    this.set_time_range()
+  },
+}
+</script>

--- a/view/vue-project/src/components/News.vue
+++ b/view/vue-project/src/components/News.vue
@@ -1,10 +1,8 @@
 <template>
-  <v-row>
-    <v-col cols="2"></v-col>
-    <v-col cols="8">
+  <div>
       <v-card class="mx-auto" outlined>
-        <v-card-title style="background-color: #eceff1; font-size: 30px">
-          <v-icon class="pr-2" size="40">mdi-bell</v-icon>
+        <v-card-title style="background-color: #eceff1;" class="title">
+          <v-icon class="pr-2" size="30">mdi-bell</v-icon>
           <b>お知らせ</b>
         </v-card-title>
 
@@ -49,9 +47,7 @@
           </v-card>
         </v-dialog>
       </v-card>
-    </v-col>
-    <v-col cols="2"></v-col>
-  </v-row>
+    </div>
 </template>
 
 <script>

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -1,843 +1,843 @@
 <template>
   <div>
-      <v-card
-        class = "mx-auto"
-        outlined
-      >
-      <v-card-title style="background-color:#ECEFF1;" class="title"><v-icon class="pr-2" size="30">mdi-information</v-icon><b>登録情報</b></v-card-title>
-        <v-divider class="mx-4"></v-divider>
-        <v-row>
-          <v-col>
-            <v-tabs vertical color="#E040FB">
-              <v-tab
-                :value="tab-1"
-                class="font-weight-bold justify-start"
-                >
-                <v-icon class="pr-2">mdi-account-group</v-icon>団体情報
-              </v-tab>
-
-              <v-tab
-                :value="tab-2"
-                class="font-weight-bold justify-start"
-                >
-                <v-icon class="pr-2">mdi-account-multiple</v-icon>副代表情報
-              </v-tab>
-
-              <v-tab
-                :value="tab-3"
-                class="font-weight-bold justify-start"
+    <v-card
+      class = "mx-auto"
+      outlined
+    >
+    <v-card-title style="background-color:#ECEFF1;" class="title"><v-icon class="pr-2" size="30">mdi-information</v-icon><b>登録情報</b></v-card-title>
+      <v-divider class="mx-4"></v-divider>
+      <v-row>
+        <v-col>
+          <v-tabs vertical color="#E040FB">
+            <v-tab
+              :value="tab-1"
+              class="font-weight-bold justify-start"
               >
-                <v-icon class="pr-2">mdi-map-marker</v-icon>会場申請情報
-              </v-tab>
+              <v-icon class="pr-2">mdi-account-group</v-icon>団体情報
+            </v-tab>
 
-              <v-tab
-                :value="tab-4"
-                class="font-weight-bold justify-start"
+            <v-tab
+              :value="tab-2"
+              class="font-weight-bold justify-start"
               >
-                <v-icon class="pr-2">mdi-power-plug</v-icon>電力申請情報
-              </v-tab>
+              <v-icon class="pr-2">mdi-account-multiple</v-icon>副代表情報
+            </v-tab>
 
-              <v-tab
-                :value="tab-5"
-                class="font-weight-bold justify-start"
+            <v-tab
+              :value="tab-3"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-map-marker</v-icon>会場申請情報
+            </v-tab>
+
+            <v-tab
+              :value="tab-4"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-power-plug</v-icon>電力申請情報
+            </v-tab>
+
+            <v-tab
+              :value="tab-5"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-table-chair</v-icon>物品申請情報
+            </v-tab>
+
+            <v-tab
+              :value="tab-6"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-microphone-variant</v-icon>ステージ利用申請情報
+            </v-tab>
+
+            <v-tab
+              :value="tab-7"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-account</v-icon>従業員情報
+            </v-tab>
+
+            <v-tab
+              :value="tab-8"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-baguette</v-icon>販売食品情報
+            </v-tab>
+
+            <v-tab
+              :value="tab-9"
+              class="font-weight-bold justify-start"
+            >
+              <v-icon class="pr-2">mdi-cart</v-icon>購入品情報
+            </v-tab>
+            <v-tab-item
               >
-                <v-icon class="pr-2">mdi-table-chair</v-icon>物品申請情報
-              </v-tab>
-
-              <v-tab
-                :value="tab-6"
-                class="font-weight-bold justify-start"
-              >
-                <v-icon class="pr-2">mdi-microphone-variant</v-icon>ステージ利用申請情報
-              </v-tab>
-
-              <v-tab
-                :value="tab-7"
-                class="font-weight-bold justify-start"
-              >
-                <v-icon class="pr-2">mdi-account</v-icon>従業員情報
-              </v-tab>
-
-              <v-tab
-                :value="tab-8"
-                class="font-weight-bold justify-start"
-              >
-                <v-icon class="pr-2">mdi-baguette</v-icon>販売食品情報
-              </v-tab>
-
-              <v-tab
-                :value="tab-9"
-                class="font-weight-bold justify-start"
-              >
-                <v-icon class="pr-2">mdi-cart</v-icon>購入品情報
-              </v-tab>
-              <v-tab-item
-                >
-                <v-row>
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card
-                      flat
-                      >
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-account-group</v-icon><b>団体情報</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditGroup" text fab @click="openGroupDisplay"><v-icon>mdi-pencil</v-icon></v-btn>
-                        <Group ref="groupDlg"
-                          :groupId="regist.group.id"
-                          :groupName="regist.group.name"
-                          :projectName="regist.group.project_name"
-                          :groupCategoryId="regist.group.group_category_id"
-                          :activity="regist.group.activity"
-                          @reload="reload"
-                          @openGroupSnackbar="openGroupSnackbar"
-                        ></Group>
-                        <v-snackbar
-                          top
-                          text
-                          color="purple accent-2"
-                          v-model="groupSnackbar"
-                          >
-                          参加団体情報を更新しました
-                        </v-snackbar>
-                      </v-card-title>
-                        <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>団体名</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.name == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.group.name }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>企画名</v-list-item-content>
-                          <v-list-item-content v-if="regist.group.project_name == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.group.project_name }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>カテゴリー</v-list-item-content>
-                          <v-list-item-content v-if="regist.group_category == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.group_category }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>活動内容</v-list-item-content>
-                          <v-list-item-content v-if="regist.group.activity == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.group.activity }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-              </v-tab-item>
-
-              <!--副代表情報 -->
-              <v-tab-item>
-                <v-row>
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title  style="color:#333333;" class="title">
-                      <v-icon class="pr-2" size="30">mdi-account-multiple</v-icon><b>副代表情報</b>
+              <v-row>
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card
+                    flat
+                    >
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-account-group</v-icon><b>団体情報</b>
                       <v-spacer></v-spacer>
-                      <v-btn v-if="isEditSubRep" text fab @click="openSubRepDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                      <SubRep ref="subRepDlg"
-                          :groupId="regist.group.id"
-                          :name="regist.sub_rep.name"
-                          :studentId="regist.sub_rep.student_id"
-                          :gradeId="regist.sub_rep.grade_id"
-                          :departmentId="regist.sub_rep.department_id"
-                          :tel="regist.sub_rep.tel"
-                          :email="regist.sub_rep.email"
-                          @reload="reload"
-                          @openSubrepSnackbar="openSubrepSnackbar">
-                      </SubRep>
-                      <v-snackbar
-                          top
-                          text
-                          color="purple accent-2"
-                          v-model="subrepSnackbar"
-                          >
-                          副代表情報を更新しました
-                        </v-snackbar>
-                      </v-card-title>
-                      <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>氏名</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.name == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.sub_rep.name }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>学籍番号</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.student_id == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.sub_rep.student_id }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>学科</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.department_id == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.sub_rep.department_id }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>学年</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.grade_id == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.sub_rep.grade_id }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>電話番号</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.tel == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.sub_rep.tel }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>メールアドレス</v-list-item-content>
-                          <v-list-item-content v-if="regist.sub_rep.email == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.sub_rep.email }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-              </v-tab-item>
-
-              <!-- 会場申請情報 -->
-              <v-tab-item>
-                <v-row>
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-map-marker</v-icon><b>会場申請情報</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditPlace" text fab @click="openPlaceDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                        <Place ref="placeDlg"
-                          :groupId="regist.group.id"
-                          :firstId="regist.place_order.first"
-                          :secondId="regist.place_order.second"
-                          :thirdId="regist.place_order.third"
-                          :remark="regist.place_order.remark"
-                          @reload="reload"
-                          @openPlaceSnackbar="openPlaceSnackbar"
-                          ></Place>
-                          <v-snackbar
-                          top
-                          text
-                          color="purple accent-2"
-                          v-model="placeSnackbar"
-                          >
-                          会場申請情報を更新しました
-                        </v-snackbar>
-                      </v-card-title>
-                      <hr>
-                      <v-card-text v-if = "regist.first_place_order == -9999">未登録</v-card-text>
-                      <v-list v-else>
-                        <v-list-item>
-                          <v-list-item-content>第1志望</v-list-item-content>
-                          <v-list-item-content v-if="regist.first_place_order == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.first_place_order }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>第2志望</v-list-item-content>
-                          <v-list-item-content v-if="regist.second_place_order == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.second_place_order }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>第3志望</v-list-item-content>
-                          <v-list-item-content v-if="regist.third_place_order == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.third_place_order }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>備考</v-list-item-content>
-                          <v-list-item-content v-if="regist.place_order == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.place_order.remark }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-              </v-tab-item>
-
-              <!-- 電力申請情報 -->
-              <v-tab-item>
-                <v-row
-                  v-for="(power_order, i) in regist.power_orders"
-                  :key="i"
-                  >
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-power-plug</v-icon><b>製品 {{ i+1 }}</b>
-                        <v-spacer></v-spacer>
-                        <v-btn 
-                          v-if="isEditPowerOrder" 
-                          text 
-                          fab 
-                          @click="openPowerDisplay(power_order.id, power_order.group_id, power_order.item, power_order.power, power_order.manufacturer, power_order.model, power_order.item_url)">
-                          <v-icon>mdi-pencil</v-icon></v-btn>
-                      </v-card-title>
-                      <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>製品名</v-list-item-content>
-                          <v-list-item-content v-if="power_order.item == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ power_order.item }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>電力量</v-list-item-content>
-                          <v-list-item-content v-if="power_order.power == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ power_order.power }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>メーカー</v-list-item-content>
-                          <v-list-item-content v-if="power_order.manufacturer == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ power_order.manufacturer }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>型番</v-list-item-content>
-                          <v-list-item-content v-if="power_order.model == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ power_order.model }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>URL</v-list-item-content>
-                          <v-list-item-content v-if="power_order.item_url == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ power_order.item_url }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-                <v-row>
-                  <v-col cols="10"></v-col>
-                  <v-col cols="1">
-                  <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs }">
-                    <v-btn
-                      fab
-                      dark
-                      v-bind="attrs"
-                      v-on="on"
-                      color="purple accent-2"
-                      elevation="0"
-                      @click="openAddpowerDisplay()">
-                      <v-icon>mdi-plus</v-icon>
-                    </v-btn>
-                  </template>
-                  <span>電力申請を追加する</span>
-                  </v-tooltip>
-                  </v-col>
-                  <v-col cols="1"></v-col>
-                </v-row>
-                <!--EditModal-->
-                <Power ref="powerDlg"
-                       :id="this.power_order_id"
-                       :groupId="this.group_id"
-                       :item="this.item"
-                       :power="this.power"
-                       :manufacturer="this.manufacturer"
-                       :model="this.model"
-                       :url="this.url"
-                       @reload="reload"
-                       @openPowerSnackbar="openPowerSnackbar"
-                       ></Power>
-                <!--AddModal-->
-                <Addpower ref="addpowerDlg"
-                          :groupId="this.regist.group.id"
-                          @reload="reload"
-                          @openAddpowerSnackbar="openAddpowerSnackbar"           
-                          ></Addpower>
-                <v-snackbar
-                  top
-                  text
-                  color="purple accent-2"
-                  v-model="powerSnackbar"
-                  >
-                  電力申請情報を更新しました
-                </v-snackbar>
-                <v-snackbar
-                  top
-                  text
-                  color="purple accent-2"
-                  v-model="addpowerSnackbar"
-                  >
-                  電力申請情報を追加しました
-                </v-snackbar>
-              </v-tab-item>
-
-              <!-- 物品申請情報 -->
-              <v-tab-item>
-                <v-row
-                    v-for="(rental_order, i) in regist.rental_orders"
-                    :key="i"
-                  >
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-table-chair</v-icon>
-                        <b>物品申請情報{{ i+1 }}</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditRentalOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                      </v-card-title>
-                      <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>物品名</v-list-item-content>
-                          <v-list-item-content v-if="rental_order.name == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ rental_order.name }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>数量</v-list-item-content>
-                          <v-list-item-content v-if="rental_order.num == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ rental_order.num }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-                <!-- 情報追加のためのボタン -->
-               <v-container>
-                  <v-row>
-                    <v-col cols="10"></v-col>
-                    <v-col cols="1">
-                      <v-tooltip top>
-                        <template v-slot:activator="{ on, attrs }">
-                          <v-btn
-                            fab 
-                            elevation="0" 
-                            v-bind="attrs" 
-                            v-on="on" 
-                            dark 
-                            color="purple accent-2" 
-                            @click="openAddRentalOrderDisplay"
-                            >
-                            <v-icon>mdi-plus</v-icon>
-                          </v-btn>
-                        </template>
-                        <span>物品申請を追加する</span>
-                      </v-tooltip>
-                    </v-col>
-                    <v-col cols="1"></v-col>
-                  </v-row>
-                </v-container>
-                <!-- モーダルウィンドウコンポーネントを呼び出す -->
-                <AddRentalOrder ref="AddRentalOrderDlg"
-                    :groupId="this.regist.group.id"
-                    @reload="reload"
-                    @openRentalOrderSnackbar="openRentalOrderSnackbar">
-                </AddRentalOrder>
-                <!-- 情報を更新した場合スナックバーを表示する -->
-                <v-snackbar
-                  top
-                  text
-                  color="purple accent-2"
-                  v-model="rentalOrderSnackbar"
-                  >
-                  物品申請情報を更新しました
-                </v-snackbar>
-                <v-snackbar
-                  top
-                  text
-                  color="purple accent-2"
-                  v-model="addRentalOrderSnackbar"
-                  >
-                  物品申請情報を更新しました
-                </v-snackbar>
-              </v-tab-item>
-
-              <!-- ステージ利用申請情報 -->
-              <v-tab-item>
-                <v-row>
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-microphone-variant</v-icon>
-                        <b>ステージ利用申請情報</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditStageOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                      </v-card-title>
-                      <hr>
-                       <v-list>
-                        <v-list-item>
-                          <v-list-item-content>月日</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_date == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_date }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>第1希望</v-list-item-content>
-                          <v-list-item-content v-if="regist.first_stage_order == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.first_stage_order }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>第2希望</v-list-item-content>
-                          <v-list-item-content v-if="regist.second_stage_order == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.second_stage_order }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>準備時間幅</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.prepare_time_interval == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.prepare_time_interval }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>使用時間幅</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.use_time_interval == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.use_time_interval }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>掃除時間幅</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.cleanup_time_interval == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.cleanup_time_interval }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>準備開始時刻</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.prepare_start_time == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.prepare_start_time }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>パフォーマンス開始時刻</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.performance_start_time == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.performance_start_time }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>パフォーマンス終了時刻</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.performance_end_time == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.performance_end_time }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>掃除終了時刻</v-list-item-content>
-                          <v-list-item-content v-if="regist.stage_order.cleanup_end_time == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ regist.stage_order.cleanup_end_time }}</v-list-item-content>
-                        </v-list-item>
-                       </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-              </v-tab-item>
-
-              <!-- 従業員情報 -->
-              <v-tab-item>
-                <v-row
-                  v-for="(employee, i) in regist.employees"
-                  :key="i"
-                  >
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-account</v-icon>
-                        <b>従業員 {{ i+1 }}</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditEmployee" text fab @click="openEmployeeDisplay(employee.id, employee.group_id, employee.name, employee.student_id)"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                      </v-card-title>
-                      <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>名前</v-list-item-content>
-                          <v-list-item-content v-if="employee.name == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ employee.name }}</v-list-item-content>
-                        </v-list-item>
-                      <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>学籍番号</v-list-item-content>
-                          <v-list-item-content v-if="employee.student_id == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ employee.student_id }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-                <!-- 情報追加のためのボタン -->
-                <v-container>
-                  <v-row>
-                    <v-col cols="10"></v-col>
-                    <v-col cols="1">
-                      <v-tooltip top>
-                        <template v-slot:activator="{ on, attrs }">
-                          <v-btn
-                            fab 
-                            elevation="0" 
-                            v-bind="attrs" 
-                            v-on="on" 
-                            dark 
-                            color="purple accent-2" 
-                            @click="openAddRentalOrderDisplay"
-                            >
-                            <v-icon>mdi-plus</v-icon>
-                          </v-btn>
-                        </template>
-                        <span>物品申請を追加する</span>
-                      </v-tooltip>
-                    </v-col>
-                    <v-col cols="1"></v-col>
-                  </v-row>
-                </v-container>
-                <!-- モーダルウィンドウコンポーネントを呼び出す -->
-                <AddRentalOrder ref="AddRentalOrderDlg"
-                    :groupId="this.regist.group.id"
-                    @reload="reload"
-                    @openRentalOrderSnackbar="openRentalOrderSnackbar">
-                </AddRentalOrder>
-                <!-- 情報を更新した場合スナックバーを表示する -->
-                <v-snackbar
-                  top
-                  text
-                  color="purple accent-2"
-                  v-model="rentalOrderSnackbar"
-                  >
-                  物品申請情報を更新しました
-                </v-snackbar>
-
-                      <Employee ref="employeeDlg"
-                        :id="this.employee_id"
-                        :groupId="this.group_id"
-                        :studentId ="this.student_id"
-                        :name="this.name"
+                      <v-btn v-if="isEditGroup" text fab @click="openGroupDisplay"><v-icon>mdi-pencil</v-icon></v-btn>
+                      <Group ref="groupDlg"
+                        :groupId="regist.group.id"
+                        :groupName="regist.group.name"
+                        :projectName="regist.group.project_name"
+                        :groupCategoryId="regist.group.group_category_id"
+                        :activity="regist.group.activity"
                         @reload="reload"
-                        @openEmployeeSnackbar="openEmployeeSnackbar"
-                      ></Employee>
+                        @openGroupSnackbar="openGroupSnackbar"
+                      ></Group>
                       <v-snackbar
                         top
                         text
                         color="purple accent-2"
-                        v-model="employeeSnackbar"
+                        v-model="groupSnackbar"
                         >
-                        従業員情報を更新しました
+                        参加団体情報を更新しました
                       </v-snackbar>
-          </v-tab-item>
-
-              <!-- 販売食品情報 -->
-              <v-tab-item>
-                <v-row
-                  v-for="(food_product, i) in regist.food_products"
-                  :key="i"
-                  >
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-baguette</v-icon>
-                        <b>販売食品情報{{ i+1 }}</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditFoodproduct" text fab @click="openFoodproductDisplay(food_product.id, food_product.group_id, food_product.name, food_product.first_day_num, food_product.second_day_num, food_product.is_cooking)"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                      </v-card-title>
+                    </v-card-title>
                       <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>商品名</v-list-item-content>
-                          <v-list-item-content v-if="food_product.name == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ food_product.name }}</v-list-item-content>
-                        </v-list-item>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>団体名</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.name == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.group.name }}</v-list-item-content>
+                      </v-list-item>
                       <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>1日目の個数</v-list-item-content>
-                          <v-list-item-content v-if="food_product.first_day_num == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ food_product.first_day_num }}</v-list-item-content>
-                        </v-list-item>
+                      <v-list-item>
+                        <v-list-item-content>企画名</v-list-item-content>
+                        <v-list-item-content v-if="regist.group.project_name == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.group.project_name }}</v-list-item-content>
+                      </v-list-item>
                       <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>2日目の個数</v-list-item-content>
-                          <v-list-item-content v-if="food_product.second_day_num == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ food_product.second_day_num }}</v-list-item-content>
-                        </v-list-item>
+                      <v-list-item>
+                        <v-list-item-content>カテゴリー</v-list-item-content>
+                        <v-list-item-content v-if="regist.group_category == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.group_category }}</v-list-item-content>
+                      </v-list-item>
                       <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>調理の有無</v-list-item-content>
-                          <v-list-item-content v-if="food_product.is_cooking == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ food_product.is_cooking }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
-                  </v-col>
-                  <v-col cols=1></v-col>
-                </v-row>
-                <!-- 情報追加のためのボタン -->
-                <v-container>
-                  <v-row>
-                    <v-col cols="10"></v-col>
-                    <v-col cols="1">
-                      <v-tooltip top>
-                        <template v-slot:activator="{ on, attrs }">
-                          <v-btn
-                            fab 
-                            elevation="0" 
-                            v-bind="attrs" 
-                            v-on="on" 
-                            dark 
-                            color="purple accent-2" 
-                            @click="openAddRentalOrderDisplay"
-                            >
-                            <v-icon>mdi-plus</v-icon>
-                          </v-btn>
-                        </template>
-                        <span>物品申請を追加する</span>
-                      </v-tooltip>
-                    </v-col>
-                    <v-col cols="1"></v-col>
-                  </v-row>
-                </v-container>
-                <!-- モーダルウィンドウコンポーネントを呼び出す -->
-                <AddRentalOrder ref="AddRentalOrderDlg"
-                    :groupId="this.regist.group.id"
-                    @reload="reload"
-                    @openRentalOrderSnackbar="openRentalOrderSnackbar">
-                </AddRentalOrder>
-                <!-- 情報を更新した場合スナックバーを表示する -->
-                <v-snackbar
-                  top
-                  text
-                  color="purple accent-2"
-                  v-model="rentalOrderSnackbar"
-                  >
-                  物品申請情報を更新しました
-                </v-snackbar>
+                      <v-list-item>
+                        <v-list-item-content>活動内容</v-list-item-content>
+                        <v-list-item-content v-if="regist.group.activity == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.group.activity }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+            </v-tab-item>
 
-                  <Foodproduct ref="foodproductDlg"
-                    :id = "this.food_product_id"
-                    :groupId = "this.group_id"
-                    :name = "this.name"
-                    :firstN = "this.first_day_num"
-                    :secondN = "this.second_day_num"
-                    :cooking = "this.is_cooking"
-                    @reload="reload"
-                    @openFoodproductSnackbar="openFoodproductSnackbar"
-                  ></Foodproduct>
-                  <v-snackbar
-                    top
-                    text
+            <!--副代表情報 -->
+            <v-tab-item>
+              <v-row>
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title  style="color:#333333;" class="title">
+                    <v-icon class="pr-2" size="30">mdi-account-multiple</v-icon><b>副代表情報</b>
+                    <v-spacer></v-spacer>
+                    <v-btn v-if="isEditSubRep" text fab @click="openSubRepDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                    <SubRep ref="subRepDlg"
+                        :groupId="regist.group.id"
+                        :name="regist.sub_rep.name"
+                        :studentId="regist.sub_rep.student_id"
+                        :gradeId="regist.sub_rep.grade_id"
+                        :departmentId="regist.sub_rep.department_id"
+                        :tel="regist.sub_rep.tel"
+                        :email="regist.sub_rep.email"
+                        @reload="reload"
+                        @openSubrepSnackbar="openSubrepSnackbar">
+                    </SubRep>
+                    <v-snackbar
+                        top
+                        text
+                        color="purple accent-2"
+                        v-model="subrepSnackbar"
+                        >
+                        副代表情報を更新しました
+                      </v-snackbar>
+                    </v-card-title>
+                    <hr>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>氏名</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.name == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.sub_rep.name }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>学籍番号</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.student_id == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.sub_rep.student_id }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>学科</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.department_id == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.sub_rep.department_id }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>学年</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.grade_id == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.sub_rep.grade_id }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>電話番号</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.tel == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.sub_rep.tel }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>メールアドレス</v-list-item-content>
+                        <v-list-item-content v-if="regist.sub_rep.email == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.sub_rep.email }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+            </v-tab-item>
+
+            <!-- 会場申請情報 -->
+            <v-tab-item>
+              <v-row>
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-map-marker</v-icon><b>会場申請情報</b>
+                      <v-spacer></v-spacer>
+                      <v-btn v-if="isEditPlace" text fab @click="openPlaceDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                      <Place ref="placeDlg"
+                        :groupId="regist.group.id"
+                        :firstId="regist.place_order.first"
+                        :secondId="regist.place_order.second"
+                        :thirdId="regist.place_order.third"
+                        :remark="regist.place_order.remark"
+                        @reload="reload"
+                        @openPlaceSnackbar="openPlaceSnackbar"
+                        ></Place>
+                        <v-snackbar
+                        top
+                        text
+                        color="purple accent-2"
+                        v-model="placeSnackbar"
+                        >
+                        会場申請情報を更新しました
+                      </v-snackbar>
+                    </v-card-title>
+                    <hr>
+                    <v-card-text v-if = "regist.first_place_order == -9999">未登録</v-card-text>
+                    <v-list v-else>
+                      <v-list-item>
+                        <v-list-item-content>第1志望</v-list-item-content>
+                        <v-list-item-content v-if="regist.first_place_order == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.first_place_order }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>第2志望</v-list-item-content>
+                        <v-list-item-content v-if="regist.second_place_order == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.second_place_order }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>第3志望</v-list-item-content>
+                        <v-list-item-content v-if="regist.third_place_order == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.third_place_order }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>備考</v-list-item-content>
+                        <v-list-item-content v-if="regist.place_order == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.place_order.remark }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+            </v-tab-item>
+
+            <!-- 電力申請情報 -->
+            <v-tab-item>
+              <v-row
+                v-for="(power_order, i) in regist.power_orders"
+                :key="i"
+                >
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-power-plug</v-icon><b>製品 {{ i+1 }}</b>
+                      <v-spacer></v-spacer>
+                      <v-btn 
+                        v-if="isEditPowerOrder" 
+                        text 
+                        fab 
+                        @click="openPowerDisplay(power_order.id, power_order.group_id, power_order.item, power_order.power, power_order.manufacturer, power_order.model, power_order.item_url)">
+                        <v-icon>mdi-pencil</v-icon></v-btn>
+                    </v-card-title>
+                    <hr>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>製品名</v-list-item-content>
+                        <v-list-item-content v-if="power_order.item == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ power_order.item }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>電力量</v-list-item-content>
+                        <v-list-item-content v-if="power_order.power == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ power_order.power }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>メーカー</v-list-item-content>
+                        <v-list-item-content v-if="power_order.manufacturer == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ power_order.manufacturer }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>型番</v-list-item-content>
+                        <v-list-item-content v-if="power_order.model == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ power_order.model }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>URL</v-list-item-content>
+                        <v-list-item-content v-if="power_order.item_url == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ power_order.item_url }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+              <v-row>
+                <v-col cols="10"></v-col>
+                <v-col cols="1">
+                <v-tooltip top>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-btn
+                    fab
+                    dark
+                    v-bind="attrs"
+                    v-on="on"
                     color="purple accent-2"
-                    v-model="foodproductSnackbar"
-                    >
-                    販売食品情報を更新しました
-                  </v-snackbar>
-              </v-tab-item>
+                    elevation="0"
+                    @click="openAddpowerDisplay()">
+                    <v-icon>mdi-plus</v-icon>
+                  </v-btn>
+                </template>
+                <span>電力申請を追加する</span>
+                </v-tooltip>
+                </v-col>
+                <v-col cols="1"></v-col>
+              </v-row>
+              <!--EditModal-->
+              <Power ref="powerDlg"
+                     :id="this.power_order_id"
+                     :groupId="this.group_id"
+                     :item="this.item"
+                     :power="this.power"
+                     :manufacturer="this.manufacturer"
+                     :model="this.model"
+                     :url="this.url"
+                     @reload="reload"
+                     @openPowerSnackbar="openPowerSnackbar"
+                     ></Power>
+              <!--AddModal-->
+              <Addpower ref="addpowerDlg"
+                        :groupId="this.regist.group.id"
+                        @reload="reload"
+                        @openAddpowerSnackbar="openAddpowerSnackbar"           
+                        ></Addpower>
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="powerSnackbar"
+                >
+                電力申請情報を更新しました
+              </v-snackbar>
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="addpowerSnackbar"
+                >
+                電力申請情報を追加しました
+              </v-snackbar>
+            </v-tab-item>
 
-              <!-- 購入品情報 -->
-              <v-tab-item>
-                <v-row
-                  v-for="(purchase_list, i) in regist.purchase_lists"
+            <!-- 物品申請情報 -->
+            <v-tab-item>
+              <v-row
+                  v-for="(rental_order, i) in regist.rental_orders"
                   :key="i"
-                  >
-                  <v-col cols=1></v-col>
-                  <v-col>
-                    <v-card flat>
-                      <v-card-title style="color:#333333;" class="title">
-                        <v-icon class="pr-2" size="30">mdi-cart</v-icon>
-                        <b>購入品情報{{ i+1 }}</b>
-                        <v-spacer></v-spacer>
-                        <v-btn v-if="isEditPurchaseList" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
-                      </v-card-title>
-                      <hr>
-                      <v-list>
-                        <v-list-item>
-                          <v-list-item-content>購入品名</v-list-item-content>
-                          <v-list-item-content v-if="purchase_list.item == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ purchase_list.item }}</v-list-item-content>
-                          </v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>使用目的製品</v-list-item-content>
-                          <v-list-item-content v-if="purchase_list.food_product == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ purchase_list.food_product }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>生鮮食品の有無</v-list-item-content>
-                          <v-list-item-content v-if="purchase_list.is_fresh == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ purchase_list.is_fresh }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>購入店舗</v-list-item-content>
-                          <v-list-item-content v-if="purchase_list.shop == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ purchase_list.shop }}</v-list-item-content>
-                        </v-list-item>
-                        <v-divider></v-divider>
-                        <v-list-item>
-                          <v-list-item-content>使用日</v-list-item-content>
-                          <v-list-item-content v-if="purchase_list.fes_date == -9999">未登録</v-list-item-content>
-                          <v-list-item-content v-else>{{ purchase_list.fes_date }}</v-list-item-content>
-                        </v-list-item>
-                      </v-list>
-                    </v-card>
+                >
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-table-chair</v-icon>
+                      <b>物品申請情報{{ i+1 }}</b>
+                      <v-spacer></v-spacer>
+                      <v-btn v-if="isEditRentalOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                    </v-card-title>
+                    <hr>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>物品名</v-list-item-content>
+                        <v-list-item-content v-if="rental_order.name == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ rental_order.name }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>数量</v-list-item-content>
+                        <v-list-item-content v-if="rental_order.num == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ rental_order.num }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+              <!-- 情報追加のためのボタン -->
+             <v-container>
+                <v-row>
+                  <v-col cols="10"></v-col>
+                  <v-col cols="1">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <v-btn
+                          fab 
+                          elevation="0" 
+                          v-bind="attrs" 
+                          v-on="on" 
+                          dark 
+                          color="purple accent-2" 
+                          @click="openAddRentalOrderDisplay"
+                          >
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>物品申請を追加する</span>
+                    </v-tooltip>
                   </v-col>
-                  <v-col cols=1></v-col>
+                  <v-col cols="1"></v-col>
                 </v-row>
-                <!-- 情報追加のためのボタン -->
-                <v-container>
-                  <v-row>
-                    <v-col cols="10"></v-col>
-                    <v-col cols="1">
-                      <v-tooltip top>
-                        <template v-slot:activator="{ on, attrs }">
-                          <v-btn
-                            fab 
-                            elevation="0" 
-                            v-bind="attrs" 
-                            v-on="on" 
-                            dark 
-                            color="purple accent-2" 
-                            @click="openAddPurchaseListDisplay"
-                            >
-                            <v-icon>mdi-plus</v-icon>
-                          </v-btn>
-                        </template>
-                        <span>購入品を追加する</span>
-                      </v-tooltip>
-                    </v-col>
-                    <v-col cols="1"></v-col>
-                  </v-row>
-                </v-container>
-                <!-- モーダルウィンドウコンポーネントを呼び出す -->
-                <AddPurchaseList ref="AddPurchaseListDlg"
-                    :groupId="this.regist.group.id"
-                    @reload="reload"
-                    @openPurchaseListSnackbar="openPurchaseListSnackbar">
-                </AddPurchaseList>
-                <!-- 情報を更新した場合スナックバーを表示する -->
+              </v-container>
+              <!-- モーダルウィンドウコンポーネントを呼び出す -->
+              <AddRentalOrder ref="AddRentalOrderDlg"
+                  :groupId="this.regist.group.id"
+                  @reload="reload"
+                  @openRentalOrderSnackbar="openRentalOrderSnackbar">
+              </AddRentalOrder>
+              <!-- 情報を更新した場合スナックバーを表示する -->
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="rentalOrderSnackbar"
+                >
+                物品申請情報を更新しました
+              </v-snackbar>
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="addRentalOrderSnackbar"
+                >
+                物品申請情報を更新しました
+              </v-snackbar>
+            </v-tab-item>
+
+            <!-- ステージ利用申請情報 -->
+            <v-tab-item>
+              <v-row>
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-microphone-variant</v-icon>
+                      <b>ステージ利用申請情報</b>
+                      <v-spacer></v-spacer>
+                      <v-btn v-if="isEditStageOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                    </v-card-title>
+                    <hr>
+                     <v-list>
+                      <v-list-item>
+                        <v-list-item-content>月日</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_date == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_date }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>第1希望</v-list-item-content>
+                        <v-list-item-content v-if="regist.first_stage_order == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.first_stage_order }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>第2希望</v-list-item-content>
+                        <v-list-item-content v-if="regist.second_stage_order == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.second_stage_order }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>準備時間幅</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.prepare_time_interval == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.prepare_time_interval }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>使用時間幅</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.use_time_interval == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.use_time_interval }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>掃除時間幅</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.cleanup_time_interval == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.cleanup_time_interval }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>準備開始時刻</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.prepare_start_time == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.prepare_start_time }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>パフォーマンス開始時刻</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.performance_start_time == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.performance_start_time }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>パフォーマンス終了時刻</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.performance_end_time == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.performance_end_time }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>掃除終了時刻</v-list-item-content>
+                        <v-list-item-content v-if="regist.stage_order.cleanup_end_time == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ regist.stage_order.cleanup_end_time }}</v-list-item-content>
+                      </v-list-item>
+                     </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+            </v-tab-item>
+
+            <!-- 従業員情報 -->
+            <v-tab-item>
+              <v-row
+                v-for="(employee, i) in regist.employees"
+                :key="i"
+                >
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-account</v-icon>
+                      <b>従業員 {{ i+1 }}</b>
+                      <v-spacer></v-spacer>
+                      <v-btn v-if="isEditEmployee" text fab @click="openEmployeeDisplay(employee.id, employee.group_id, employee.name, employee.student_id)"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                    </v-card-title>
+                    <hr>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>名前</v-list-item-content>
+                        <v-list-item-content v-if="employee.name == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ employee.name }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>学籍番号</v-list-item-content>
+                        <v-list-item-content v-if="employee.student_id == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ employee.student_id }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+              <!-- 情報追加のためのボタン -->
+              <v-container>
+                <v-row>
+                  <v-col cols="10"></v-col>
+                  <v-col cols="1">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <v-btn
+                          fab 
+                          elevation="0" 
+                          v-bind="attrs" 
+                          v-on="on" 
+                          dark 
+                          color="purple accent-2" 
+                          @click="openAddRentalOrderDisplay"
+                          >
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>物品申請を追加する</span>
+                    </v-tooltip>
+                  </v-col>
+                  <v-col cols="1"></v-col>
+                </v-row>
+              </v-container>
+              <!-- モーダルウィンドウコンポーネントを呼び出す -->
+              <AddRentalOrder ref="AddRentalOrderDlg"
+                  :groupId="this.regist.group.id"
+                  @reload="reload"
+                  @openRentalOrderSnackbar="openRentalOrderSnackbar">
+              </AddRentalOrder>
+              <!-- 情報を更新した場合スナックバーを表示する -->
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="rentalOrderSnackbar"
+                >
+                物品申請情報を更新しました
+              </v-snackbar>
+
+                    <Employee ref="employeeDlg"
+                      :id="this.employee_id"
+                      :groupId="this.group_id"
+                      :studentId ="this.student_id"
+                      :name="this.name"
+                      @reload="reload"
+                      @openEmployeeSnackbar="openEmployeeSnackbar"
+                    ></Employee>
+                    <v-snackbar
+                      top
+                      text
+                      color="purple accent-2"
+                      v-model="employeeSnackbar"
+                      >
+                      従業員情報を更新しました
+                    </v-snackbar>
+        </v-tab-item>
+
+            <!-- 販売食品情報 -->
+            <v-tab-item>
+              <v-row
+                v-for="(food_product, i) in regist.food_products"
+                :key="i"
+                >
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-baguette</v-icon>
+                      <b>販売食品情報{{ i+1 }}</b>
+                      <v-spacer></v-spacer>
+                      <v-btn v-if="isEditFoodproduct" text fab @click="openFoodproductDisplay(food_product.id, food_product.group_id, food_product.name, food_product.first_day_num, food_product.second_day_num, food_product.is_cooking)"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                    </v-card-title>
+                    <hr>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>商品名</v-list-item-content>
+                        <v-list-item-content v-if="food_product.name == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ food_product.name }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>1日目の個数</v-list-item-content>
+                        <v-list-item-content v-if="food_product.first_day_num == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ food_product.first_day_num }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>2日目の個数</v-list-item-content>
+                        <v-list-item-content v-if="food_product.second_day_num == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ food_product.second_day_num }}</v-list-item-content>
+                      </v-list-item>
+                    <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>調理の有無</v-list-item-content>
+                        <v-list-item-content v-if="food_product.is_cooking == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ food_product.is_cooking }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+              <!-- 情報追加のためのボタン -->
+              <v-container>
+                <v-row>
+                  <v-col cols="10"></v-col>
+                  <v-col cols="1">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <v-btn
+                          fab 
+                          elevation="0" 
+                          v-bind="attrs" 
+                          v-on="on" 
+                          dark 
+                          color="purple accent-2" 
+                          @click="openAddRentalOrderDisplay"
+                          >
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>物品申請を追加する</span>
+                    </v-tooltip>
+                  </v-col>
+                  <v-col cols="1"></v-col>
+                </v-row>
+              </v-container>
+              <!-- モーダルウィンドウコンポーネントを呼び出す -->
+              <AddRentalOrder ref="AddRentalOrderDlg"
+                  :groupId="this.regist.group.id"
+                  @reload="reload"
+                  @openRentalOrderSnackbar="openRentalOrderSnackbar">
+              </AddRentalOrder>
+              <!-- 情報を更新した場合スナックバーを表示する -->
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="rentalOrderSnackbar"
+                >
+                物品申請情報を更新しました
+              </v-snackbar>
+
+                <Foodproduct ref="foodproductDlg"
+                  :id = "this.food_product_id"
+                  :groupId = "this.group_id"
+                  :name = "this.name"
+                  :firstN = "this.first_day_num"
+                  :secondN = "this.second_day_num"
+                  :cooking = "this.is_cooking"
+                  @reload="reload"
+                  @openFoodproductSnackbar="openFoodproductSnackbar"
+                ></Foodproduct>
                 <v-snackbar
                   top
                   text
                   color="purple accent-2"
-                  v-model="PurchaseListSnackbar"
+                  v-model="foodproductSnackbar"
                   >
-                  購入品情報を更新しました
+                  販売食品情報を更新しました
                 </v-snackbar>
-              </v-tab-item>
-            </v-tabs>
-          </v-col>
-        </v-row>
-      </v-card>
+            </v-tab-item>
+
+            <!-- 購入品情報 -->
+            <v-tab-item>
+              <v-row
+                v-for="(purchase_list, i) in regist.purchase_lists"
+                :key="i"
+                >
+                <v-col cols=1></v-col>
+                <v-col>
+                  <v-card flat>
+                    <v-card-title style="color:#333333;" class="title">
+                      <v-icon class="pr-2" size="30">mdi-cart</v-icon>
+                      <b>購入品情報{{ i+1 }}</b>
+                      <v-spacer></v-spacer>
+                      <v-btn v-if="isEditPurchaseList" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                    </v-card-title>
+                    <hr>
+                    <v-list>
+                      <v-list-item>
+                        <v-list-item-content>購入品名</v-list-item-content>
+                        <v-list-item-content v-if="purchase_list.item == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ purchase_list.item }}</v-list-item-content>
+                        </v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>使用目的製品</v-list-item-content>
+                        <v-list-item-content v-if="purchase_list.food_product == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ purchase_list.food_product }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>生鮮食品の有無</v-list-item-content>
+                        <v-list-item-content v-if="purchase_list.is_fresh == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ purchase_list.is_fresh }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>購入店舗</v-list-item-content>
+                        <v-list-item-content v-if="purchase_list.shop == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ purchase_list.shop }}</v-list-item-content>
+                      </v-list-item>
+                      <v-divider></v-divider>
+                      <v-list-item>
+                        <v-list-item-content>使用日</v-list-item-content>
+                        <v-list-item-content v-if="purchase_list.fes_date == -9999">未登録</v-list-item-content>
+                        <v-list-item-content v-else>{{ purchase_list.fes_date }}</v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-col>
+                <v-col cols=1></v-col>
+              </v-row>
+              <!-- 情報追加のためのボタン -->
+              <v-container>
+                <v-row>
+                  <v-col cols="10"></v-col>
+                  <v-col cols="1">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs }">
+                        <v-btn
+                          fab 
+                          elevation="0" 
+                          v-bind="attrs" 
+                          v-on="on" 
+                          dark 
+                          color="purple accent-2" 
+                          @click="openAddPurchaseListDisplay"
+                          >
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>購入品を追加する</span>
+                    </v-tooltip>
+                  </v-col>
+                  <v-col cols="1"></v-col>
+                </v-row>
+              </v-container>
+              <!-- モーダルウィンドウコンポーネントを呼び出す -->
+              <AddPurchaseList ref="AddPurchaseListDlg"
+                  :groupId="this.regist.group.id"
+                  @reload="reload"
+                  @openPurchaseListSnackbar="openPurchaseListSnackbar">
+              </AddPurchaseList>
+              <!-- 情報を更新した場合スナックバーを表示する -->
+              <v-snackbar
+                top
+                text
+                color="purple accent-2"
+                v-model="PurchaseListSnackbar"
+                >
+                購入品情報を更新しました
+              </v-snackbar>
+            </v-tab-item>
+          </v-tabs>
+        </v-col>
+      </v-row>
+    </v-card>
   </div>
 </template>
 

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -673,7 +673,8 @@
                       <v-list-item>
                         <v-list-item-content>調理の有無</v-list-item-content>
                         <v-list-item-content v-if="food_product.is_cooking == -9999">未登録</v-list-item-content>
-                        <v-list-item-content v-else>{{ food_product.is_cooking }}</v-list-item-content>
+                        <v-list-item-content v-else-if="food_product.is_cooking === true">調理する</v-list-item-content>
+                        <v-list-item-content v-else>調理しない</v-list-item-content>
                       </v-list-item>
                     </v-list>
                   </v-card>
@@ -694,32 +695,32 @@
                           v-on="on" 
                           dark 
                           color="purple accent-2" 
-                          @click="openAddRentalOrderDisplay"
+                          @click="openAddFoodProductDisplay"
                           >
                           <v-icon>mdi-plus</v-icon>
                         </v-btn>
                       </template>
-                      <span>物品申請を追加する</span>
+                      <span>販売食品情報申請を追加する</span>
                     </v-tooltip>
                   </v-col>
                   <v-col cols="1"></v-col>
                 </v-row>
               </v-container>
               <!-- モーダルウィンドウコンポーネントを呼び出す -->
-              <AddRentalOrder ref="AddRentalOrderDlg"
+              <AddFoodProduct ref="AddFoodProductDlg"
                   :groupId="this.regist.group.id"
                   @reload="reload"
-                  @openRentalOrderSnackbar="openRentalOrderSnackbar">
-              </AddRentalOrder>
-              <!-- 情報を更新した場合スナックバーを表示する -->
+              >
+              </AddFoodProduct>
+              <!-- 情報を更新した場合スナックバーを表示する
               <v-snackbar
                 top
                 text
                 color="purple accent-2"
-                v-model="rentalOrderSnackbar"
+                v-model="foodPSnackbar"
                 >
                 物品申請情報を更新しました
-              </v-snackbar>
+              </v-snackbar> -->
 
                 <Foodproduct ref="foodproductDlg"
                   :id = "this.food_product_id"
@@ -866,6 +867,7 @@
       Place,
       Employee,
       Foodproduct,
+      AddFoodProduct,
       Addpower,
       AddRentalOrder,
       AddPurchaseList
@@ -1021,6 +1023,10 @@
         this.second_day_num = second_day_num
         this.is_cooking = is_cooking
         this.$refs.foodproductDlg.isDisplay = true
+      },
+      openAddFoodProductDisplay() {
+        this.$refs.AddFoodProductDlg.isDisplay = true
+        console.log(this.$refs.AddFoodProductDlg.isDisplay)
       },
       openAddpowerDisplay() {
         this.$refs.addpowerDlg.isDisplay = true

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -1,13 +1,10 @@
 <template>
-  <v-row>
-    <v-col cols="2"></v-col>
-    <v-col cols="8"
-      >
+  <div>
       <v-card
         class = "mx-auto"
         outlined
       >
-      <v-card-title style="background-color:#ECEFF1; font-size:30px"><v-icon class="pr-2" size="40">mdi-information</v-icon><b>登録情報</b></v-card-title>
+      <v-card-title style="background-color:#ECEFF1;" class="title"><v-icon class="pr-2" size="30">mdi-information</v-icon><b>登録情報</b></v-card-title>
         <v-divider class="mx-4"></v-divider>
         <v-row>
           <v-col>
@@ -82,7 +79,7 @@
                     <v-card
                       flat
                       >
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-account-group</v-icon><b>団体情報</b>
                         <v-spacer></v-spacer>
                         <v-btn v-if="isEditGroup" text fab @click="openGroupDisplay"><v-icon>mdi-pencil</v-icon></v-btn>
@@ -142,7 +139,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title  style="color:#333333; font-size:25px">
+                      <v-card-title  style="color:#333333;" class="title">
                       <v-icon class="pr-2" size="30">mdi-account-multiple</v-icon><b>副代表情報</b>
                       <v-spacer></v-spacer>
                       <v-btn v-if="isEditSubRep" text fab @click="openSubRepDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
@@ -216,7 +213,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-map-marker</v-icon><b>会場申請情報</b>
                         <v-spacer></v-spacer>
                         <v-btn v-if="isEditPlace" text fab @click="openPlaceDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
@@ -280,10 +277,15 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-power-plug</v-icon><b>製品 {{ i+1 }}</b>
                         <v-spacer></v-spacer>
-                        <v-btn v-if="isEditPowerOrder" text fab @click="openPowerDisplay(power_order.id, power_order.group_id, power_order.item, power_order.power, power_order.manufacturer, power_order.model, power_order.item_url)"><v-icon>mdi-pencil</v-icon></v-btn>
+                        <v-btn 
+                          v-if="isEditPowerOrder" 
+                          text 
+                          fab 
+                          @click="openPowerDisplay(power_order.id, power_order.group_id, power_order.item, power_order.power, power_order.manufacturer, power_order.model, power_order.item_url)">
+                          <v-icon>mdi-pencil</v-icon></v-btn>
                       </v-card-title>
                       <hr>
                       <v-list>
@@ -325,7 +327,7 @@
                   <v-col cols="10"></v-col>
                   <v-col cols="1">
                   <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
+                  <template v-slot:activator="{ on, attrs }">
                     <v-btn
                       fab
                       dark
@@ -337,8 +339,8 @@
                       <v-icon>mdi-plus</v-icon>
                     </v-btn>
                   </template>
-            <span>電力申請を追加する</span>
-          </v-tooltip>
+                  <span>電力申請を追加する</span>
+                  </v-tooltip>
                   </v-col>
                   <v-col cols="1"></v-col>
                 </v-row>
@@ -387,7 +389,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-table-chair</v-icon>
                         <b>物品申請情報{{ i+1 }}</b>
                         <v-spacer></v-spacer>
@@ -411,41 +413,54 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
-                  <AddRentalOrder ref="AddRentalOrderDlg"
-                      :groupId="this.regist.group.id"
-                      @reload="reload"
-                      @openRentalOrderSnackbar="openRentalOrderSnackbar">
-                  </AddRentalOrder>
-                  <v-snackbar
-                      top
-                      text
-                      color="purple accent-2"
-                      v-model="rentalOrderSnackbar"
-                      >
-                      物品申請情報を更新しました
-                    </v-snackbar>
-                  <v-snackbar
-                      top
-                      text
-                      color="purple accent-2"
-                      v-model="addRentalOrderSnackbar"
-                      >
-                      物品申請情報を更新しました
-                    </v-snackbar>
-                <v-container>
+                <!-- 情報追加のためのボタン -->
+               <v-container>
                   <v-row>
                     <v-col cols="10"></v-col>
                     <v-col cols="1">
-                  <v-tooltip top>
-                  <template v-slot:activator="{ on, attrs  }">
-                      <v-btn fab elevation="0" v-bind="attrs" v-on="on" dark color="purple accent-2" @click="openAddRentalOrderDisplay"><v-icon>mdi-plus</v-icon></v-btn>
-                  </template>
-            <span>電力申請を追加する</span>
-          </v-tooltip>
+                      <v-tooltip top>
+                        <template v-slot:activator="{ on, attrs }">
+                          <v-btn
+                            fab 
+                            elevation="0" 
+                            v-bind="attrs" 
+                            v-on="on" 
+                            dark 
+                            color="purple accent-2" 
+                            @click="openAddRentalOrderDisplay"
+                            >
+                            <v-icon>mdi-plus</v-icon>
+                          </v-btn>
+                        </template>
+                        <span>物品申請を追加する</span>
+                      </v-tooltip>
                     </v-col>
                     <v-col cols="1"></v-col>
                   </v-row>
                 </v-container>
+                <!-- モーダルウィンドウコンポーネントを呼び出す -->
+                <AddRentalOrder ref="AddRentalOrderDlg"
+                    :groupId="this.regist.group.id"
+                    @reload="reload"
+                    @openRentalOrderSnackbar="openRentalOrderSnackbar">
+                </AddRentalOrder>
+                <!-- 情報を更新した場合スナックバーを表示する -->
+                <v-snackbar
+                  top
+                  text
+                  color="purple accent-2"
+                  v-model="rentalOrderSnackbar"
+                  >
+                  物品申請情報を更新しました
+                </v-snackbar>
+                <v-snackbar
+                  top
+                  text
+                  color="purple accent-2"
+                  v-model="addRentalOrderSnackbar"
+                  >
+                  物品申請情報を更新しました
+                </v-snackbar>
               </v-tab-item>
 
               <!-- ステージ利用申請情報 -->
@@ -454,7 +469,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-microphone-variant</v-icon>
                         <b>ステージ利用申請情報</b>
                         <v-spacer></v-spacer>
@@ -537,7 +552,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-account</v-icon>
                         <b>従業員 {{ i+1 }}</b>
                         <v-spacer></v-spacer>
@@ -561,6 +576,47 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <!-- 情報追加のためのボタン -->
+                <v-container>
+                  <v-row>
+                    <v-col cols="10"></v-col>
+                    <v-col cols="1">
+                      <v-tooltip top>
+                        <template v-slot:activator="{ on, attrs }">
+                          <v-btn
+                            fab 
+                            elevation="0" 
+                            v-bind="attrs" 
+                            v-on="on" 
+                            dark 
+                            color="purple accent-2" 
+                            @click="openAddRentalOrderDisplay"
+                            >
+                            <v-icon>mdi-plus</v-icon>
+                          </v-btn>
+                        </template>
+                        <span>物品申請を追加する</span>
+                      </v-tooltip>
+                    </v-col>
+                    <v-col cols="1"></v-col>
+                  </v-row>
+                </v-container>
+                <!-- モーダルウィンドウコンポーネントを呼び出す -->
+                <AddRentalOrder ref="AddRentalOrderDlg"
+                    :groupId="this.regist.group.id"
+                    @reload="reload"
+                    @openRentalOrderSnackbar="openRentalOrderSnackbar">
+                </AddRentalOrder>
+                <!-- 情報を更新した場合スナックバーを表示する -->
+                <v-snackbar
+                  top
+                  text
+                  color="purple accent-2"
+                  v-model="rentalOrderSnackbar"
+                  >
+                  物品申請情報を更新しました
+                </v-snackbar>
+
                       <Employee ref="employeeDlg"
                         :id="this.employee_id"
                         :groupId="this.group_id"
@@ -588,7 +644,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-baguette</v-icon>
                         <b>販売食品情報{{ i+1 }}</b>
                         <v-spacer></v-spacer>
@@ -624,6 +680,47 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <!-- 情報追加のためのボタン -->
+                <v-container>
+                  <v-row>
+                    <v-col cols="10"></v-col>
+                    <v-col cols="1">
+                      <v-tooltip top>
+                        <template v-slot:activator="{ on, attrs }">
+                          <v-btn
+                            fab 
+                            elevation="0" 
+                            v-bind="attrs" 
+                            v-on="on" 
+                            dark 
+                            color="purple accent-2" 
+                            @click="openAddRentalOrderDisplay"
+                            >
+                            <v-icon>mdi-plus</v-icon>
+                          </v-btn>
+                        </template>
+                        <span>物品申請を追加する</span>
+                      </v-tooltip>
+                    </v-col>
+                    <v-col cols="1"></v-col>
+                  </v-row>
+                </v-container>
+                <!-- モーダルウィンドウコンポーネントを呼び出す -->
+                <AddRentalOrder ref="AddRentalOrderDlg"
+                    :groupId="this.regist.group.id"
+                    @reload="reload"
+                    @openRentalOrderSnackbar="openRentalOrderSnackbar">
+                </AddRentalOrder>
+                <!-- 情報を更新した場合スナックバーを表示する -->
+                <v-snackbar
+                  top
+                  text
+                  color="purple accent-2"
+                  v-model="rentalOrderSnackbar"
+                  >
+                  物品申請情報を更新しました
+                </v-snackbar>
+
                   <Foodproduct ref="foodproductDlg"
                     :id = "this.food_product_id"
                     :groupId = "this.group_id"
@@ -653,7 +750,7 @@
                   <v-col cols=1></v-col>
                   <v-col>
                     <v-card flat>
-                      <v-card-title style="color:#333333; font-size:25px">
+                      <v-card-title style="color:#333333;" class="title">
                         <v-icon class="pr-2" size="30">mdi-cart</v-icon>
                         <b>購入品情報{{ i+1 }}</b>
                         <v-spacer></v-spacer>
@@ -696,14 +793,52 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <!-- 情報追加のためのボタン -->
+                <v-container>
+                  <v-row>
+                    <v-col cols="10"></v-col>
+                    <v-col cols="1">
+                      <v-tooltip top>
+                        <template v-slot:activator="{ on, attrs }">
+                          <v-btn
+                            fab 
+                            elevation="0" 
+                            v-bind="attrs" 
+                            v-on="on" 
+                            dark 
+                            color="purple accent-2" 
+                            @click="openAddPurchaseListDisplay"
+                            >
+                            <v-icon>mdi-plus</v-icon>
+                          </v-btn>
+                        </template>
+                        <span>購入品を追加する</span>
+                      </v-tooltip>
+                    </v-col>
+                    <v-col cols="1"></v-col>
+                  </v-row>
+                </v-container>
+                <!-- モーダルウィンドウコンポーネントを呼び出す -->
+                <AddPurchaseList ref="AddPurchaseListDlg"
+                    :groupId="this.regist.group.id"
+                    @reload="reload"
+                    @openPurchaseListSnackbar="openPurchaseListSnackbar">
+                </AddPurchaseList>
+                <!-- 情報を更新した場合スナックバーを表示する -->
+                <v-snackbar
+                  top
+                  text
+                  color="purple accent-2"
+                  v-model="PurchaseListSnackbar"
+                  >
+                  購入品情報を更新しました
+                </v-snackbar>
               </v-tab-item>
             </v-tabs>
           </v-col>
         </v-row>
       </v-card>
-    </v-col>
-    <v-col cols="2"></v-col>
-  </v-row>
+  </div>
 </template>
 
 <script>
@@ -716,6 +851,8 @@
   import Foodproduct from '@/components/EditModal/foodproduct.vue'
   import Addpower from '@/components/AddModal/power.vue'
   import AddRentalOrder from '@/components/AddModal/RentalOrder.vue'
+  import AddFoodProduct from '@/components/AddModal/FoodProduct.vue'
+  import AddPurchaseList from '@/components/AddModal/PurchaseList.vue'
 
   export default {
     props: {
@@ -730,7 +867,8 @@
       Employee,
       Foodproduct,
       Addpower,
-      AddRentalOrder
+      AddRentalOrder,
+      AddPurchaseList
     },
     data () {
     return {
@@ -748,8 +886,8 @@
       rentalOrderSnackbar: false,
       employeeSnackbar: false,
       foodproductSnackbar: false,
+      purchaseListSnackbar: false,
       addpowerSnackbar: false,
-      addRentalOrderSnackbar: false,
       isEditGroup: [],
       isEditSubRep: [],
       isEditPlace: [],
@@ -759,7 +897,6 @@
       isEditEmployee: [],
       isEditFoodproduct:[],
       isEditPurchaseList: [],
-      // 物品申請用
       isAddRentalOrder: [],
       num: [],
 
@@ -816,8 +953,6 @@
           this.isEditEmployee = response.data[0].is_edit_employee
           this.isEditFoodproduct = response.data[0].is_edit_food_product
           this.isEditPurchaseList = response.data[0].is_edit_purchase_list
-          this.isAddRentalOrder = response.data[0].is_add_rental_order
-          console.log(response)
         })
     },
     methods: {
@@ -845,9 +980,6 @@
       openAddpowerSnackbar() {
         this.addPowerSnackbar = true
       },
-      openAddRentalOrderSnackbar(){
-        this.addRentalOrderSnackbar = true
-      },
       openGroupDisplay() {
         this.$refs.groupDlg.isDisplay = true
       },
@@ -857,13 +989,11 @@
       openPlaceDisplay() {
         this.$refs.placeDlg.isDisplay = true
       },
-      openAddRentalOrderDisplay(id, group_id, name, num) {
-        this.rental_order_id = id
-        this.group_id = group_id
-        this.name = name
-        this.num = num
+      openPurchaseListSnackbar(){
+        this.addRentalOrderSnackbar = true
+      },
+      openAddRentalOrderDisplay() {
         this.$refs.AddRentalOrderDlg.isDisplay = true
-        console.log(this.$refs.AddRentalOrderDlg.isDisplay)
       },
       openPowerDisplay(id, group_id, item, power, manufacturer, model, url) {
         this.power_order_id = id
@@ -894,6 +1024,13 @@
       },
       openAddpowerDisplay() {
         this.$refs.addpowerDlg.isDisplay = true
+      },
+      openPurchaseListSnackbar(){
+        this.addRentalOrderSnackbar = true
+      },
+      openAddPurchaseListDisplay() {
+        this.$refs.AddPurchaseListDlg.isDisplay = true
+        console.log(this.$refs.AddPurchaseListDlg.isDisplay)
       },
     }
   }

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-row>
-    <v-col cols="2"></v-col>
-    <v-col cols="8"
-      >
+<div>
       <v-card
         class = "mx-auto"
         outlined
@@ -470,7 +467,7 @@
                         <v-icon class="pr-2" size="30">mdi-microphone-variant</v-icon>
                         <b>ステージ利用申請情報</b>
                         <v-spacer></v-spacer>
-                        <v-btn v-if="isEditStageOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                        <v-btn v-if="isEditStageOrder" fab text @click="openStageOrderDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
                       </v-card-title>
                       <hr>
                        <v-list>
@@ -538,6 +535,25 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <!-- Edit Modal -->
+                <StageOrder ref="stageOrderDlg"
+                  :id="this.regist.stage_order.id"
+                  :groupId="this.regist.stage_order.group_id"
+                  :isSunny="this.regist.stage_order.is_sunny"
+                  :fesDataId="this.regist.stage_order.fes_date_id"
+                  :stageFirst="this.regist.stage_order.stage_first"
+                  :stageSecond="this.regist.stage_order.stage_second"
+                  :useTimeInterval="this.regist.stage_order.use_time_interval"
+                  :prepareTimeInterval="this.regist.stage_order.prepare_time_interval"
+                  :cleanupTimeInterval="this.regist.stage_order.cleanup_time_interval"
+                  :prepareStartTime="this.regist.stage_order.prepare_start_time"
+                  :performanceStartTime="this.regist.stage_order.performance_start_time"
+                  :performanceEndTime="this.regist.stage_order.performance_end_time"
+                  :cleanupEndTime="this.regist.stage_order.cleanup_end_time"
+                  @reload="reload"
+                  @openEmployeeSnackbar="openStageOrderSnackbar"
+                />
+
               </v-tab-item>
 
               <!-- 従業員情報 -->
@@ -672,6 +688,34 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <v-row>
+                  <v-col cols="10"></v-col>
+                  <v-col cols="1">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs  }">
+                        <v-btn
+                          fab
+                          dark
+                          v-bind="attrs"
+                          v-on="on"
+                          color="purple accent-2"
+                          elevation="0"
+                          @click="openAddFoodProductDisplay()">
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>販売食品を追加する</span>
+                    </v-tooltip>
+                  </v-col>
+                  <v-col cols="1"></v-col>
+                </v-row>
+
+              <!-- AddModal -->  
+              <AddFoodProduct ref="AddFoodProductDlg"
+                :groupId="this.regist.group.id"
+                @reload="reload"
+              >
+              </AddFoodProduct>
                 <!--EditModal-->
                   <Foodproduct ref="foodproductDlg"
                     :id = "this.food_product_id"
@@ -745,14 +789,38 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <v-row>
+                  <v-col cols="10"></v-col>
+                  <v-col cols="1">
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on, attrs  }">
+                        <v-btn
+                          fab
+                          dark
+                          v-bind="attrs"
+                          v-on="on"
+                          color="purple accent-2"
+                          elevation="0"
+                          @click="openAddPurchaseListDisplay()">
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>購入品を追加する</span>
+                    </v-tooltip>
+                  </v-col>
+                  <v-col cols="1"></v-col>
+                </v-row>
+                <!-- AddModal -->
+                <AddPurchaseList ref="AddPurchaseListDlg"
+                  :groupId="this.regist.group.id"
+                  @reload="reload"
+                />
               </v-tab-item>
             </v-tabs>
           </v-col>
         </v-row>
       </v-card>
-    </v-col>
-    <v-col cols="2"></v-col>
-  </v-row>
+    </div>
 </template>
 
 <script>
@@ -761,12 +829,15 @@
   import SubRep from '@/components/EditModal/sub_rep.vue'
   import Power from '@/components/EditModal/power.vue'
   import Place from '@/components/EditModal/place.vue'
+  import StageOrder from '@/components/EditModal/stage_order.vue'
   import Employee from '@/components/EditModal/employee.vue'
   import Foodproduct from '@/components/EditModal/foodproduct.vue'
   import Rentalorder from '@/components/EditModal/rental_order.vue'
   import Addpower from '@/components/AddModal/power.vue'
   import AddRentalOrder from '@/components/AddModal/RentalOrder.vue'
   import Addemployee from '@/components/AddModal/employee.vue'
+  import AddFoodProduct from '@/components/AddModal/FoodProduct.vue'
+  import AddPurchaseList from '@/components/AddModal/PurchaseList.vue'
 
   export default {
     props: {
@@ -778,12 +849,15 @@
       SubRep,
       Power,
       Place,
+      StageOrder,
       Employee,
       Foodproduct,
       Rentalorder,
       Addpower,
       AddRentalOrder,
-      Addemployee
+      Addemployee,
+      AddFoodProduct,
+      AddPurchaseList,
     },
     data () {
     return {
@@ -804,6 +878,7 @@
       addpowerSnackbar: false,
       addRentalOrderSnackbar: false,
       addEmployeeSnackbar: false,
+      addRentalOrderSnackbar: false,
       isEditGroup: [],
       isEditSubRep: [],
       isEditPlace: [],
@@ -910,8 +985,15 @@
       openAddemployeeSnackbar() {
         this.addemployeeSnackbar = true
       },
+      openAddFoodProductDisplay() {
+        this.$refs.AddFoodProductDlg.isDisplay = true
+        console.log(this.$refs.AddFoodProductDlg.isDisplay)
+      },
       openGroupDisplay() {
         this.$refs.groupDlg.isDisplay = true
+      },
+      openStageOrderDisplay() {
+        this.$refs.stageOrderDlg.isDisplay = true
       },
       openSubRepDisplay() {
         this.$refs.subRepDlg.isDisplay = true
@@ -965,6 +1047,13 @@
         this.rental_item_id = rental_item_id
         this.num = num
         this.$refs.rentalorderDlg.isDisplay = true
+      },
+      openAddPurchaseListDisplay() {
+        this.$refs.AddPurchaseListDlg.isDisplay = true
+        console.log(this.$refs.AddPurchaseListDlg.isDisplay)
+      },
+      openPurchaseListSnackbar(){
+        this.addRentalOrderSnackbar = true
       },
     }
   }

--- a/view/vue-project/src/components/UserInfo.vue
+++ b/view/vue-project/src/components/UserInfo.vue
@@ -1,15 +1,14 @@
 <template>
-  <v-row>
-    <v-col cols="2"></v-col>
-    <v-col cols="8">
-      <v-card
+  <div>
+    <v-card
         class = "mx-auto"
+        height = "700px"
         outlined
       >
-      <v-card-title style="background-color:#ECEFF1; font-size:30px"><v-icon class="pr-2" size="40">mdi-account-circle</v-icon><b>ユーザー情報</b></v-card-title>  
+      <v-card-title style="background-color:#ECEFF1;" class="title"><v-icon class="pr-2" size="30">mdi-account-circle</v-icon><b>ユーザー情報</b></v-card-title>  
       <v-row>
         <v-col>
-          <v-card-text class="font-weight-bold display-1">
+          <v-card-text class="font-weight-bold title">
             {{ user.user.name }} 
           </v-card-text>
           <v-card-text class="font-weight-bold subtitle-1">
@@ -21,10 +20,8 @@
           </v-card-text>
         </v-col>
       </v-row>
-      </v-card>
-    </v-col>
-    <v-col cols="2"></v-col>
-  </v-row>
+    </v-card>
+  </div>
 </template>
 
 <script>

--- a/view/vue-project/src/views/mypage.vue
+++ b/view/vue-project/src/views/mypage.vue
@@ -1,19 +1,30 @@
 <template>
   <div>
-    <DashBoard />
-    <UserInfo />
-    <News />
-    <div v-if="this.regist_info.length === 0">
-      <v-progress-circular
-        indeterminate
-        color="primary"
-        ></v-progress-circular>
-    </div>
-    <div v-else>
-      <div v-for="(regist, i) in regist_info" :key="i">
-        <Regist :num="i" :regist="regist" @reload="reload()" />
-        <div style="text-align:center" v-if="isRegistGroup">
-          <v-container>
+    <v-row>
+      <v-col>
+        <DashBoard />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="2"></v-col>
+      <v-col cols="2">
+        <v-row>
+          <v-col>
+            <UserInfo />
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col cols="6">
+        <v-row>
+          <v-col>
+            <News />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <div v-for="(regist, i) in regist_info" :key="i">
+              <Regist :num="i" :regist="regist" @reload="reload()" />
+              <v-container>
             <v-row>
               <v-col cols="4"></v-col>
               <v-col cols="4">
@@ -31,11 +42,12 @@
               <v-col cols="4"></v-col>
             </v-row>
           </v-container>
-        </div>
-      </div>
-    </div>
-    <br />
-    <div style="text-align:center" v-if="isRegistGroup">
+            </div>
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col cols="2"></v-col>
+    </v-row>
       <v-container>
         <v-row>
           <v-col cols="4"></v-col>
@@ -53,7 +65,6 @@
           <v-col cols="4"></v-col>
         </v-row>
       </v-container>
-    </div>
     <br>
   </div>
 </template>

--- a/view/vue-project/src/views/mypage.vue
+++ b/view/vue-project/src/views/mypage.vue
@@ -1,21 +1,35 @@
 <template>
   <div>
-    <DashBoard />
-    <UserInfo />
-    <News />
-    <div v-if="this.regist_info.length === 0">
-      <v-progress-circular
-        indeterminate
-        color="primary"
-        ></v-progress-circular>
-    </div>
-    <div v-else>
-      <div v-for="(regist, i) in regist_info" :key="i">
-        <Regist :num="i" :regist="regist" @reload="reload()" />
-      </div>
-    </div>
-    <br />
-    <div style="text-align:center" v-if="isRegistGroup">
+    <v-row>
+      <v-col>
+        <DashBoard />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="2"></v-col>
+      <v-col cols="2">
+        <v-row>
+          <v-col>
+            <UserInfo />
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col cols="6">
+        <v-row>
+          <v-col>
+            <News />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <div v-for="(regist, i) in regist_info" :key="i">
+              <Regist :num="i" :regist="regist" @reload="reload()" />
+            </div>
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col cols="2"></v-col>
+    </v-row>
       <v-container>
         <v-row>
           <v-col cols="4"></v-col>
@@ -33,7 +47,6 @@
           <v-col cols="4"></v-col>
         </v-row>
       </v-container>
-    </div>
     <br>
   </div>
 </template>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #369 

# 概要
<!-- 開発内容の概要を記載 -->
ユーザー画面のRegist.vueに設置したボタンからモーダルを呼び出し，販売食品情報を追加できるようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- /view/vue-project/src/components/Regist.vue
- /view/vue-project/src/components/AddModal/FoodProduct.vue
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://user-images.githubusercontent.com/66663224/111253983-7483bf00-8657-11eb-9393-362eea9118d3.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- ユーザー画面での販売食品情報追加
-
-

# 備考
