### PR TITLE
[mod]管理者画面_参加団体ページで参加団体に紐付いた情報を全て表示する（#415）

### DIFF
--- a/admin_view/nuxt-project/pages/groups/_id.vue
+++ b/admin_view/nuxt-project/pages/groups/_id.vue
@@ -1,5 +1,19 @@
 <template>
-  <div>
+  <div v-if="data.length === 0">
+    <div class="card">
+      <v-card flat>
+        <br><br>
+        <div class="text-center">
+        <v-progress-circular
+          indeterminate
+          color="#009688"
+        ></v-progress-circular>
+        <br><br>
+        </div>
+      </v-card>
+    </div>
+  </div>
+  <div v-else>
     <v-row>
       <v-col>
         <div class="card">
@@ -131,13 +145,13 @@
                       <tr>
                         <th>登録日時：</th>
                         <td class="caption">
-                          {{ group.created_at | (format - date) }}
+                          {{ group.created_at | format-date }}
                         </td>
                       </tr>
                       <tr>
                         <th>編集日時：</th>
                         <td class="caption">
-                          {{ group.updated_at | (format - date) }}
+                          {{ group.updated_at | format-date }}
                         </td>
                       </tr>
                     </tbody>
@@ -149,7 +163,7 @@
           <br />
           <v-row>
             <v-col cols=6>
-              <v-card flats>
+              <v-card flat>
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -175,43 +189,13 @@
                 </v-row>
               </v-card>
             </v-col>
-            <v-col cols="6">
+             <v-col cols=6>
               <v-card flat>
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
                     <v-card-title class="font-weight-bold mt-3">
-                      従業員
-                    </v-card-title>
-                    <hr class="mt-n3" />
-                    <v-simple-table class="my-9">
-                      <template v-slot:default>
-                        <tbody v-for="Employee in Employees" :key="Employee.id">
-                          <tr>
-                            <router-link :to="{ name: 'employees-id', params:{ id: Employee.id }}" tag="th">
-                              <th>{{ Employee.id }}</th>
-                            </router-link>
-                            <router-link :to="{ name: 'employees-id', params:{ id: Employee.id }}" tag="td">
-                              <td class="caption">{{ Employee.name }}</td>
-                            </router-link>
-                          </tr>
-                        </tbody>
-                      </template>
-                    </v-simple-table>
-                  </v-col>
-                </v-row>
-              </v-card>
-            </v-col>
-          </v-row>
-          <br>
-          <v-row>
-            <v-col cols=6>
-              <v-card flat>
-                <v-row>
-                  <v-col cols="1"></v-col>
-                  <v-col cols="10">
-                    <v-card-title class="font-weight-bold mt-3">
-                      会場
+                      会場申請
                     </v-card-title>
                     <hr class="mt-n3" />
                     <v-simple-table class="my-9">
@@ -248,13 +232,16 @@
                 </v-row>
               </v-card>
             </v-col>
+          </v-row>
+          <br>
+          <v-row>
             <v-col cols="6">
               <v-card flat　:to="{ name: 'power_orders'}">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
                     <v-card-title class="font-weight-bold mt-3">
-                      電力
+                      電力申請
                     </v-card-title>
                     <hr class="mt-n3" />
                     <v-simple-table class="my-9">
@@ -279,15 +266,13 @@
                 </v-row>
               </v-card>
             </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
+            <v-col cols="6">
               <v-card flat>
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
                     <v-card-title class="font-weight-bold mt-3">
-                      物品
+                      物品申請
                     </v-card-title>
                     <hr class="mt-n3" />
                     <v-simple-table class="my-9">
@@ -314,7 +299,7 @@
             </v-col>
           </v-row>
           <br />
-          <v-row>
+          <v-row v-if="groupCategoryId === 3">
             <v-col cols="6">
               <v-card flat>
                 <v-row>
@@ -455,7 +440,7 @@
             </v-col>
           </v-row>
           <br />
-          <v-row>
+          <v-row v-if="groupCategoryId !== 3">
             <v-col>
               <v-card flat>
                 <v-row>
@@ -496,11 +481,37 @@
                 </v-row>
               </v-card>
             </v-col>
+            <v-col cols="6">
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      従業員
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody v-for="Employee in Employees" :key="Employee.id">
+                          <tr>
+                            <router-link :to="{ name: 'employees-id', params:{ id: Employee.id }}" tag="th">
+                              <th>{{ Employee.id }}</th>
+                            </router-link>
+                            <router-link :to="{ name: 'employees-id', params:{ id: Employee.id }}" tag="td">
+                              <td class="caption">{{ Employee.name }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
           </v-row>
         </div>
       </v-col>
     </v-row>
-
     <v-row>
       <v-col>
         <div class="card">
@@ -638,6 +649,8 @@ import moment from "moment";
 export default {
   data() {
     return {
+      data: [],
+      detail_data: [],
       group: [],
       user_id: [],
       user: [],
@@ -748,6 +761,7 @@ export default {
           },
         })
         .then((response) => {
+          this.data = response.data
           this.group = response.data.group;
           this.groupName = this.group.name;
           this.groupProjectName = this.group.project_name;
@@ -755,17 +769,35 @@ export default {
           this.groupActivity = this.group.activity;
           this.user_id = this.group.user_id;
           this.fes_year_id = this.group.fes_year_id;
-          this.user = response.data.user;
-          this.year = response.data.fes_year;
-          this.place_first = response.data.place_first;
-          this.place_second = response.data.place_second;
-          this.place_third = response.data.place_third;
-          this.stage_first = response.data.stage_first;
-          this.stage_second = response.data.stage_second;
-          this.rentalOrderLists = response.data.rental_order_lists;
-          this.fes_date = response.data.fes_date;
-          this.purchase_lists = response.data.purchase_lists;
+          this.user = this.data.user;
+          this.year = this.data.fes_year;
+          this.place_first = this.data.place_first;
+          this.place_second = this.data.place_second;
+          this.place_third = this.data.place_third;
+          this.stage_first = this.data.stage_first;
+          this.stage_second = this.data.stage_second;
+          this.rentalOrderLists = this.data.rental_order_lists;
+          this.fes_date = this.data.fes_date;
+          this.purchase_lists = this.data.purchase_lists;
         });
+      const group_detail_url = "api/v1/get_group_detail/" + this.$route.params.id;
+      this.$axios.get(group_detail_url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        this.detail_data = response.data
+        this.Group = this.detail_data.group;
+        this.subRep = this.detail_data.sub_rep;
+        this.Employees = this.detail_data.employees;
+        this.placeOrder = this.detail_data.place_order;
+        this.powerOrders = this.detail_data.power_orders;
+        this.rentalOrders = this.detail_data.rental_orders;
+        this.stageOrder = this.detail_data.stage_order;
+        this.stageCommonOption = this.detail_data.stage_common_option;
+        this.foodProducts = this.detail_data.food_products;
+      });
     },
     edit_dialog_open: function () {
       const year_url = "/fes_years/";
@@ -833,6 +865,7 @@ export default {
         },
       })
       .then((response) => {
+        this.data = response.data
         this.group = response.data.group;
         this.groupName = this.group.name;
         this.groupProjectName = this.group.project_name;
@@ -840,16 +873,16 @@ export default {
         this.groupActivity = this.group.activity;
         this.user_id = this.group.user_id;
         this.fes_year_id = this.group.fes_year_id;
-        this.user = response.data.user;
-        this.year = response.data.fes_year;
-        this.place_first = response.data.place_first;
-        this.place_second = response.data.place_second;
-        this.place_third = response.data.place_third;
-        this.stage_first = response.data.stage_first;
-        this.stage_second = response.data.stage_second;
-        this.rentalOrderLists = response.data.rental_order_lists;
-        this.fes_date = response.data.fes_date;
-        this.purchase_lists = response.data.purchase_lists;
+        this.user = this.data.user;
+        this.year = this.data.fes_year;
+        this.place_first = this.data.place_first;
+        this.place_second = this.data.place_second;
+        this.place_third = this.data.place_third;
+        this.stage_first = this.data.stage_first;
+        this.stage_second = this.data.stage_second;
+        this.rentalOrderLists = this.data.rental_order_lists;
+        this.fes_date = this.data.fes_date;
+        this.purchase_lists = this.data.purchase_lists;
       });
 
     const category_url = "group_categories/";
@@ -875,29 +908,17 @@ export default {
         },
       })
       .then((response) => {
-        console.log(response);
-        this.Group = response.data.group;
-        this.subRep = response.data.sub_rep;
-        this.Employees = response.data.employees;
-        this.placeOrder = response.data.place_order;
-        this.powerOrders = response.data.power_orders;
-        this.rentalOrders = response.data.rental_orders;
-        this.stageOrder = response.data.stage_order;
-        this.stageCommonOption = response.data.stage_common_option;
-        this.foodProducts = response.data.food_products;
+        this.detail_data = response.data
+        this.Group = this.detail_data.group;
+        this.subRep = this.detail_data.sub_rep;
+        this.Employees = this.detail_data.employees;
+        this.placeOrder = this.detail_data.place_order;
+        this.powerOrders = this.detail_data.power_orders;
+        this.rentalOrders = this.detail_data.rental_orders;
+        this.stageOrder = this.detail_data.stage_order;
+        this.stageCommonOption = this.detail_data.stage_common_option;
+        this.foodProducts = this.detail_data.food_products;
       });
-      
-    this.$axios.get('/places', {
-      headers: { 
-        "Content-Type": "application/json", 
-      }
-    })
-      .then(response => {
-        this.places = response.data
-        for (let i = 0; i < this.places.length; i++) {
-          this.place_list.push(this.places[i]['name'])
-        }
-      })
   },
 
   filters: {

--- a/admin_view/nuxt-project/pages/groups/_id.vue
+++ b/admin_view/nuxt-project/pages/groups/_id.vue
@@ -146,6 +146,357 @@
               </v-col>
             </v-row>
           </v-card>
+          <br />
+          <v-row>
+            <v-col cols=6>
+              <v-card flats>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      副代表
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                            <router-link :to="{ name: 'sub_reps-id', params:{ id: subRep.id }}" tag="th">
+                              <th>名前：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'sub_reps-id', params:{ id: subRep.id }}" tag="th">
+                            <td class="caption">{{ subRep.name }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+            <v-col cols="6">
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      従業員
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody v-for="Employee in Employees" :key="Employee.id">
+                          <tr>
+                            <router-link :to="{ name: 'employees-id', params:{ id: Employee.id }}" tag="th">
+                              <th>{{ Employee.id }}</th>
+                            </router-link>
+                            <router-link :to="{ name: 'employees-id', params:{ id: Employee.id }}" tag="td">
+                              <td class="caption">{{ Employee.name }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
+          <br>
+          <v-row>
+            <v-col cols=6>
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      会場
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                            <router-link :to="{ name: 'place_orders-id', params:{ id: placeOrder.id }}" tag="th">
+                              <th>第一希望</th>
+                            </router-link>
+                            <router-link :to="{ name: 'place_orders-id', params:{ id: placeOrder.id }}" tag="td">
+                              <td>{{ place_first }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'place_orders-id', params:{ id: placeOrder.id }}" tag="th">
+                              <th>第二希望</th>
+                            </router-link>
+                            <router-link :to="{ name: 'place_orders-id', params:{ id: placeOrder.id }}" tag="td">
+                              <td>{{ place_second }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'place_orders-id', params:{ id: placeOrder.id }}" tag="th">
+                              <th>第三希望</th>
+                            </router-link>
+                            <router-link :to="{ name: 'place_orders-id', params:{ id: placeOrder.id }}" tag="td">
+                              <td>{{ place_third }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+            <v-col cols="6">
+              <v-card flat　:to="{ name: 'power_orders'}">
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      電力
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                              <th>製品</th>
+                              <th>電力</th>
+                          </tr>
+                          <tr v-for="powerOrder in powerOrders" :key="powerOrder.id">
+                            <router-link :to="{ name: 'power_orders-id', params:{ id: powerOrder.id }}" tag="td">
+                              <td class="caption">{{ powerOrder.item }}</td>
+                            </router-link>
+                            <router-link :to="{ name: 'power_orders-id', params:{ id: powerOrder.id }}" tag="td">
+                              <td class="caption">{{ powerOrder.power }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      物品
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                            <th>貸し出し物品名：</th>
+                            <th>貸し出し個数：</th>
+                          </tr>
+                          <tr v-for="rentalOrderList in rentalOrderLists" :key="rentalOrderList.id">
+                            <router-link :to="{ name: 'rental_orders-id', params:{ id: rentalOrderList.rental_id }}" tag="td">
+                              <td>{{ rentalOrderList.rental_item }}</td>
+                            </router-link>
+                            <router-link :to="{ name: 'rental_orders-id', params:{ id: rentalOrderList.rental_id }}" tag="td">
+                              <td>{{ rentalOrderList.rental_num }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>  
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
+          <br />
+          <v-row>
+            <v-col cols="6">
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      ステージ：
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>希望日：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ fes_date }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>第一希望：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ stage_first }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>第二希望：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ stage_second }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>準備開始時刻：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ stageOrder.prepare_start_time }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>パフォーマンス開始時刻：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ stageOrder.performance_start_time }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>パフォーマンス終了時刻：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ stageOrder.performance_end_time }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="th">
+                              <th>掃除終了時刻：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_orders-id', params:{ id: stageOrder.id }}" tag="td">
+                              <td>{{ stageOrder.cleanup_end_time }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+            <v-col cols="6">
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      ステージオプション
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="th">
+                              <th>所持機器の使用：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="td">
+                              <td v-if="stageCommonOption.own_equipment == true">{{ items_available[0].label }}</td>
+                              <td v-if="stageCommonOption.own_equipment == false">{{ items_available[1].label }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="th">
+                              <th>音楽をかける：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="td">
+                              <td v-if="stageCommonOption.bgm == true">{{ items_available[0].label }}</td>
+                              <td v-if="stageCommonOption.bgm == false">{{ items_available[1].label }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="th">
+                              <th>撮影許可：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="td">
+                              <td v-if="stageCommonOption.camera_permission == true">{{ photo_available[0].label }}</td>
+                              <td v-if="stageCommonOption.camera_permission == false">{{ photo_available[1].label }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="th">
+                            <th>大きな音を出すか：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="td">
+                              <td v-if="stageCommonOption.loud_sound == true">{{ loud_able[0].label }}</td>
+                              <td v-if="stageCommonOption.loud_sound == false">{{ loud_able[1].label }}</td>
+                            </router-link>
+                          </tr>
+                          <tr>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="th">
+                              <th>ステージ内容：</th>
+                            </router-link>
+                            <router-link :to="{ name: 'stage_common_options-id', params:{ id: stageCommonOption.id }}" tag="td">
+                              <td>{{ stageCommonOption.stage_content }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
+          <br />
+          <v-row>
+            <v-col>
+              <v-card flat>
+                <v-row>
+                  <v-col cols="1"></v-col>
+                  <v-col cols="10">
+                    <v-card-title class="font-weight-bold mt-3">
+                      販売食品
+                    </v-card-title>
+                    <hr class="mt-n3" />
+                    <v-simple-table class="my-9">
+                      <template v-slot:default>
+                        <tbody>
+                          <tr>
+                            <th>名前：</th>
+                            <th>調理の有無：</th>
+                            <th>1日目の個数：</th>
+                            <th>2日目の個数：</th>
+                          </tr>
+                          <tr v-for="foodProduct in foodProducts" :key="foodProduct.id">
+                            <router-link :to="{ name: 'food_products-id', params:{ id: foodProduct.id }}" tag="td">
+                              <td>{{ foodProduct.name }}</td>
+                            </router-link>
+                            <router-link :to="{ name: 'food_products-id', params:{ id: foodProduct.id }}" tag="td">
+                              <td v-if="foodProduct.is_cooking == true">{{ cooking_available[0].label }}</td>
+                              <td v-if="foodProduct.is_cooking == false">{{ cooking_available[1].label }}</td>
+                            </router-link>
+                            <router-link :to="{ name: 'food_products-id', params:{ id: foodProduct.id }}" tag="td">
+                              <td>{{ foodProduct.first_day_num }}</td>
+                            </router-link>
+                            <router-link :to="{ name: 'food_products-id', params:{ id: foodProduct.id }}" tag="td">
+                              <td>{{ foodProduct.second_day_num }}</td>
+                            </router-link>
+                          </tr>
+                        </tbody>
+                      </template>
+                    </v-simple-table>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
         </div>
       </v-col>
     </v-row>
@@ -192,7 +543,7 @@
                   :rules="[rules.required]"
                   :menu-props="{
                     top: true,
-                    offsetY: true
+                    offsetY: true,
                   }"
                   item-text="name"
                   item-value="id"
@@ -221,7 +572,7 @@
                   :rules="[rules.required]"
                   :menu-props="{
                     top: true,
-                    offsetY: true
+                    offsetY: true,
                   }"
                   item-text="year_num"
                   item-value="id"
@@ -253,17 +604,13 @@
           </v-btn>
         </v-card-title>
 
-        <v-card-title>
-          削除してよろしいですか？
-        </v-card-title>
+        <v-card-title> 削除してよろしいですか？ </v-card-title>
 
         <v-divider></v-divider>
 
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn flat color="red" dark @click="delete_yes">
-            はい
-          </v-btn>
+          <v-btn flat color="red" dark @click="delete_yes"> はい </v-btn>
           <v-btn flat color="blue" dark @click="delete_dialog = false">
             いいえ
           </v-btn>
@@ -286,6 +633,7 @@
 
 <script>
 import axios from "axios";
+import moment from "moment";
 
 export default {
   data() {
@@ -299,53 +647,135 @@ export default {
       category: [],
       fes_years: [],
       years: [],
+      place_first: [],
+      place_second: [],
+      place_third: [],
+      stage_first: [],
+      stage_second: [],
+      rentalOrderLists: [],
+      fes_date: [],
+      purchase_lists: [],
       expand: false,
       dialog: false,
       groupName: [],
       groupProjectName: [],
       groupCategoryId: [],
       groupActivity: [],
+      Group: [],
+      subRep: [],
+      Employees: [],
+      placeOrder: [],
+      powerOrders: [],
+      rentalOrders: [],
+      stageOrder: [],
+      stageCommonOption: [],
+      foodProducts: [],
       edit_dialog: false,
       delete_dialog: false,
       success_snackbar: false,
       delete_snackbar: false,
       year_list: [],
       groupCategories: [],
+      // 課程
+      departments: [
+        { name: "機械創造工学課程", id: 1 },
+        { name: "電気電子情報工学課程", id: 2 },
+        { name: "物質材料工学課程", id: 3 },
+        { name: "環境社会基盤工学課程", id: 4 },
+        { name: "生物機能工学課程", id: 5 },
+        { name: "情報・経営システム工学課程", id: 6 },
+        { name: "機械創造工学専攻", id: 7 },
+        { name: "電気電子情報工学専攻", id: 8 },
+        { name: "物質材料工学専攻", id: 9 },
+        { name: "環境社会基盤工学専攻", id: 10 },
+        { name: "生物機能工学専攻", id: 11 },
+        { name: "情報・経営システム工学専攻", id: 12 },
+        { name: "原子力システム安全工学専攻", id: 13 },
+        { name: "システム安全専攻", id: 14 },
+        { name: "技術科学イノベーション専攻", id: 15 },
+        { name: "情報・制御工学専攻", id: 16 },
+        { name: "材料工学専攻", id: 17 },
+        { name: "エネルギー・環境工学専攻", id: 18 },
+        { name: "生物統合工学専攻", id: 19 },
+        { name: "その他", id: 20 },
+      ],
+      // 学年
+      grades: [
+        { name: "B1 [学部1年]", id: 1 },
+        { name: "B2 [学部2年]", id: 2 },
+        { name: "B3 [学部3年]", id: 3 },
+        { name: "B4 [学部4年]", id: 4 },
+        { name: "M1 [修士1年]", id: 5 },
+        { name: "M2 [修士2年]", id: 6 },
+        { name: "D1 [博士1年]", id: 7 },
+        { name: "D2 [博士2年]", id: 8 },
+        { name: "D3 [博士3年]", id: 9 },
+        { name: "GD1 [イノベ1年]", id: 10 },
+        { name: "GD2 [イノベ2年]", id: 11 },
+        { name: "GD3 [イノベ3年]", id: 12 },
+        { name: "GD4 [イノベ4年]", id: 13 },
+        { name: "GD5 [イノベ5年]", id: 14 },
+        { name: "その他", id: 15 },
+      ],
+      items_available:[
+        {label:"使用",value:true},
+        {label:"不使用",value:false}
+      ],
+      photo_available:[
+        {label:"許可",value:true},
+        {label:"禁止",value:false}
+      ],
+      loud_able:[
+        {label:"出す",value:true},
+        {label:"出さない",value:false}
+      ],
+      cooking_available:[
+        {label:"する",value:true},
+        {label:"しない",value:false}
+      ],
       rules: {
-        required: value => !!value || "入力してください"
-      }
+        required: (value) => !!value || "入力してください",
+      },
     };
   },
   methods: {
-    reload: function() {
+    reload: function () {
       const url = "api/v1/get_group/" + this.$route.params.id;
       this.$axios
         .get(url, {
           headers: {
-            "Content-Type": "application/json"
-          }
+            "Content-Type": "application/json",
+          },
         })
-        .then(response => {
+        .then((response) => {
           this.group = response.data.group;
-          this.groupName = response.data.group.name;
-          this.groupProjectName = response.data.group.project_name;
-          this.groupCategoryId = response.data.group.group_category_id;
-          this.groupActivity = response.data.group.activity;
-          this.user_id = response.data.group.user_id;
-          this.fes_year_id = response.data.group.fes_year_id;
+          this.groupName = this.group.name;
+          this.groupProjectName = this.group.project_name;
+          this.groupCategoryId = this.group.group_category_id;
+          this.groupActivity = this.group.activity;
+          this.user_id = this.group.user_id;
+          this.fes_year_id = this.group.fes_year_id;
           this.user = response.data.user;
           this.year = response.data.fes_year;
+          this.place_first = response.data.place_first;
+          this.place_second = response.data.place_second;
+          this.place_third = response.data.place_third;
+          this.stage_first = response.data.stage_first;
+          this.stage_second = response.data.stage_second;
+          this.rentalOrderLists = response.data.rental_order_lists;
+          this.fes_date = response.data.fes_date;
+          this.purchase_lists = response.data.purchase_lists;
         });
     },
-    edit_dialog_open: function() {
+    edit_dialog_open: function () {
       const year_url = "/fes_years/";
       this.$axios
         .get(year_url, {
           headers: {
-            "Content-Type": "application/json"
-          }
+            "Content-Type": "application/json",
+          },
         })
-        .then(response => {
+        .then((response) => {
           this.year_list = response.data;
         });
       this.edit_dialog = true;
@@ -354,15 +784,15 @@ export default {
       this.$axios
         .get(group_categories_url, {
           headers: {
-            "Content-Type": "application/json"
-          }
+            "Content-Type": "application/json",
+          },
         })
-        .then(response => {
+        .then((response) => {
           this.groupCategories = response.data;
         });
       this.edit_dialog = true;
     },
-    edit: function() {
+    edit: function () {
       const edit_url =
         "/groups/" +
         this.group.id +
@@ -379,55 +809,101 @@ export default {
       this.$axios
         .put(edit_url, {
           headers: {
-            "Content-Type": "application/json"
-          }
+            "Content-Type": "application/json",
+          },
         })
-        .then(response => {
+        .then((response) => {
           console.log(response);
           this.reload();
           this.edit_dialog = false;
         });
     },
-    delete_yes: function() {
+    delete_yes: function () {
       const url = "/groups/" + this.$route.params.id;
       this.$axios.delete(url);
       this.$router.push("/groups");
-    }
+    },
   },
   mounted() {
     const url = "api/v1/get_group/" + this.$route.params.id;
     this.$axios
       .get(url, {
         headers: {
-          "Content-Type": "application/json"
-        }
+          "Content-Type": "application/json",
+        },
       })
-      .then(response => {
+      .then((response) => {
         this.group = response.data.group;
-        this.groupName = response.data.group.name;
-        this.groupProjectName = response.data.group.project_name;
-        this.groupCategoryId = response.data.group.group_category_id;
-        this.groupActivity = response.data.group.activity;
-        this.user_id = response.data.group.user_id;
-        this.fes_year_id = response.data.group.fes_year_id;
+        this.groupName = this.group.name;
+        this.groupProjectName = this.group.project_name;
+        this.groupCategoryId = this.group.group_category_id;
+        this.groupActivity = this.group.activity;
+        this.user_id = this.group.user_id;
+        this.fes_year_id = this.group.fes_year_id;
         this.user = response.data.user;
         this.year = response.data.fes_year;
+        this.place_first = response.data.place_first;
+        this.place_second = response.data.place_second;
+        this.place_third = response.data.place_third;
+        this.stage_first = response.data.stage_first;
+        this.stage_second = response.data.stage_second;
+        this.rentalOrderLists = response.data.rental_order_lists;
+        this.fes_date = response.data.fes_date;
+        this.purchase_lists = response.data.purchase_lists;
       });
 
     const category_url = "group_categories/";
     this.$axios
       .get(category_url, {
         headers: {
-          "Content-Type": "application/json"
-        }
+          "Content-Type": "application/json",
+        },
       })
-      .then(response => {
+      .then((response) => {
         console.log(response);
         this.group_categories = response.data;
         for (let i = 0; i < this.group_categories.length; i++) {
           this.category.push(this.group_categories[i]["name"]);
         }
       });
-  }
+
+    const group_detail_url = "api/v1/get_group_detail/" + this.$route.params.id;
+    this.$axios
+      .get(group_detail_url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        console.log(response);
+        this.Group = response.data.group;
+        this.subRep = response.data.sub_rep;
+        this.Employees = response.data.employees;
+        this.placeOrder = response.data.place_order;
+        this.powerOrders = response.data.power_orders;
+        this.rentalOrders = response.data.rental_orders;
+        this.stageOrder = response.data.stage_order;
+        this.stageCommonOption = response.data.stage_common_option;
+        this.foodProducts = response.data.food_products;
+      });
+      
+    this.$axios.get('/places', {
+      headers: { 
+        "Content-Type": "application/json", 
+      }
+    })
+      .then(response => {
+        this.places = response.data
+        for (let i = 0; i < this.places.length; i++) {
+          this.place_list.push(this.places[i]['name'])
+        }
+      })
+  },
+
+  filters: {
+    moment: function (date) {
+      return moment(date).format("YYYY/MM/DD");
+    },
+  },
 };
 </script>

--- a/api/app/controllers/api/v1/groups_api_controller.rb
+++ b/api/app/controllers/api/v1/groups_api_controller.rb
@@ -45,13 +45,68 @@ class Api::V1::GroupsApiController < ApplicationController
     group = Group.find(params[:id])
     user = group.user.name
     fes_year = group.fes_year.year_num
+    place_first = Place.find(group.place_order.first).name
+    place_second = Place.find(group.place_order.second).name
+    place_third = Place.find(group.place_order.third).name
+    stage_first = Stage.find(group.stage_order.stage_first).name
+    stage_second = Stage.find(group.stage_order.stage_second).name
+    fes_date = FesDate.find(group.stage_order.fes_date_id).date
+    rental_order_lists = []
+    for rental_order in group.rental_orders
+      rental_id = rental_order.rental_item.id
+      rental_item = rental_order.rental_item.name
+      rental_num = rental_order.num
+      rental_order_lists << {
+        rental_id: rental_id,
+        rental_item: rental_item,
+        rental_num: rental_num
+      }
+    end
+    purchase_list = []
+    for food_product in group.food_products
+      purchase_lists = food_product.purchase_lists
+      purchase_list << {
+        purchase_lists: purchase_lists
+      }
+    end
     group_list = []
     group_list = {
       group: group,
       user: user,
-      fes_year: fes_year
+      fes_year: fes_year,
+      place_first: place_first,
+      place_second: place_second,
+      place_third: place_third,
+      stage_first: stage_first,
+      stage_second: stage_second,
+      fes_date: fes_date,
+      purchase_list: purchase_list,
+      rental_order_lists: rental_order_lists,
     }
     render json: group_list
+  end
+
+  def get_group_detail
+    group = Group.find(params[:id])
+    sub_rep = group.sub_rep
+    employees = group.employees
+    stage_common_option = group.stage_common_option
+    power_orders = group.power_orders
+    place_order = group.place_order
+    stage_order = group.stage_order
+    food_products = group.food_products
+    group_details = []
+    group_details = {
+      group: group,
+      sub_rep: sub_rep,
+      employees: employees,
+      stage_common_option: stage_common_option,
+      power_orders: power_orders,
+      place_order: place_order,
+      stage_order: stage_order,
+      food_products: food_products,
+    }
+    render json: group_details 
   end
 
 end

--- a/api/app/controllers/api/v1/groups_api_controller.rb
+++ b/api/app/controllers/api/v1/groups_api_controller.rb
@@ -48,9 +48,15 @@ class Api::V1::GroupsApiController < ApplicationController
     place_first = Place.find(group.place_order.first).name
     place_second = Place.find(group.place_order.second).name
     place_third = Place.find(group.place_order.third).name
-    stage_first = Stage.find(group.stage_order.stage_first).name
-    stage_second = Stage.find(group.stage_order.stage_second).name
-    fes_date = FesDate.find(group.stage_order.fes_date_id).date
+    if group.stage_order == nil
+      stage_first = '未登録'
+      stage_second = '未登録'
+      fes_date = '未登録'
+    else
+      stage_first = Stage.find(group.stage_order.stage_first).name
+      stage_second = Stage.find(group.stage_order.stage_second).name
+      fes_date = FesDate.find(group.stage_order.fes_date_id).date
+    end
     rental_order_lists = []
     for rental_order in group.rental_orders
       rental_id = rental_order.rental_item.id

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       get "get_group_from_project_name/:id" => "groups_api#get_group_from_project_name"
       get "get_groups" => "groups_api#get_groups"
       get "get_group/:id" => "groups_api#get_group"
+      get "get_group_detail/:id" => "groups_api#get_group_detail"
       # ステージオプション周り
       get "get_stage_common_options_with_group/" => "stage_common_options_api#get_stage_common_options_with_group"
       get "get_stage_common_options_with_group/:id" => "stage_common_options_api#get_stage_common_option_with_group"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #415 

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面のそれぞれの参加団体ページで参加団体に紐付いた情報を全て表示できるようにした．
それぞれのカードの表の中身をクリックしたらその詳細のページに飛ぶようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- api/app/controllers/api/v1/groups_api_controller.rb
- admin_view/nuxt-project/pages/groups/_id.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `http://localhost:8000/groups/1`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者画面の参加団体ページで参加団体に紐付いた情報が表示されるか
- 管理者画面の参加団体ページで各カードの各データを選択したらその詳細ページに遷移するか