### PR TITLE
[管理者画面]ユーザー情報・パスワードの変更

### DIFF
--- a/admin_view/nuxt-project/pages/users/_id.vue
+++ b/admin_view/nuxt-project/pages/users/_id.vue
@@ -8,7 +8,6 @@
               <ul>
                 <li><div class="breadcrumbs-item"><router-link to="/users">ユーザー一覧</router-link></div></li>
                 <li><div class="breadcrumbs-item">{{show.user_name}}</div></li>
-                {{ user.id }}
               </ul>
             </div>
           </v-card-text>
@@ -29,18 +28,31 @@
                   <v-icon v-if="user.role_id == 3" color="blue">mdi-account</v-icon>
                   {{show.user_name}}
                   <v-spacer></v-spacer>
+                <v-tooltip top v-if="email != uid">
+                  <template v-slot:activator="{ on, attrs  }">
+                      <v-btn 
+                      text 
+                      v-bind="attrs"
+                      v-on="on"
+                      @click="edit_user_info_dialog = true" 
+                      fab>
+                      <v-icon class="ma-5">mdi-account-edit-outline</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>ユーザー情報編集</span>
+                </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">
                       <v-btn 
                       text 
                       v-bind="attrs"
                       v-on="on"
-                      @click="edit_dialog_open" 
+                      @click="edit_role_dialog_open" 
                       fab>
                       <v-icon class="ma-5">mdi-pencil</v-icon>
                     </v-btn>
                   </template>
-                  <span>編集</span>
+                  <span>権限編集</span>
                 </v-tooltip>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs  }">
@@ -167,18 +179,101 @@
       <v-col></v-col>
     </v-row>
 
-    <!-- 編集ダイアログ -->
+    <!-- ユーザー情報編集ダイアログ -->
     <v-dialog
-      v-model="edit_dialog"
+      v-model="edit_user_info_dialog"
       width="500"
       >
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
           <div style="color: white">
-            <v-icon class="ma-5" dark>mdi-pencil</v-icon>編集
+            <v-icon class="ma-5" dark>mdi-pencil</v-icon>ユーザー情報編集
           </div>
           <v-spacer></v-spacer>
-          <v-btn text @click="edit_dialog = false" fab dark>
+          <v-btn text @click="edit_user_info_dialog = false" fab dark>
+            ​ <v-icon>mdi-close</v-icon>
+          </v-btn>
+      </v-card-title>
+
+      <v-card-text>
+        <v-row>
+          <v-col>
+            <v-form ref="form">
+            <v-text-field
+              label="名前"
+              v-model="name"
+              :rules="[rules.requied]"
+              outlined
+              /></v-text-field>
+            <v-text-field
+              label="学籍番号"
+              v-model="student_id"
+              :rules="[rules.requied]"
+              outlined
+              counter=8
+              /></v-text-field>
+            <v-select
+              label="学年"
+              v-model="grade_id"
+              :items="items_grade"
+              item-text="label"
+              item-value="id"
+              outlined
+              /></v-select>
+            <v-select
+              label="課程"
+              v-model="department_id"
+              :items="items_department"
+              item-text="label"
+              item-value="id"
+              outlined
+              /></v-select>
+            <v-text-field
+              label="電話番号"
+              v-model="tel"
+              :rules="[rules.requied]"
+              outlined
+              counter=11
+              /></v-text-field>
+            <v-text-field
+              label="メールアドレス"
+              v-model="email"
+              :rules="[rules.requied]"
+              outlined
+              /></v-text-field>
+            </v-form>
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="#78909C"
+          dark
+          @click="edit_user_info"
+          >
+          編集する
+        </v-btn>
+      </v-card-actions>
+      </v-card>
+    </v-dialog> 
+
+
+    <!-- 権限編集ダイアログ -->
+    <v-dialog
+      v-model="edit_role_dialog"
+      width="500"
+      >
+      <v-card>
+        <v-card-title class="headline blue-grey darken-3">
+          <div style="color: white">
+            <v-icon class="ma-5" dark>mdi-pencil</v-icon>権限編集
+          </div>
+          <v-spacer></v-spacer>
+          <v-btn text @click="edit_role_dialog = false" fab dark>
             ​ <v-icon>mdi-close</v-icon>
           </v-btn>
       </v-card-title>
@@ -207,7 +302,7 @@
         <v-btn
           color="#78909C"
           dark
-          @click="edit"
+          @click="edit_role"
           >
           編集する
         </v-btn>
@@ -288,28 +383,88 @@ export default {
 
   data() {
     return {
+      uid: localStorage.getItem('uid'),
       show: [],
       user: [],
-      id: [],
+      name: [],
+      student_id: [],
+      tel: [],      
+      email: [],
+      user_id: [],
       role_id: [],
       role: [],
-      grade: [],
-      department: [],
+      grade_id: [],
+      department_id: [],
       detail: [],
-      spgroup:[],
       group_categories:[],
       fes_years:[],
       expand: false,
-      edit_dialog: false,
+      edit_user_info_dialog: false,
+      edit_role_dialog: false,
       delete_dialog: false,
       items_role:[
         {label:"developer",id:1},
         {label:"maneger",id:2},
         {label:"user",id:3}
-      ]
+      ],
+      items_department:[
+        { label: "機械創造工学課程", id: 1 },
+        { label: "電気電子情報工学課程", id: 2 },
+        { label: "物質材料工学課程", id: 3 },
+        { label: "環境社会基盤工学課程", id: 4 },
+        { label: "生物機能工学課程", id: 5 },
+        { label: "情報・経営システム工学課程", id: 6 },
+        { label: "機械創造工学専攻", id: 7 },
+        { label: "電気電子情報工学専攻", id: 8 },
+        { label: "物質材料工学専攻", id: 9 },
+        { label: "環境社会基盤工学専攻", id: 10 },
+        { label: "生物機能工学専攻", id: 11 },
+        { label: "情報・経営システム工学専攻", id: 12 },
+        { label: "原子力システム安全工学専攻", id: 13 },
+        { label: "システム安全専攻", id: 14 },
+        { label: "技術科学イノベーション専攻", id: 15 },
+        { label: "情報・制御工学専攻", id: 16 },
+        { label: "材料工学専攻", id: 17 },
+        { label: "エネルギー・環境工学専攻", id: 18 },
+        { label: "生物統合工学専攻", id: 19 },
+        { label: "その他", id: 20 }
+      ],
+      items_grade:[
+        { label: "B1[学部1年]", id: 1 },
+        { label: "B2[学部2年]", id: 2 },
+        { label: "B3[学部3年]", id: 3 },
+        { label: "B4[学部4年]", id: 4 },
+        { label: "M1[修士1年]", id: 5 },
+        { label: "M2[修士2年]", id: 6 },
+        { label: "D1[博士1年]", id: 7 },
+        { label: "D2[博士2年]", id: 8 },
+        { label: "D3[博士3年]", id: 9 },
+        { label: "GD1[イノベ1年]", id: 10 },
+        { label: "GD2[イノベ2年]", id: 11 },
+        { label: "GD3[イノベ3年]", id: 12 },
+        { label: "GD4[イノベ4年]", id: 13 },
+        { label: "GD5[イノベ5年]", id: 14 },
+        { label: "その他", id: 15 }
+      ],
+      rules: {
+        requied: value => !!value || '入力してください'
+      }
     };
   },
   mounted() {
+    const get_user_detail_url = "/user_details/" + this.$route.params.id;
+    this.$axios.get(get_user_detail_url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) => {
+        console.log(response)
+        this.student_id = response.data.student_id
+        this.grade_id = response.data.grade_id
+        this.department_id = response.data.department_id
+        this.tel = response.data.tel
+      })
     const url = "api/v1/users/show_user_detail/" + this.$route.params.id;
     this.$axios.get(url, {
         headers: {
@@ -319,6 +474,9 @@ export default {
       .then((response) => {
         this.show = response.data
         this.user = response.data.user
+        this.user_id = response.data.user_id
+        this.name = response.data.user.name
+        this.email = response.data.user.email
         this.role_id = response.data.user.role_id
       })
   },
@@ -336,10 +494,10 @@ export default {
         this.role_id = response.data.user.role_id
       })
     },
-    edit_dialog_open: function() {
-      this.edit_dialog = true
+    edit_role_dialog_open: function() {
+      this.edit_role_dialog = true
     },
-    edit: function() {
+    edit_role: function() {
       const edit_url = '/api/v1/update_user/' + this.user.id + '/' + this.role_id
       console.log(edit_url)
       this.$axios.get(edit_url , {
@@ -349,7 +507,26 @@ export default {
       }).then(response => {
         console.log(response)
         this.reload()
-        this.edit_dialog = false
+        this.edit_role_dialog = false
+        this.success_snackbar = true
+      })
+    },
+    edit_user_info: function() {
+      if ( !this.$refs.form.validate() ) return;
+      const edit_user_info_url = '/api/v1/users/edit_user_info'
+      var params = {
+        'user_id': this.user_id,
+        'name': this.name,
+        'student_id': this.student_id,
+        'grade_id': this.grade_id,
+        'department_id': this.department_id,
+        'tel': this.tel,
+        'email': this.email 
+      }
+      console.log(edit_user_info_url)
+      this.$axios.post(edit_user_info_url, params).then(response => {
+        this.reload()
+        this.edit_user_info_dialog = false
         this.success_snackbar = true
       })
     },

--- a/admin_view/nuxt-project/pages/users/_id.vue
+++ b/admin_view/nuxt-project/pages/users/_id.vue
@@ -47,9 +47,22 @@
                       text 
                       v-bind="attrs"
                       v-on="on"
+                      @click="reset_password_dialog = true" 
+                      fab>
+                      <v-icon class="ma-5">mdi-lock-outline</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>パスワード変更</span>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs  }">
+                      <v-btn 
+                      text 
+                      v-bind="attrs"
+                      v-on="on"
                       @click="edit_role_dialog_open" 
                       fab>
-                      <v-icon class="ma-5">mdi-pencil</v-icon>
+                      <v-icon class="ma-5">mdi-star-outline</v-icon>
                     </v-btn>
                   </template>
                   <span>権限編集</span>
@@ -187,7 +200,7 @@
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
           <div style="color: white">
-            <v-icon class="ma-5" dark>mdi-pencil</v-icon>ユーザー情報編集
+            <v-icon class="ma-5" dark>mdi-account-edit-outline</v-icon>ユーザー情報編集
           </div>
           <v-spacer></v-spacer>
           <v-btn text @click="edit_user_info_dialog = false" fab dark>
@@ -260,6 +273,68 @@
       </v-card-actions>
       </v-card>
     </v-dialog> 
+    
+    <!--  パスワード再設定ダイアログ -->
+    <v-dialog
+      v-model="reset_password_dialog"
+      width="500"
+      >
+      <v-card>
+        <v-card-title class="headline blue-grey darken-3">
+          <div style="color: white">
+            <v-icon class="ma-5" dark>mdi-lock-outline</v-icon>パスワード変更
+          </div>
+          <v-spacer></v-spacer>
+          <v-btn text @click="reset_password_dialog = false" fab dark>
+            ​ <v-icon>mdi-close</v-icon>
+          </v-btn>
+      </v-card-title>
+
+      <v-card-text>
+        <v-row>
+          <v-col>
+            <v-form ref="form">
+              <v-text-field
+                label="新しいパスワード"
+                v-model="password"
+                :append-icon="show_pass ? 'mdi-eye-off' : 'mdi-eye'"
+                :rules="[rules.requied, rules.min]"
+                :type="show_pass ? 'password' : 'text'"
+                hint="8文字以上"
+                counter
+                outlined
+                @click:append="show_pass = !show_pass"
+              ></v-text-field>
+              <v-text-field
+                label="新しいパスワードの再入力"
+                v-model="password_confirmation"
+                :append-icon="show_pass_confirmation ? 'mdi-eye-off' : 'mdi-eye'"
+                :rules="[rules.requied, rules.min, rules.match]"
+                :type="show_pass_confirmation ? 'password' : 'text'"
+                hint="8文字以上"
+                counter
+                outlined
+                @click:append="show_pass_confirmation = !show_pass_confirmation"
+              ></v-text-field>
+            </v-form>
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="#78909C"
+          dark
+          @click="reset_password"
+          >
+          変更する
+        </v-btn>
+      </v-card-actions>
+      </v-card>
+    </v-dialog> 
 
 
     <!-- 権限編集ダイアログ -->
@@ -270,7 +345,7 @@
       <v-card>
         <v-card-title class="headline blue-grey darken-3">
           <div style="color: white">
-            <v-icon class="ma-5" dark>mdi-pencil</v-icon>権限編集
+            <v-icon class="ma-5" dark>mdi-star-outline</v-icon>権限編集
           </div>
           <v-spacer></v-spacer>
           <v-btn text @click="edit_role_dialog = false" fab dark>
@@ -386,20 +461,25 @@ export default {
       uid: localStorage.getItem('uid'),
       show: [],
       user: [],
-      name: [],
-      student_id: [],
-      tel: [],      
-      email: [],
       user_id: [],
+      name: [],
+      email: [],
+      password: [],
+      password_confirmation: [],
       role_id: [],
       role: [],
+      tel: [],      
+      student_id: [],
       grade_id: [],
       department_id: [],
       detail: [],
       group_categories:[],
       fes_years:[],
       expand: false,
+      show_pass: true,
+      show_pass_confirmation: true,
       edit_user_info_dialog: false,
+      reset_password_dialog: false,
       edit_role_dialog: false,
       delete_dialog: false,
       items_role:[
@@ -447,7 +527,9 @@ export default {
         { label: "その他", id: 15 }
       ],
       rules: {
-        requied: value => !!value || '入力してください'
+        requied: value => !!value || '入力してください',
+        min: v => v.length >= 8 || '８文字未満です',
+        match: v => v === this.password || 'パスワードと再確認パスワードが一致していません',
       }
     };
   },
@@ -523,10 +605,23 @@ export default {
         'tel': this.tel,
         'email': this.email 
       }
-      console.log(edit_user_info_url)
       this.$axios.post(edit_user_info_url, params).then(response => {
         this.reload()
         this.edit_user_info_dialog = false
+        this.success_snackbar = true
+      })
+    },
+    reset_password: function() {
+      if ( !this.$refs.form.validate() ) return;
+      const reset_password_url = '/api/v1/users/reset_password'
+      var params = {
+        'user_id': this.user_id,
+        'password': this.password,
+        'password_confirmation': this.password_confirmation
+      }
+      this.$axios.post(reset_password_url, params).then(response => {
+        this.reload()
+        this.reset_password_dialog = false
         this.success_snackbar = true
       })
     },

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -92,8 +92,20 @@ class Api::V1::UsersController < ApplicationController
     @user_detail.save!
   end
 
+  def reset_password
+    @user = User.find(reset_password_params[:user_id])
+    @user.password = reset_password_params[:password]
+    @user.password_confirmation = reset_password_params[:password_confirmation]
+    @user.save!
+  end
+
   private
+  
     def edit_user_info_params
       params.permit(:user_id, :name, :student_id, :grade_id, :department_id, :tel, :email)
+    end
+
+    def reset_password_params
+      params.permit(:user_id, :password, :password_confirmation)
     end
 end

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -79,4 +79,21 @@ class Api::V1::UsersController < ApplicationController
     render json: user_detail
   end
 
+  def edit_user_info
+    @user = User.find(edit_user_info_params[:user_id])
+    @user_detail = @user.user_detail
+    @user.name = edit_user_info_params[:name] 
+    @user.email = edit_user_info_params[:email] 
+    @user_detail.student_id = edit_user_info_params[:student_id] 
+    @user_detail.grade_id = edit_user_info_params[:grade_id] 
+    @user_detail.department_id = edit_user_info_params[:department_id] 
+    @user_detail.tel = edit_user_info_params[:tel] 
+    @user.save!
+    @user_detail.save!
+  end
+
+  private
+    def edit_user_info_params
+      params.permit(:user_id, :name, :student_id, :grade_id, :department_id, :tel, :email)
+    end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
       get "users/show_user_detail/:id" => "users#show_user_detail"
       get "users/get_user_detail" => "users#get_user_detail"
       get "update_user/:id/:role_id" => "users#update"
+      post "users/edit_user_info" => "users#edit_user_info"
       # 副代表周り
       get "get_sub_rep_details/:id" => "sub_rep_api#get_sub_rep_details"
       # 現在のユーザーについて

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       get "users/get_user_detail" => "users#get_user_detail"
       get "update_user/:id/:role_id" => "users#update"
       post "users/edit_user_info" => "users#edit_user_info"
+      post "users/reset_password" => "users#reset_password"
       # 副代表周り
       get "get_sub_rep_details/:id" => "sub_rep_api#get_sub_rep_details"
       # 現在のユーザーについて


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #449 

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面でのユーザーの情報とパスワードを編集できるようにした．
ログインしているユーザーの情報は，カレントユーザー用の変更ページを作成するため，編集できないようにした．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- `admin_view/nuxt-project/pages/users/_id.vue`
- `api/app/controllers/api/v1/users_controller.rb`
- `api/config/routes.rb`

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `http"//localhost:8000/users`
スクリーンショット
![image](https://user-images.githubusercontent.com/52201107/113514011-3bc86d00-95a7-11eb-9728-543a771cb260.png)
![image](https://user-images.githubusercontent.com/52201107/113514019-46830200-95a7-11eb-85b1-7248edd976f8.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- それぞれ情報が変更されるかを確認
-
-

# 備考
roleによる条件分岐はさせていない．