### PR TITLE
[fix]パスワードリセットのモバイル対応(#525)

### DIFF
--- a/view/vue-project/src/components/Mobile/Header.vue
+++ b/view/vue-project/src/components/Mobile/Header.vue
@@ -43,7 +43,7 @@
                     </v-list-item-title>
                   </v-list-item-content>
                 </v-list-item>
-                <v-list-item to="/password_reset">
+                <v-list-item to="/mobile_password_reset">
                   <v-list-item-content>
                     <v-list-item-title class="font-weight-bold">
                       <v-icon class="pr-2" size="30">mdi-lock-reset</v-icon

--- a/view/vue-project/src/router/index.js
+++ b/view/vue-project/src/router/index.js
@@ -18,6 +18,7 @@ import EditUserInfo from "../views/edit_user_info.vue";
 import PasswordReset from "../views/password_reset.vue";
 import MobileWelcome from "../views/Mobile/Welcome.vue"
 import MobileMypage from "../views/Mobile/Mypage.vue"
+import MobilePasswordReset from "../views/Mobile/password_reset.vue";
 
 Vue.use(VueRouter);
 
@@ -107,6 +108,11 @@ const routes = [
     path: "/mobile_mypage",
     name: "MobileMypage",
     component: MobileMypage,
+  },
+  {
+    path: "/mobile_password_reset",
+    name: "MobilePasswordReset",
+    component: MobilePasswordReset,
   },
 ];
 

--- a/view/vue-project/src/views/Mobile/password_reset.vue
+++ b/view/vue-project/src/views/Mobile/password_reset.vue
@@ -1,119 +1,115 @@
 <template>
-  <v-row justify="center">
-    <v-col cols="2"></v-col>
-    <v-col cols="8">
-      <v-card flat>
-        <v-container class="justify-content-center">
-          <v-row>
-            <v-col cols="2"></v-col>
-            <v-col cols="8" align="center">
-              <v-card-title class="justify-center">
-                <h1 style="color:#333333">パスワード再設定</h1>
-              </v-card-title>
-                <br>
-                <v-divider></v-divider>
-                <br>
-              <v-card-text>
-                <v-form ref="form">
-                  <v-text-field
-                    label="パスワード"
-                    ref="password"
-                    outlined
-                    v-model="password"
-                    :append-icon="show_pass ? 'mdi-eye-off' : 'mdi-eye'"
-                    :rules="[rules.requied, rules.min]"
-                    :type="show_pass ? 'password' : 'text'"
-                    hint="8文字以上"
-                    counter
-                    @click:append="show_pass = !show_pass"
-                    required
-                  ></v-text-field>
-                  <v-text-field
-                    label="パスワードの再入力"
-                    outlined
-                    ref="password_confirmation"
-                    v-model="password_confirmation"
-                    :append-icon="show_pass_confirmation ? 'mdi-eye-off' : 'mdi-eye'"
-                    :rules="[rules.requied, rules.min, rules.match]"
-                    :type="show_pass_confirmation ? 'password' : 'text'"
-                    hint="8文字以上"
-                    counter
-                    @click:append="show_pass_confirmation = !show_pass_confirmation"
-                    required
-                  ></v-text-field>
-                </v-form>
-              </v-card-text>
-              <v-card-action>
-                <v-btn color="btn" rounded depressed dark block @click="submit">変更登録</v-btn>
-                <v-btn color="btn" text block rounded to="/mypage">マイページに戻る</v-btn>
-              </v-card-action>
-            </v-col>
-            <v-col cols="2"></v-col>
-          </v-row>
-        </v-container>
-      </v-card>
-    </v-col>
-    <v-col cols="2"></v-col>
-  </v-row>
+  <v-card flat>
+    <v-container class="justify-content-center">
+      <v-card-title class="justify-center">
+        <h1 style="color: #333333">パスワード<br /><br />再設定</h1>
+      </v-card-title>
+      <br />
+      <v-divider></v-divider>
+      <br />
+      <v-card-text>
+        <v-form ref="form">
+          <v-text-field
+            label="パスワード"
+            ref="password"
+            outlined
+            v-model="password"
+            :append-icon="show_pass ? 'mdi-eye-off' : 'mdi-eye'"
+            :rules="[rules.requied, rules.min]"
+            :type="show_pass ? 'password' : 'text'"
+            hint="8文字以上"
+            counter
+            @click:append="show_pass = !show_pass"
+            required
+          ></v-text-field>
+          <v-text-field
+            label="パスワードの再入力"
+            outlined
+            ref="password_confirmation"
+            v-model="password_confirmation"
+            :append-icon="show_pass_confirmation ? 'mdi-eye-off' : 'mdi-eye'"
+            :rules="[rules.requied, rules.min, rules.match]"
+            :type="show_pass_confirmation ? 'password' : 'text'"
+            hint="8文字以上"
+            counter
+            @click:append="show_pass_confirmation = !show_pass_confirmation"
+            required
+          ></v-text-field>
+        </v-form>
+      </v-card-text>
+      <v-card-action>
+        <v-btn color="btn" rounded depressed dark block @click="submit"
+          >変更登録</v-btn
+        >
+        <v-btn color="btn" text block rounded to="/mypage"
+          >マイページに戻る</v-btn
+        >
+      </v-card-action>
+    </v-container>
+  </v-card>
 </template>
 
 <script>
-
-import axios from 'axios'
+import axios from "axios";
 export default {
-  data () {
+  data() {
     return {
       show_pass: true,
       show_pass_confirmation: true,
       rules: {
-        requied: value => !!value || '入力してください',
-        min: v => v.length >= 8 || '８文字未満です',
-        match: v => v === this.password || 'パスワードと再確認パスワードが一致していません',
+        requied: (value) => !!value || "入力してください",
+        min: (v) => v.length >= 8 || "８文字未満です",
+        match: (v) =>
+          v === this.password ||
+          "パスワードと再確認パスワードが一致していません",
       },
-      message: '',
+      message: "",
       warnStyle: {
-        color: '#F44336'
+        color: "#F44336",
       },
       password: null,
-      password_confirmation: null
-    }
+      password_confirmation: null,
+    };
   },
-  computed: {
-  },
+  computed: {},
   methods: {
-    cancel: function() {
+    cancel: function () {
       this.$refs.form.reset();
     },
-    submit: function() {
-      if ( !this.$refs.form.validate() ) return;
+    submit: function () {
+      if (!this.$refs.form.validate()) return;
 
-      const url = process.env.VUE_APP_URL + '/api/v1/current_user/password_reset'
+      const url =
+        process.env.VUE_APP_URL + "/api/v1/current_user/password_reset";
 
-      axios.post(url, {
-          'password' : this.password,
-          'password_confirmation' : this.password_confirmation
-        }, {
-          headers: {
-            'Content-Type': 'application/json',
-            'access-token': localStorage.getItem('access-token'),
-            'client': localStorage.getItem('client'),
-            'uid': localStorage.getItem('uid')
+      axios
+        .post(
+          url,
+          {
+            password: this.password,
+            password_confirmation: this.password_confirmation,
+          },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              "access-token": localStorage.getItem("access-token"),
+              client: localStorage.getItem("client"),
+              uid: localStorage.getItem("uid"),
+            },
           }
-        }
-      ).then(
-        (response) => {
-          console.log('response:', response)
-          this.$router.push('MyPage')
-        },
-        (error) => {
-          console.log('登録できませんでした')
-          return error;
-        }
-      )
+        )
+        .then(
+          (response) => {
+            console.log("response:", response);
+            this.$router.push("MyPage");
+          },
+          (error) => {
+            console.log("登録できませんでした");
+            return error;
+          }
+        );
     },
   },
-  mounted() {
-  },
-}
-
+  mounted() {},
+};
 </script>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #525 

# 概要
<!-- 開発内容の概要を記載 -->
ヘッダーから遷移するパスワードリセットのモバイル対応を行った

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- view/vue-project/src/components/Mobile/Header.vue
- view/vue-project/src/router/index.js
- view/vue-project/src/views/Mobile/password_reset.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `localhost:8080/mobile_password_reset`
スクリーンショット
![image](https://user-images.githubusercontent.com/71711872/120348143-ddfe9a00-c337-11eb-8b2a-35e57d1a3afb.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- ヘッダーのアイコンからモバイルのパスワードリセット画面に遷移できるか
- パスワードリセット画面がモバイル対応になっているか
- パスワードの再設定ができるか

# 備考
