### PR TITLE
[管理者画面]v-mainとMenuコンポーネントの余白調整 Dev/issue453

### DIFF
--- a/admin_view/nuxt-project/components/Header.vue
+++ b/admin_view/nuxt-project/components/Header.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
-    <v-row>
-      <v-app-bar app dark dense color="#424242">
+      <v-app-bar
+        app
+        clipped-left
+        dark 
+        dense 
+        color="#424242"
+      >
         <v-toolbar-title><v-btn text to="/dashboard" color="#424242"><div style="color:white">参加団体管理アプリ-管理者ページ</div></v-btn></v-toolbar-title>
         <v-spacer></v-spacer>
         <v-btn text to="/dashboard" color="#424242">
@@ -75,7 +80,6 @@
           </v-list>
         </div>
       </v-navigation-drawer>
-    </v-row>
   </div>
 </template>
 

--- a/admin_view/nuxt-project/components/ItemOrders.vue
+++ b/admin_view/nuxt-project/components/ItemOrders.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
-    <div class="card">
-      <v-card flat>
+      <v-card flat class="mr-15">
         <v-row> 
           <v-col cols=1></v-col>
           <v-col cols=10>

--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -1,13 +1,12 @@
 <template>
     <v-navigation-drawer
       v-model="drawer"
-      absolute
+      app
+      fixed
+      clipped
       permanent
       color="#37474F"
       >
-      <!-- ヘッダーと重ならないようにする -->
-      <v-list-item dark>
-      </v-list-item>
       <v-list-item dark style="background-color:#bf794e">
         <v-list-item-avatar rounded class="mx-auto" width="55" height="55">
           <v-img :src="icon_src"></v-img>
@@ -32,9 +31,9 @@
         </v-list-item>
       </v-list>
 
-      <v-list-item dark style="background-color:#81D4FA">
-        <v-list-item-content>
-          <v-list-item-title><div style="color:#333333"><b>一覧情報</b></div></v-list-item-title>
+      <v-list-item dark style="background-color:#FFFFFF">
+        <v-list-item-content class="#FFFFFF">
+          <v-list-item-title><div style="color:#37474F"><b>一覧情報</b></div></v-list-item-title>
         </v-list-item-content>
       </v-list-item>
 
@@ -56,9 +55,9 @@
         </v-list-item>
       </v-list>
 
-      <v-list-item dark style="background-color:#81D4FA">
+      <v-list-item dark style="background-color:#FFFFFF">
         <v-list-item-content>
-          <v-list-item-title><div style="color:#333333"><b>申請情報</b></div></v-list-item-title>
+          <v-list-item-title><div style="color:#37474F"><b>申請情報</b></div></v-list-item-title>
         </v-list-item-content>
       </v-list-item>
       
@@ -80,9 +79,9 @@
         </v-list-item>
       </v-list>
 
-      <v-list-item dark style="background-color:#81D4FA">
+      <v-list-item dark style="background-color:#FFFFFF">
         <v-list-item-content>
-          <v-list-item-title><div style="color:#333333"><b>操作</b></div></v-list-item-title>
+          <v-list-item-title><div style="color:#37474F"><b>操作</b></div></v-list-item-title>
         </v-list-item-content>
       </v-list-item>
 
@@ -104,7 +103,6 @@
         </v-list-item>
       </v-list>
     </v-navigation-drawer>
-  </div>
 </template>
 <script>
 import axios from 'axios' 

--- a/admin_view/nuxt-project/components/Update.vue
+++ b/admin_view/nuxt-project/components/Update.vue
@@ -1,6 +1,5 @@
 <template>
-    <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
             <v-row>
                 <v-col cols=1></v-col>
                 <v-col>
@@ -14,7 +13,6 @@
                 <v-col cols=1></v-col>
             </v-row>
         </v-card>
-    </div>
 </template>
 <script>
 export default {

--- a/admin_view/nuxt-project/layouts/default.vue
+++ b/admin_view/nuxt-project/layouts/default.vue
@@ -1,20 +1,12 @@
 <template>
-  <v-app dark :style="{ background: $vuetify.theme.themes.light.background }">
+  <v-app :style="{ background: $vuetify.theme.themes.light.background }">
+    <Menu v-if="main && print" />
     <Header v-if="main && print" />
-      <div class="pad-bottom">
-        <v-row>
-          <v-col cols="2" v-if="main && print">
-            <Menu/>
-          </v-col>
-          <v-col cols=10>
-            <v-main>
-              <transition mode='in-out'>
-              <nuxt />
-              </transition>
-            </v-main>
-          </v-col>
-        </v-row>
-      </div>
+    <v-main fluid>
+    <transition mode='in-out'>
+          <nuxt />
+    </transition>
+    </v-main>
   </v-app>
 </template>
 

--- a/admin_view/nuxt-project/pages/assign_items/_id.vue
+++ b/admin_view/nuxt-project/pages/assign_items/_id.vue
@@ -19,8 +19,7 @@
       <v-col cols=6>
         <v-row>
           <v-col>
-            <div class="card">
-              <v-card flat>
+              <v-card flat class="ml-15">
                 <v-row>
                   <v-col cols=1></v-col>
                   <v-col cols=10>
@@ -72,13 +71,11 @@
                   <v-col cols=1></v-col>
                 </v-row>
               </v-card>
-            </div>
           </v-col>
         </v-row>
         <v-row>
           <v-col>
-            <div class="card">
-              <v-card flat>
+              <v-card flat class="ml-15">
                 <v-row>
                   <v-col cols=1></v-col>
                   <v-col cols=10>
@@ -130,7 +127,6 @@
                   <v-col cols=1></v-col>
                 </v-row>
               </v-card>
-            </div>
           </v-col>
         </v-row>
       </v-col>

--- a/admin_view/nuxt-project/pages/assign_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_items/index.vue
@@ -1,9 +1,8 @@
 <template>
   <div> 
-    <div class="card"> 
       <v-row>
         <v-col>
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols=1></v-col>
               <v-col cols=10>
@@ -24,7 +23,6 @@
           </v-card>
         </v-col>
       </v-row>
-    </div>
     <div class="text-center" v-if="stocker_places.length === 0">
       <br><br>
       <v-progress-circular
@@ -33,8 +31,7 @@
         ></v-progress-circular>
       <br><br>
     </div>
-    <div v-else style="padding-right:5%; padding-left:1%">
-      <v-row>
+      <v-row class="mx-15" align="center" justify="center">
         <v-col v-for="stocker_place in stocker_places">
           <v-hover v-slot:default="{ hover }">
             <v-card 
@@ -65,7 +62,6 @@
           </v-hover>
         </v-col>
       </v-row>
-    </div>
   </div>
 </template>
 

--- a/admin_view/nuxt-project/pages/assign_rental_items/_id.vue
+++ b/admin_view/nuxt-project/pages/assign_rental_items/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -94,7 +93,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/assign_rental_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_rental_items/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-      <v-card flat>
+      <v-card flat class="mx-15">
         <v-row>
           <v-col cols="1"></v-col>
           <v-col cols="10">
@@ -145,7 +144,6 @@
           <v-col cols="1"></v-col>
         </v-row>
       </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/dashboard.vue
+++ b/admin_view/nuxt-project/pages/dashboard.vue
@@ -1,9 +1,8 @@
 <template>
   <div>
-    <v-row>
+     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+         <v-card flat class="mx-15 ">
             <v-container>
               <v-row>
                 <v-col cols="1"></v-col>
@@ -72,7 +71,6 @@
               </v-row>
             </v-container>
           </v-card>
-        </div>
       </v-col>
     </v-row>
     <v-row>
@@ -85,6 +83,7 @@
         <div>
           <v-card
             flat
+            class="ml-15"
             :to="{
               name: 'groups',
             }"
@@ -113,9 +112,9 @@
         </div>
       </v-col>
       <v-col>
-        <div style="padding-right:10%">
           <v-card 
              flat
+             class="mr-15"
              :to="{
                   name: 'users'
                   }"
@@ -146,6 +145,7 @@
           <br>
           <v-card
             flat
+            class="mr-15"
             :to="{
               name: 'assign_items',
             }"
@@ -176,7 +176,6 @@
               </v-row>
             </v-container>
           </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/employees/_id.vue
+++ b/admin_view/nuxt-project/pages/employees/_id.vue
@@ -20,8 +20,7 @@
     </v-row>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10"> 
@@ -88,7 +87,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/employees/index.vue
+++ b/admin_view/nuxt-project/pages/employees/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-      <v-card flat>
+      <v-card flat class="mx-15">
         <v-row>
           <v-col cols="1"></v-col>
           <v-col cols="10">
@@ -142,7 +141,6 @@
           <v-col cols="1"></v-col>
         </v-row>
       </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/fes_dates/_id.vue
+++ b/admin_view/nuxt-project/pages/fes_dates/_id.vue
@@ -6,7 +6,6 @@
     <div v-else>
     <v-row>
       <v-col>
-        <div class="card">
           <v-card-text>
             <div class="breadcrumbs">
               <ul>
@@ -15,7 +14,7 @@
               </ul>
             </div>
           </v-card-text>
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10"> 
@@ -87,7 +86,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/fes_dates/index.vue
+++ b/admin_view/nuxt-project/pages/fes_dates/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -152,7 +151,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/fes_years/_id.vue
+++ b/admin_view/nuxt-project/pages/fes_years/_id.vue
@@ -6,7 +6,6 @@
     <div v-else>
     <v-row>
       <v-col>
-        <div class="card">
           <v-card-text>
             <div class="breadcrumbs">
               <ul>
@@ -15,7 +14,7 @@
               </ul>
             </div>
           </v-card-text>
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10"> 
@@ -75,7 +74,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/fes_years/index.vue
+++ b/admin_view/nuxt-project/pages/fes_years/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -126,7 +125,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/food_products/_id.vue
+++ b/admin_view/nuxt-project/pages/food_products/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10"> 
@@ -97,7 +96,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/food_products/index.vue
+++ b/admin_view/nuxt-project/pages/food_products/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -167,7 +166,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/groups/_id.vue
+++ b/admin_view/nuxt-project/pages/groups/_id.vue
@@ -16,7 +16,6 @@
   <div v-else>
     <v-row>
       <v-col>
-        <div class="card">
           <v-card-text>
             <div class="breadcrumbs">
               <ul>
@@ -31,7 +30,7 @@
               </ul>
             </div>
           </v-card-text>
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -163,7 +162,7 @@
           <br />
           <v-row>
             <v-col cols=6>
-              <v-card flat>
+              <v-card flat class="ml-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -190,7 +189,7 @@
               </v-card>
             </v-col>
              <v-col cols=6>
-              <v-card flat>
+              <v-card flat class="mr-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -239,7 +238,7 @@
           <br>
           <v-row>
             <v-col cols="6">
-              <v-card flat　:to="{ name: 'power_orders'}">
+              <v-card flat class="ml-15" :to="{ name: 'power_orders'}">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -270,7 +269,7 @@
               </v-card>
             </v-col>
             <v-col cols="6">
-              <v-card flat>
+              <v-card flat class="mr-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -304,7 +303,7 @@
           <br />
           <v-row v-if="groupCategoryId === 3">
             <v-col cols="6">
-              <v-card flat>
+              <v-card flat class="ml-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -379,7 +378,7 @@
               </v-card>
             </v-col>
             <v-col cols="6">
-              <v-card flat>
+              <v-card flat class="mr-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -445,7 +444,7 @@
           <br />
           <v-row v-if="groupCategoryId !== 3">
             <v-col>
-              <v-card flat>
+              <v-card flat class="ml-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -485,7 +484,7 @@
               </v-card>
             </v-col>
             <v-col cols="6">
-              <v-card flat>
+              <v-card flat class="mr-15">
                 <v-row>
                   <v-col cols="1"></v-col>
                   <v-col cols="10">
@@ -512,7 +511,6 @@
               </v-card>
             </v-col>
           </v-row>
-        </div>
       </v-col>
     </v-row>
     <v-row>

--- a/admin_view/nuxt-project/pages/groups/index.vue
+++ b/admin_view/nuxt-project/pages/groups/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -194,7 +193,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/index.vue
+++ b/admin_view/nuxt-project/pages/index.vue
@@ -1,7 +1,9 @@
 <template>
-  <v-row>
-    <v-col>
-      <div class="login-card">
+  <div class="login-card">
+  <v-container fill-height fluid>
+  <v-row justify="center" align="center">
+    <v-col cols=1></v-col>
+    <v-col cols=10 align-self="auto">
         <v-card flat>
           <v-row align="center">
             <v-col cols="5">
@@ -92,9 +94,11 @@
             </v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
+    <v-col cols=1></v-col>
   </v-row>
+</v-container>
+  </div>
 </template>
 
 <script>
@@ -168,7 +172,9 @@ export default {
 <style scoped>
 .login-card {
   padding-top: 5%;
-  padding-left: 20%;
+  padding-left: 10%;
+  padding-right: 10%;
+  padding-bottom: 5%;
 }
 .grey-title {
   color: #424242;

--- a/admin_view/nuxt-project/pages/news/_id.vue
+++ b/admin_view/nuxt-project/pages/news/_id.vue
@@ -6,7 +6,6 @@
     <div v-else>  
     <v-row>
       <v-col>
-        <div class="card">
           <v-card-text>
             <div class="breadcrumbs">
               <ul>
@@ -15,7 +14,7 @@
               </ul>
             </div>
           </v-card-text>
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10"> 
@@ -79,7 +78,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/news/index.vue
+++ b/admin_view/nuxt-project/pages/news/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -140,7 +139,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/place_allow_lists/_id.vue
+++ b/admin_view/nuxt-project/pages/place_allow_lists/_id.vue
@@ -20,8 +20,7 @@
     </v-row>
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -103,14 +102,12 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 
     <v-row v-for="group in groups" :key="group.id">
       <v-col>
-        <div class="card">
-          <v-card flat v-if="group.user_id === user.id">
+          <v-card flat class="mx-15" v-if="group.user_id === user.id">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -150,7 +147,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/place_allow_lists/index.vue
+++ b/admin_view/nuxt-project/pages/place_allow_lists/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -150,7 +149,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/place_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/place_orders/_id.vue
@@ -22,8 +22,7 @@
     </v-row>
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -112,7 +111,6 @@
               <v-col cols="1"></v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/place_orders/index.vue
+++ b/admin_view/nuxt-project/pages/place_orders/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -159,7 +158,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/places/_id.vue
+++ b/admin_view/nuxt-project/pages/places/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -88,14 +87,12 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 
     <v-row v-for="group in groups" :key="group.id">
       <v-col>
-        <div class="card">
-          <v-card flat v-if="group.user_id === user.id">
+          <v-card flat class="mx-15" v-if="group.user_id === user.id">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -135,7 +132,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/places/index.vue
+++ b/admin_view/nuxt-project/pages/places/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -119,7 +118,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/power_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/power_orders/_id.vue
@@ -17,8 +17,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10"> 
@@ -101,7 +100,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/power_orders/index.vue
+++ b/admin_view/nuxt-project/pages/power_orders/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -169,7 +168,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/print/index.vue
+++ b/admin_view/nuxt-project/pages/print/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -31,7 +30,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/project_names/_id.vue
+++ b/admin_view/nuxt-project/pages/project_names/_id.vue
@@ -2,7 +2,6 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
         <v-card-text>
           <div class="breadcrumbs">
             <ul>
@@ -11,7 +10,7 @@
             </ul>
           </div>
           </v-card-text>
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10"> 
@@ -75,7 +74,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/project_names/index.vue
+++ b/admin_view/nuxt-project/pages/project_names/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -44,7 +43,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/purchase_lists/_id.vue
+++ b/admin_view/nuxt-project/pages/purchase_lists/_id.vue
@@ -23,8 +23,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -142,7 +141,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/purchase_lists/index.vue
+++ b/admin_view/nuxt-project/pages/purchase_lists/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-      <v-card flat>
+      <v-card flat class="mx-15">
         <v-row>
           <v-col cols="1"></v-col>
           <v-col cols="10">
@@ -178,7 +177,6 @@
           <v-col cols="1"></v-col>
         </v-row>
       </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/rental_item_allow_lists/_id.vue
+++ b/admin_view/nuxt-project/pages/rental_item_allow_lists/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -97,7 +96,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_allow_lists/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -189,7 +188,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/rental_items/_id.vue
+++ b/admin_view/nuxt-project/pages/rental_items/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card" >
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -99,14 +98,12 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 
     <v-row v-for="group in groups" :key="group.id">
       <v-col>
-        <div class="card">
-          <v-card flat v-if="group.user_id === user.id">
+          <v-card flat class="mx-15" v-if="group.user_id === user.id">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -146,7 +143,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/rental_items/index.vue
+++ b/admin_view/nuxt-project/pages/rental_items/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-      <v-card flat>
+      <v-card flat class="mx-15">
         <v-row>
           <v-col cols="1"></v-col>
           <v-col cols="10">
@@ -132,7 +131,6 @@
           <v-col cols="1"></v-col>
         </v-row>
       </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>j

--- a/admin_view/nuxt-project/pages/rental_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/rental_orders/_id.vue
@@ -17,8 +17,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10"> 
@@ -89,7 +88,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/rental_orders/index.vue
+++ b/admin_view/nuxt-project/pages/rental_orders/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -144,7 +143,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/shops/_id.vue
+++ b/admin_view/nuxt-project/pages/shops/_id.vue
@@ -6,7 +6,6 @@
     <div v-else>
     <v-row>
       <v-col>
-        <div class="card">
           <v-card-text>
             <div class="breadcrumbs">
               <ul>
@@ -15,7 +14,7 @@
               </ul>
             </div>
           </v-card-text>
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10"> 
@@ -89,7 +88,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/shops/index.vue
+++ b/admin_view/nuxt-project/pages/shops/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -144,7 +143,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/signup.vue
+++ b/admin_view/nuxt-project/pages/signup.vue
@@ -110,7 +110,7 @@ export default {
 
 <style>
 .signup-card {
-  padding-top: 5%;
-  padding-left: 20%;
+  padding-left: 10%;
+  padding-right: 10%;
 }
 </style>

--- a/admin_view/nuxt-project/pages/stage_common_options/_id.vue
+++ b/admin_view/nuxt-project/pages/stage_common_options/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -110,7 +109,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/stage_common_options/index.vue
+++ b/admin_view/nuxt-project/pages/stage_common_options/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -266,7 +265,6 @@
               <v-col cols="1"></v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/stage_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/_id.vue
@@ -17,8 +17,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10"> 
@@ -128,7 +127,6 @@
               <v-col cols="1"></v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/stage_orders/index.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -240,7 +239,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/stages/_id.vue
+++ b/admin_view/nuxt-project/pages/stages/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -94,7 +93,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/stages/index.vue
+++ b/admin_view/nuxt-project/pages/stages/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -145,7 +144,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/stocker_items/_id.vue
+++ b/admin_view/nuxt-project/pages/stocker_items/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -98,7 +97,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/stocker_items/index.vue
+++ b/admin_view/nuxt-project/pages/stocker_items/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -157,7 +156,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/stocker_places/_id.vue
+++ b/admin_view/nuxt-project/pages/stocker_places/_id.vue
@@ -21,8 +21,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -102,7 +101,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/stocker_places/index.vue
+++ b/admin_view/nuxt-project/pages/stocker_places/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -161,7 +160,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/sub_reps/_id.vue
+++ b/admin_view/nuxt-project/pages/sub_reps/_id.vue
@@ -6,7 +6,6 @@
     <div v-else>
     <v-row>
       <v-col>
-        <div class="card">
         <v-card-text>
           <div class="breadcrumbs">
             <ul>
@@ -15,7 +14,7 @@
             </ul>
           </div>
           </v-card-text>
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10"> 
@@ -94,7 +93,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-        </div>
       </v-col>
     </v-row>
     </div>

--- a/admin_view/nuxt-project/pages/sub_reps/index.vue
+++ b/admin_view/nuxt-project/pages/sub_reps/index.vue
@@ -2,8 +2,7 @@
   <div>
     <v-row>
       <v-col>
-        <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -187,7 +186,6 @@
               <v-col cols="1"></v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
   </div>

--- a/admin_view/nuxt-project/pages/user_page_setting/index.vue
+++ b/admin_view/nuxt-project/pages/user_page_setting/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -520,7 +519,6 @@
           <v-col cols=1></v-col>
         </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
 </template>

--- a/admin_view/nuxt-project/pages/users/_id.vue
+++ b/admin_view/nuxt-project/pages/users/_id.vue
@@ -17,8 +17,7 @@
 
     <v-row>
       <v-col>
-        <div class="card">
-          <v-card flat>
+          <v-card flat class="mx-15">
             <v-row>
               <v-col cols="1"></v-col>
               <v-col cols="10">
@@ -123,7 +122,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 
@@ -132,8 +130,9 @@
     :key="i"
     >
       <v-col>
-        <div class="card">
-          <v-card flat
+          <v-card 
+              flat
+              class="mx-15"
               :to="{
               name: 'groups-id',
               params:{
@@ -180,7 +179,6 @@
               </v-col>
             </v-row>
           </v-card>
-        </div>
       </v-col>
     </v-row>
 

--- a/admin_view/nuxt-project/pages/users/index.vue
+++ b/admin_view/nuxt-project/pages/users/index.vue
@@ -1,8 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <div class="card">
-        <v-card flat>
+        <v-card flat class="mx-15">
           <v-row>
             <v-col cols="1"></v-col>
             <v-col cols="10">
@@ -63,7 +62,6 @@
             <v-col cols="1"></v-col>
           </v-row>
         </v-card>
-      </div>
     </v-col>
   </v-row>
   </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #453 

# 概要
<!-- 開発内容の概要を記載 -->
`v-main`とMenuコンポーネントが表示倍率によっては重なって表示されるので直しました．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- group-manager-2/admin_view/nuxt-project/components/*
- group-manager-2/admin_view/nuxt-project/pages/*
- group-manager-2/admin_view/nuxt-project/layouts/default.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
