### PR TITLE
[mod] ユーザページでステージオプション申請一覧を閲覧できるようにした（#398）

### DIFF
--- a/admin_view/nuxt-project/package-lock.json
+++ b/admin_view/nuxt-project/package-lock.json
@@ -1548,6 +1548,14 @@
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
     },
+    "@types/chart.js": {
+      "version": "2.9.31",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.31.tgz",
+      "integrity": "sha512-hzS6phN/kx3jClk3iYqEHNnYIRSi4RZrIGJ8CDLjgatpHoftCezvC44uqB3o3OUm9ftU1m7sHG8+RLyPTlACrA==",
+      "requires": {
+        "moment": "^2.10.2"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
@@ -2925,6 +2933,32 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "chart.js": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
     },
     "check-types": {
       "version": "8.0.3",
@@ -10500,6 +10534,14 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
       "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
+    },
+    "vue-chartjs": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-3.5.1.tgz",
+      "integrity": "sha512-foocQbJ7FtveICxb4EV5QuVpo6d8CmZFmAopBppDIGKY+esJV8IJgwmEW0RexQhxqXaL/E1xNURsgFFYyKzS/g==",
+      "requires": {
+        "@types/chart.js": "^2.7.55"
+      }
     },
     "vue-client-only": {
       "version": "2.0.0",

--- a/admin_view/nuxt-project/package.json
+++ b/admin_view/nuxt-project/package.json
@@ -12,11 +12,13 @@
     "@nuxtjs/auth": "^4.9.1",
     "@nuxtjs/moment": "^1.6.1",
     "axios": "^0.21.1",
+    "chart.js": "^2.9.4",
     "core-js": "^3.6.5",
     "inject": "^1.0.0-beta2",
     "moment": "^2.29.1",
     "nuxt": "^2.14.6",
     "pdfmake": "^0.1.70",
+    "vue-chartjs": "^3.5.1",
     "vue2-timepicker": "^1.1.6"
   },
   "devDependencies": {

--- a/admin_view/nuxt-project/pages/stage_common_options/index.vue
+++ b/admin_view/nuxt-project/pages/stage_common_options/index.vue
@@ -90,6 +90,7 @@
                               label="所持機器の使用"
                               v-model="ownEquipment"
                               :items="items_available"
+                              :menu-props="{ top: true, offsetY: true }"
                               item-text="label"
                               item-value="value"
                               background-color="white"

--- a/api/app/controllers/api/v1/current_user_api_controller.rb
+++ b/api/app/controllers/api/v1/current_user_api_controller.rb
@@ -118,6 +118,22 @@ class Api::V1::CurrentUserApiController < ApplicationController
           cleanup_end_time: "-9999",
         }
       end
+
+      # ステージオプション申請情報を取得
+      if !group.stage_common_option.nil?
+        stage_common_option = group.stage_common_option
+      else
+        stage_common_option = []
+        stage_common_option = {
+          own_equipment: "-9999",
+          bgm: "-9999",
+          camera_permission: "-9999",
+          loud_sound: "-9999",
+          stage_content: "-9999",
+        }
+      end
+
+
       # 電力申請情報を取得
       if !group.power_orders.nil?
         power_orders = group.power_orders
@@ -227,6 +243,7 @@ class Api::V1::CurrentUserApiController < ApplicationController
         first_stage_order: first_stage_order, # 第一希望ステージのIDからステージ名を復号
         second_stage_order: second_stage_order, # 第二希望ステージのIDからステージ名を復号
         stage_date: stage_date, # 日付のIDから日付を復号
+        stage_common_option: stage_common_option,
         power_orders: power_orders,
         rental_orders: rental_orders_list,
         employees: employees,

--- a/api/app/controllers/api/v1/current_user_api_controller.rb
+++ b/api/app/controllers/api/v1/current_user_api_controller.rb
@@ -107,7 +107,6 @@ class Api::V1::CurrentUserApiController < ApplicationController
         first_stage_order = "-9999"
         second_stage_order = "-9999"
         stage_date = "-9999"
-        stage_order = [] 
         stage_order = {
           use_time_interval: "-9999",
           prepare_time_interval: "-9999",

--- a/view/vue-project/src/components/EditModal/StageCommonOption.vue
+++ b/view/vue-project/src/components/EditModal/StageCommonOption.vue
@@ -120,7 +120,7 @@ export default {
       ],
       photoAvailable: [
         { label: "許可", value: true },
-        { label: "禁止", value: false },
+        { label: "許可しない", value: false },
       ],
       loudAble: [
         { label: "出す", value: true },

--- a/view/vue-project/src/components/EditModal/StageCommonOption.vue
+++ b/view/vue-project/src/components/EditModal/StageCommonOption.vue
@@ -1,0 +1,185 @@
+<template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color: #eceff1; font-size: 30px">
+        <v-icon class="pr-3" size="35">mdi-microphone-plus</v-icon
+        ><b>ステージオプション申請情報を修正する</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay = false"
+          ><v-icon>mdi-close</v-icon></v-btn
+        >
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols="2"></v-col>
+          <v-col cols="8">
+            <v-form ref="form">
+              <v-select
+                label="所持機器の使用"
+                ref="ownEquipment"
+                v-model="ownEquipment"
+                :items="this.itemsAvailable"
+                :menu-props="{
+                  top: true,
+                  offsetY: true,
+                }"
+                item-text="label"
+                item-value="value"
+                text
+                outlined
+              ></v-select>
+              <v-select
+                label="音楽"
+                ref="Bgm"
+                v-model="Bgm"
+                :items="this.itemsAvailable"
+                :menu-props="{
+                  top: true,
+                  offsetY: true,
+                }"
+                item-text="label"
+                item-value="value"
+                text
+                outlined
+              ></v-select>
+              <v-select
+                label="撮影許可"
+                ref="cameraPermission"
+                v-model="cameraPermission"
+                :items="this.photoAvailable"
+                :menu-props="{
+                  top: true,
+                  offsetY: true,
+                }"
+                item-text="label"
+                item-value="value"
+                text
+                outlined
+              ></v-select>
+              <v-select
+                label="騒音"
+                ref="loudSound"
+                v-model="loudSound"
+                :items="this.loudAble"
+                :menu-props="{
+                  top: true,
+                  offsetY: true,
+                }"
+                item-text="label"
+                item-value="value"
+                text
+                outlined
+              ></v-select>
+              <v-textarea
+                class="body-1"
+                label="ステージ内容"
+                v-model="stageContent"
+                background-color="white"
+                outlined
+                clearable
+              >
+              </v-textarea>
+            </v-form>
+            <br />
+          </v-col>
+          <v-col cols="2"></v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4"></v-col>
+          <v-col cols="4">
+            <v-btn color="blue darken-1" large block dark @click="edit"
+              >編集する</v-btn
+            >
+          </v-col>
+          <v-col cols="4"></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from "axios";
+export default {
+  props: {
+    id: Number,
+    groupId: Number,
+    ownEquipment: String,
+    Bgm: String,
+    cameraPermission: String,
+    loudSound: String,
+    stageContent: String,
+  },
+  data() {
+    return {
+      isDisplay: false,
+      groups: [],
+      itemsAvailable: [
+        { label: "使用", value: true },
+        { label: "使用しない", value: false },
+      ],
+      photoAvailable: [
+        { label: "許可", value: true },
+        { label: "禁止", value: false },
+      ],
+      loudAble: [
+        { label: "出す", value: true },
+        { label: "出さない", value: false },
+      ],
+    };
+  },
+  computed: {
+    form() {
+      return {};
+    },
+  },
+  methods: {
+    adjustHeight() {
+      const textarea = this.$refs.activity;
+      const resetHeight = new Promise(function (resolve) {
+        resolve((textarea.style.height = "auto"));
+      });
+      resetHeight.then(function () {
+        textarea.style.height = textarea.scrollHeight + "px";
+      });
+    },
+    cancel: function () {
+      this.$refs.form.reset();
+    },
+    edit: function () {
+      if (!this.$refs.form.validate()) return;
+
+      const url =
+        process.env.VUE_APP_URL + "/stage_common_options" + "/" + this.id + "?group_id=" + this.groupId + "&own_equipment=" + this.ownEquipment + "&bgm=" + this.Bgm + "&camera_permission=" + this.cameraPermission + "&loud_sound=" + this.loudSound + "&stage_content=" + this.stageContent;
+      axios.defaults.headers.common["Content-Type"] = "application/json";
+      axios.put(url).then(
+        (response) => {
+          this.isDisplay = false;
+          this.$emit("openEmployeeSnackbar");
+          this.$emit("reload");
+        },
+        (error) => {
+          return error;
+        }
+      );
+    },
+  },
+  mounted() {
+    const groupUrl = process.env.VUE_APP_URL + "/groups";
+    axios
+      .get(groupUrl, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then(
+        (response) => {
+          this.groups = response.data;
+        },
+        (error) => {
+          return error;
+        }
+      );
+  },
+};
+</script>

--- a/view/vue-project/src/components/EditModal/employee.vue
+++ b/view/vue-project/src/components/EditModal/employee.vue
@@ -56,7 +56,6 @@ export default {
   data () {
     return {
       isDisplay: false,
-      groups:[],
       }
     },
     computed: {
@@ -95,20 +94,7 @@ export default {
       )
     },
   },
-    mounted() {
-    const groupUrl = process.env.VUE_APP_URL + '/groups'
-    axios.get(groupUrl, {
-      headers: {
-        "Content-Type": "application/json",
-      }
-    }).then(
-      (response) => {
-        this.groups = response.data
-      },
-      (error) => {
-        return error;
-      }
-    )
+  mounted() {
   },
 }
 </script>

--- a/view/vue-project/src/components/EditModal/stage_order.vue
+++ b/view/vue-project/src/components/EditModal/stage_order.vue
@@ -1,0 +1,208 @@
+<template>
+  <v-dialog v-model="isDisplay" persistent width="1000">
+    <v-card flat>
+      <v-card-title style="background-color:#ECEFF1; font-size:30px">
+        <v-icon class="pr-3" size="35">mdi-account-single</v-icon><b>ステージ利用申請を修正する</b>
+        <v-spacer></v-spacer>
+        <v-btn text fab @click="isDisplay=false"><v-icon>mdi-close</v-icon></v-btn>
+      </v-card-title>
+      <v-container>
+        <v-row>
+          <v-col cols=2></v-col>
+          <v-col cols=8>
+            <v-form ref="form">
+              <v-select
+                label="天気"
+                v-model="isSunny"
+                :items="is_sunny_list"
+                item-text="label"
+                item-value="value"
+                text
+                outlined
+                clearable
+                />
+                <v-select
+                  label="第一希望"
+                  v-model="stageFirst"
+                  :items="stages_list"
+                  item-text="name"
+                  item-value="id"
+                  text
+                  outlined
+                  clearable
+                  />
+                  <v-select
+                    label="第二希望"
+                    v-model="stageSecond"
+                    :items="stages_list"
+                    item-text="name"
+                    item-value="id"
+                    text
+                    outlined
+                    clearable
+                    />
+                    <v-radio-group v-model="radioGroup">
+                      <v-radio
+                        label="時間幅で修正"
+                        :value="1"
+                        ></v-radio>
+                      <v-radio
+                        label="時刻で修正"
+                        :value="2"
+                        ></v-radio>
+                    </v-radio-group>
+                    <div v-if="radioGroup === 1">
+                      <v-select
+                        label="使用時間"
+                        v-model="useTimeInterval"
+                        :items="time_interval"
+                        text
+                        outlined
+                        clearable
+                        />
+                        <v-select
+                          label="準備時間"
+                          v-model="prepareTimeInterval"
+                          :items="time_interval"
+                          text
+                          outlined
+                          clearable
+                          />
+                          <v-select
+                            label="掃除時間"
+                              v-model="cleanupTimeInterval"
+                            :items="time_interval"
+                            text
+                            outlined
+                            clearable
+                            />
+                    </div>
+
+                    <div v-if="radioGroup === 2">
+                      <v-select
+                        label="準備開始時刻"
+                        v-model="prepareStartTime"
+                        :items="time_range"
+                        text
+                        outlined
+                        clearable
+                        />
+                        <v-select
+                          label="パフォーマンス開始時刻"
+                          v-model="performanceStartTime"
+                          :items="time_range"
+                          text
+                          outlined
+                          clearable
+                          />
+                          <v-select
+                            label="パフォーマンス終了時刻"
+                            v-model="performanceEndTime"
+                            :items="time_range"
+                            text
+                            outlined
+                            clearable
+                            />
+                            <v-select
+                              label="掃除終了時刻"
+                              v-model="cleanupEndTime"
+                              :items="time_range"
+                              text
+                              outlined
+                              clearable
+                              />
+                    </div>
+            </v-form>
+            <br>
+          </v-col>
+          <v-col cols=2></v-col>
+        </v-row>
+        <v-row>
+          <v-col cols=4></v-col>
+            <v-col cols=4>
+            <v-btn color="blue darken-1" large block dark @click="edit">編集する</v-btn>
+            </v-col>
+            <v-col cols=4></v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from 'axios'
+export default {
+  props: {
+    id: Number,
+    groupId: Number,
+    isSunny: Boolean,
+    fesDataId: Number,
+    stageFirst: Number,
+    stageSecond: Number,
+    useTimeInterval: String,
+    prepareTimeInterval: String,
+    cleanupTimeInterval: String,
+    prepareStartTime: String,
+    performanceStartTime: String,
+    performanceEndTime: String,
+    cleanupEndTime: String,
+  },
+  data () {
+    return {
+      isDisplay: false,
+      is_sunny_list: [
+        {label:"晴れ",value:true},
+        {label:"雨",value:false}
+      ],
+      stages_list: [],
+      radioGroup: 1,
+      time_interval: ["5分", "10分", "15分", "20分", "25分", "30分", "35分", "40分", "45分", "50分", "55分", "60分", "65分", "70分", "75分", "80分", "90分", "95分", "100分", "105分", "110分", "115分", "120分"],
+      hour_range: ["9", "10", "11", "12", "13", "14", "15", "16", "17", "00"],
+      minute_range: ["00", "05", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55"],
+      time_range: [],
+    }
+  },
+  computed: {
+    form () {
+      return {
+      }
+    },
+  },
+  methods: {
+    edit: function() {
+      if ( !this.$refs.form.validate() ) return;
+
+      const url = process.env.VUE_APP_URL + '/employees' + '/' + this.id + '?group_id=' + this.groupId + '&name=' + this.name + '&student_id=' + this.studentId
+      axios.defaults.headers.common['Content-Type'] = 'application/json';
+      axios.put(url).then(
+        (response) => {
+          this.isDisplay = false
+          this.$emit('openEmployeeSnackbar')
+          this.$emit('reload')
+        },
+        (error) => {
+          return error;
+        }
+      )
+    },
+    set_time_range: function(){
+      for(var hour of this.hour_range){
+        for(var minute of this.minute_range){
+          this.time_range.push(hour+":"+minute)
+        }
+      }
+    },
+  },
+  mounted() {
+    axios.get(process.env.VUE_APP_URL + '/stages', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.stages_list = response.data
+      })
+    this.set_time_range()
+  },
+}
+</script>

--- a/view/vue-project/src/components/EditModal/stage_order.vue
+++ b/view/vue-project/src/components/EditModal/stage_order.vue
@@ -53,16 +53,16 @@
                     </v-radio-group>
                     <div v-if="radioGroup === 1">
                       <v-select
-                        label="使用時間"
-                        v-model="useTimeInterval"
+                        label="準備時間"
+                        v-model="prepareTimeInterval"
                         :items="time_interval"
                         text
                         outlined
                         clearable
                         />
                         <v-select
-                          label="準備時間"
-                          v-model="prepareTimeInterval"
+                          label="使用時間"
+                          v-model="useTimeInterval"
                           :items="time_interval"
                           text
                           outlined
@@ -70,7 +70,7 @@
                           />
                           <v-select
                             label="掃除時間"
-                              v-model="cleanupTimeInterval"
+                            v-model="cleanupTimeInterval"
                             :items="time_interval"
                             text
                             outlined
@@ -119,10 +119,10 @@
         </v-row>
         <v-row>
           <v-col cols=4></v-col>
-            <v-col cols=4>
+          <v-col cols=4>
             <v-btn color="blue darken-1" large block dark @click="edit">編集する</v-btn>
-            </v-col>
-            <v-col cols=4></v-col>
+          </v-col>
+          <v-col cols=4></v-col>
         </v-row>
       </v-container>
     </v-card>
@@ -136,7 +136,7 @@ export default {
     id: Number,
     groupId: Number,
     isSunny: Boolean,
-    fesDataId: Number,
+    fesDateId: Number,
     stageFirst: Number,
     stageSecond: Number,
     useTimeInterval: String,
@@ -170,12 +170,13 @@ export default {
   },
   methods: {
     edit: function() {
-      if ( !this.$refs.form.validate() ) return;
-
-      const url = process.env.VUE_APP_URL + '/employees' + '/' + this.id + '?group_id=' + this.groupId + '&name=' + this.name + '&student_id=' + this.studentId
+      const url = process.env.VUE_APP_URL + '/stage_orders/' + this.id + '?group_id=' + this.groupId + '&is_sunny=' + this.isSunny + '&fes_date_id=' + this.fesDateId + '&stage_first=' + this.stageFirst + '&stage_second=' + this.stageSecond + '&use_time_interval=' + this.useTimeInterval + '&prepare_time_interval=' + this.prepareTimeInterval + '&cleanup_time_interval=' + this.cleanupTimeInterval + '&prepare_start_time=' + this.prepareStartTime + '&performance_start_time=' + this.performanceStartTime + '&performance_end_time=' + this.performanceEndTime + '&cleanup_end_time=' + this.cleanupEndTime
+      console.log(url)
       axios.defaults.headers.common['Content-Type'] = 'application/json';
       axios.put(url).then(
         (response) => {
+          console.log("aaaaaaaaaaaaaa")
+          console.log(response)
           this.isDisplay = false
           this.$emit('openEmployeeSnackbar')
           this.$emit('reload')

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -470,7 +470,7 @@
                         <v-icon class="pr-2" size="30">mdi-microphone-variant</v-icon>
                         <b>ステージ利用申請情報</b>
                         <v-spacer></v-spacer>
-                        <v-btn v-if="isEditStageOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
+                        <v-btn v-if="isEditStageOrder" fab text @click="openStageOrderDisplay"><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
                       </v-card-title>
                       <hr>
                        <v-list>
@@ -538,6 +538,25 @@
                   </v-col>
                   <v-col cols=1></v-col>
                 </v-row>
+                <!-- Edit Modal -->
+                <StageOrder ref="stageOrderDlg"
+                  :id="this.regist.stage_order.id"
+                  :groupId="this.regist.stage_order.group_id"
+                  :isSunny="this.regist.stage_order.is_sunny"
+                  :fesDataId="this.regist.stage_order.fes_date_id"
+                  :stageFirst="this.regist.stage_order.stage_first"
+                  :stageSecond="this.regist.stage_order.stage_second"
+                  :useTimeInterval="this.regist.stage_order.use_time_interval"
+                  :prepareTimeInterval="this.regist.stage_order.prepare_time_interval"
+                  :cleanupTimeInterval="this.regist.stage_order.cleanup_time_interval"
+                  :prepareStartTime="this.regist.stage_order.prepare_start_time"
+                  :performanceStartTime="this.regist.stage_order.performance_start_time"
+                  :performanceEndTime="this.regist.stage_order.performance_end_time"
+                  :cleanupEndTime="this.regist.stage_order.cleanup_end_time"
+                  @reload="reload"
+                  @openEmployeeSnackbar="openStageOrderSnackbar"
+                />
+
               </v-tab-item>
 
               <!-- 従業員情報 -->
@@ -761,6 +780,7 @@
   import SubRep from '@/components/EditModal/sub_rep.vue'
   import Power from '@/components/EditModal/power.vue'
   import Place from '@/components/EditModal/place.vue'
+  import StageOrder from '@/components/EditModal/stage_order.vue'
   import Employee from '@/components/EditModal/employee.vue'
   import Foodproduct from '@/components/EditModal/foodproduct.vue'
   import Rentalorder from '@/components/EditModal/rental_order.vue'
@@ -778,6 +798,7 @@
       SubRep,
       Power,
       Place,
+      StageOrder,
       Employee,
       Foodproduct,
       Rentalorder,
@@ -912,6 +933,9 @@
       },
       openGroupDisplay() {
         this.$refs.groupDlg.isDisplay = true
+      },
+      openStageOrderDisplay() {
+        this.$refs.stageOrderDlg.isDisplay = true
       },
       openSubRepDisplay() {
         this.$refs.subRepDlg.isDisplay = true

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -51,25 +51,32 @@
                 :value="tab-6"
                 class="font-weight-bold justify-start"
               >
-                <v-icon class="pr-2">mdi-microphone-variant</v-icon>ステージ利用申請情報
+                <v-icon class="pr-2">mdi-microphone</v-icon>ステージ利用申請情報
               </v-tab>
 
               <v-tab
                 :value="tab-7"
                 class="font-weight-bold justify-start"
               >
-                <v-icon class="pr-2">mdi-account</v-icon>従業員情報
+                <v-icon class="pr-2">mdi-microphone-plus</v-icon>ステージオプション申請情報
               </v-tab>
 
               <v-tab
                 :value="tab-8"
                 class="font-weight-bold justify-start"
               >
-                <v-icon class="pr-2">mdi-baguette</v-icon>販売食品情報
+                <v-icon class="pr-2">mdi-account</v-icon>従業員情報
               </v-tab>
 
               <v-tab
                 :value="tab-9"
+                class="font-weight-bold justify-start"
+              >
+                <v-icon class="pr-2">mdi-baguette</v-icon>販売食品情報
+              </v-tab>
+
+              <v-tab
+                :value="tab-10"
                 class="font-weight-bold justify-start"
               >
                 <v-icon class="pr-2">mdi-cart</v-icon>購入品情報
@@ -467,7 +474,7 @@
                   <v-col>
                     <v-card flat>
                       <v-card-title style="color:#333333; font-size:25px">
-                        <v-icon class="pr-2" size="30">mdi-microphone-variant</v-icon>
+                        <v-icon class="pr-2" size="30">mdi-microphone</v-icon>
                         <b>ステージ利用申請情報</b>
                         <v-spacer></v-spacer>
                         <v-btn v-if="isEditStageOrder" text><v-icon class="pr-2">mdi-pencil</v-icon></v-btn>
@@ -540,6 +547,70 @@
                 </v-row>
               </v-tab-item>
 
+              <!-- ステージオプション申請情報 -->
+              <v-tab-item>
+                <v-row>
+                  <v-col cols=1></v-col>
+                  <v-col>
+                    <v-card flat>
+                      <v-card-title style="color:#333333; font-size:25px">
+                        <v-icon class="pr-2" size="30">mdi-microphone-plus</v-icon>
+                        <b>ステージオプション申請情報</b>
+                        <v-spacer></v-spacer>
+                        <v-btn v-if="isEditStageOrder" text fab @click="openStageOptionDisplay"><v-icon>mdi-pencil</v-icon></v-btn>
+                      </v-card-title>
+                      <hr>
+                       <v-list>
+                        <v-list-item>
+                          <v-list-item-content>所持機器の使用</v-list-item-content>
+                          <v-list-item-content v-if="regist.stage_common_option.own_equipment == -9999">未登録</v-list-item-content>
+                          <v-list-item-content v-else-if="regist.stage_common_option.own_equipment === true">使用</v-list-item-content>
+                          <v-list-item-content v-else>使用しない</v-list-item-content>
+                        </v-list-item>
+                      <v-divider></v-divider>
+                        <v-list-item>
+                          <v-list-item-content>音楽</v-list-item-content>
+                          <v-list-item-content v-if="regist.stage_common_option.bgm == -9999">未登録</v-list-item-content>
+                          <v-list-item-content v-else-if="regist.stage_common_option.bgm === true">使用</v-list-item-content>
+                          <v-list-item-content v-else>使用しない</v-list-item-content>
+                        </v-list-item>
+                      <v-divider></v-divider>
+                        <v-list-item>
+                          <v-list-item-content>撮影許可</v-list-item-content>
+                          <v-list-item-content v-if="regist.stage_common_option.camera_permission == -9999">未登録</v-list-item-content>
+                          <v-list-item-content v-else-if="regist.stage_common_option.camera_permission === true">許可</v-list-item-content>
+                          <v-list-item-content v-else>許可しない</v-list-item-content>
+                        </v-list-item>
+                      <v-divider></v-divider>
+                        <v-list-item>
+                          <v-list-item-content>騒音</v-list-item-content>
+                          <v-list-item-content v-if="regist.stage_common_option.loud_sound == -9999">未登録</v-list-item-content>
+                          <v-list-item-content v-else-if="regist.stage_common_option.loud_sound === true">出す</v-list-item-content>
+                          <v-list-item-content v-else>出さない</v-list-item-content>
+                        </v-list-item>
+                        <v-divider></v-divider>
+                        <v-list-item>
+                          <v-list-item-content>ステージ内容</v-list-item-content>
+                          <v-list-item-content v-if="regist.stage_common_option.stage_content == -9999">未登録</v-list-item-content>
+                          <v-list-item-content v-else>{{ regist.stage_common_option.stage_content }}</v-list-item-content>
+                        </v-list-item>
+                       </v-list>
+                    </v-card>
+                  </v-col>
+                  <v-col cols=1></v-col>
+                </v-row>
+                <!--EditModal-->
+                <StageOption ref="StageOptionDlg"
+                      :id = "regist.stage_common_option.id"
+                      :groupId = "regist.stage_common_option.group_id"
+                      :ownEquipment = "regist.stage_common_option.own_equipment"
+                      :Bgm = "regist.stage_common_option.bgm"
+                      :cameraPermission = "regist.stage_common_option.camera_permission"
+                      :loudSound = "regist.stage_common_option.loud_sound"
+                      :stageContent = "regist.stage_common_option.stage_content"
+                      @reload="reload"
+                ></StageOption>
+              </v-tab-item>
               <!-- 従業員情報 -->
               <v-tab-item>
                 <v-row
@@ -762,6 +833,7 @@
   import Power from '@/components/EditModal/power.vue'
   import Place from '@/components/EditModal/place.vue'
   import Employee from '@/components/EditModal/employee.vue'
+  import StageOption from '@/components/EditModal/StageCommonOption.vue'
   import Foodproduct from '@/components/EditModal/foodproduct.vue'
   import Rentalorder from '@/components/EditModal/rental_order.vue'
   import Addpower from '@/components/AddModal/power.vue'
@@ -779,6 +851,7 @@
       Power,
       Place,
       Employee,
+      StageOption,
       Foodproduct,
       Rentalorder,
       Addpower,
@@ -827,6 +900,13 @@
       model:[], 
       power: [],
       url:[],
+      //ステージオプション申請用
+      stage_option_id: [],
+      own_equipment: [],
+      bgm: [],
+      camera_permission: [],
+      loud_sound: [],
+      stage_content: [],
       //従業員申請用
       employee_id: [],
       name:[],
@@ -937,6 +1017,16 @@
         this.url = url
         this.$refs.powerDlg.isDisplay = true
         console.log(this.$refs.powerDlg.isDisplay)
+      },
+      openStageOptionDisplay(id, group_id, own_equipment, bgm, camera_permission, loud_sound, stage_content) {
+        this.stage_option_id = id
+        this.group_id = group_id
+        this.own_equipment = own_equipment
+        this.bgm = bgm
+        this.camera_permission = camera_permission
+        this.loud_sound = loud_sound
+        this.stage_content = stage_content
+        this.$refs.StageOptionDlg.isDisplay = true
       },
       openEmployeeDisplay(id, group_id, name, student_id){
         this.employee_id = id

--- a/view/vue-project/src/components/Regist.vue
+++ b/view/vue-project/src/components/Regist.vue
@@ -587,7 +587,7 @@
                             text
                             v-bind="attrs"
                             v-on="on"
-                            @click
+                            @click="openStageOrderDisplay()"
                             >
                             <v-icon　class="pr-2">mdi-pencil</v-icon>
                           </v-btn>
@@ -666,7 +666,7 @@
                   :id="this.regist.stage_order.id"
                   :groupId="this.regist.stage_order.group_id"
                   :isSunny="this.regist.stage_order.is_sunny"
-                  :fesDataId="this.regist.stage_order.fes_date_id"
+                  :fesDateId="this.regist.stage_order.fes_date_id"
                   :stageFirst="this.regist.stage_order.stage_first"
                   :stageSecond="this.regist.stage_order.stage_second"
                   :useTimeInterval="this.regist.stage_order.use_time_interval"

--- a/view/vue-project/src/views/mypage.vue
+++ b/view/vue-project/src/views/mypage.vue
@@ -3,10 +3,10 @@
     <DashBoard />
     <UserInfo />
     <News />
-    <div v-if="this.regist_info.length === 0">
+    <div v-if="this.regist_info.length === 0" style="text-align:center">
       <v-progress-circular
         indeterminate
-        color="primary"
+        color="purple accent-2"
         ></v-progress-circular>
     </div>
     <div v-else>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #398 

# 概要
<!-- 開発内容の概要を記載 -->
ユーザページでステージオプション申請一覧を閲覧できるようにした.
ステージオプション申請一覧の編集機能も追加した．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-　api/app/controllers/api/v1/current_user_api_controller.rb
- admin_view/nuxt-project/pages/stage_common_options/index.rb
- view/vue-project/src/components/Regist.vue
- view/vue-project/src/components/EditModal/StageCommonOption.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost8080/MyPage`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- ユーザページの登録情報の部分にステージオプション申請一覧が表示されるか
- 編集ボタンを押すとダイアログが表示されるか
- ダイアログに値が代入されているか
- 実際に編集できるか