### PR TITLE
投稿したメモの装飾追加 [mod] Header.vue, default.vue

### DIFF
--- a/admin_view/nuxt-project/components/Header.vue
+++ b/admin_view/nuxt-project/components/Header.vue
@@ -62,14 +62,15 @@
               v-for="item in memos"
               :key="item.id"
               >
-              <v-list-item-content>
-                <v-list-title>{{ item.user }}</v-list-title>
-                <v-list-title>{{ item.memo.content }}</v-list-title>
+              <v-list-item-content class="sticky-note">
+                <v-list-title class="sticky-note__item">{{ item.user }}</v-list-title>
+                <v-list-title class="sticky-note__item">{{ item.memo.content }}</v-list-title>
                 <br>
                 <br>
-                <v-list-title style="text-align:right">{{ item.created_at | format-date}}</v-list-title>
+                <v-list-title class="sticky-note__date">{{ item.created_at | format-date}}</v-list-title>
                 <v-divider/>
               </v-list-item-content>
+
             </v-list-item>
           </v-list>
         </div>

--- a/admin_view/nuxt-project/layouts/default.vue
+++ b/admin_view/nuxt-project/layouts/default.vue
@@ -196,4 +196,30 @@ export default {
   font-size: 0.8125rem;
   text-decoration: none;
 }
+
+.sticky-note {
+  width: max-content;
+  height: max-content;
+  margin-bottom: 1em;
+  overflow: hidden;
+  box-shadow: .25rem 0 .25rem hsla(0, 0%, 0%, .1);
+  background-image:
+    linear-gradient(90deg, hsla(0, 0%, 45%, .1) 2rem, hsla(0, 100%, 100%, 0) 2.5rem)
+  , linear-gradient(90deg, hsla(60, 100%, 85%, 1), hsla(60, 100%, 85%, 1));
+  line-height: 1.8;
+}
+
+.sticky-note hr {
+  border: none;
+}
+
+.sticky-note__item {
+  padding: 0 .25em 0 3em;
+}
+
+.sticky-note__date {
+  text-align: right;
+  padding-right: .5em;
+}
+
 </style>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #291 

# 概要
<!-- 開発内容の概要を記載 -->
メモ機能で投稿したメモの内容を付箋風に装飾しました
# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- /admin_view/nuxt-project/layouts/default.vue
- /admin_view/nuxt-project/components/Header.vue


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://user-images.githubusercontent.com/66411240/111873992-6d9dd900-89d6-11eb-8576-6b7302a69077.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 意図していない部分に変更がないか
- 配色は適切か
- 使いにくい、わかりにくいデザインになっていないか
- 付箋に見えるか

# 備考
[参考記事](https://www.ya-n.com/blog/2019-09-23-post-it/)

