### PR TITLE
団体ごとの識別番号を付ける機能と会場割り当て機能の追加

### DIFF
--- a/api/app/controllers/group_identification_controller.rb
+++ b/api/app/controllers/group_identification_controller.rb
@@ -1,0 +1,33 @@
+class GroupIdentificationController < ApplicationController
+  before_action :set_group_identification, only: [:update, :destroy]
+
+  def create
+    @group_identification = GroupIdentification.create(group_identification_params)
+    render json: fmt(created, @group_identification)
+  end
+
+  def update
+    @group_identification.update(group_identification_params)
+    render json: fmt(ok, @group_identification, "Updated group_identification id = "+params[:id])
+  end
+
+  def destroy
+    @group_identification.destroy
+    render json: fmt(ok, [], "Deleted group_identification id = "+params[:id])
+  end
+
+  private
+
+  def set_group_identification
+    if GroupIdentification.exists?(params[:id])
+      @group_identification = GroupIdentification.find(params[:id])
+    else
+      render json: fmt(not_found, [], "Not found group_identification = "+params[:id])
+    end
+  end
+
+  def group_identification_params
+    params.permit(:group_id, :number)
+  end
+
+end

--- a/api/app/controllers/place_number_controller.rb
+++ b/api/app/controllers/place_number_controller.rb
@@ -1,0 +1,40 @@
+class PlaceNumberController < ApplicationController
+  before_action :set_place_number, only: [:show, :update, :destroy]
+
+  # 会場割り当て
+  
+  def index
+  end
+
+  def show
+  end
+
+  def create
+    @place_number = PlaceNumber.create(place_number_params)
+    render json: fmt(created, @place_number)
+  end
+
+  def update
+    @place_number.update(place_number_params)
+    render json: fmt(ok, @place_number, "Updated place_number id ="+params[:id])
+  end
+
+  def destroy
+    @place_number.destroy
+    render json: fmt(ok, [], "Deleted place_number id ="+params[:id])
+  end
+
+  private
+
+  def set_place_number
+    if PlaceNumber.exists?(params[:id])
+      @place_number = PlaceNumber.find(params[:id])
+    else
+      render json: fmt(not_found, [], "Not found place_number id = "+params[:id])
+    end
+  end
+
+  def place_number_params
+    params.permit(:place_id, :group_identification_id)
+  end
+end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -11,6 +11,7 @@ class Group < ApplicationRecord
     has_many :food_products, dependent: :destroy
     has_many :rental_orders, dependent: :destroy
     has_many :assign_rental_items, dependent: :destroy
+    has_one :group_identification, dependent: :destroy
 
     ### group_category (参加団体カテゴリ)
     

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -290,4 +290,14 @@ class Group < ApplicationRecord
         }
     end
 
+    # 割り当てられた会場を取得
+    def place
+      return self.group_identification.place_number.place
+    end
+
+    # 識別番号取得
+    def number
+      return self.group_identification.number
+    end
+
 end

--- a/api/app/models/group_identification.rb
+++ b/api/app/models/group_identification.rb
@@ -1,3 +1,4 @@
 class GroupIdentification < ApplicationRecord
   belongs_to :group
+  has_one :place_number
 end

--- a/api/app/models/group_identification.rb
+++ b/api/app/models/group_identification.rb
@@ -1,0 +1,3 @@
+class GroupIdentification < ApplicationRecord
+  belongs_to :group
+end

--- a/api/app/models/place.rb
+++ b/api/app/models/place.rb
@@ -1,8 +1,14 @@
 class Place < ApplicationRecord
     has_many :assign_group_places
     has_many :place_allow_lists
+    has_many :place_numbers
 
     def to_name
       return self.name
+    end
+
+    # その会場の参加団体を取得する
+    def groups
+      return self.place_numbers.preload(:group_identification).map{ |place_number| place_number.group_identification.group }
     end
 end

--- a/api/app/models/place_number.rb
+++ b/api/app/models/place_number.rb
@@ -1,0 +1,4 @@
+class PlaceNumber < ApplicationRecord
+  belongs_to :place
+  belongs_to :group_identification
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,8 +1,17 @@
 Rails.application.routes.draw do
 
+  # 識別番号
   post 'group_identification' => "group_identification#create"
   put 'group_identification/:id' => "group_identification#update"
   delete 'group_identification/:id' => "group_identification#destroy"
+
+  # 会場割り当て機能
+  get 'place_numbers' => "place_number#index"
+  get 'place_numbers/:id' => "place_number#show"
+  post 'place_numbers' => "place_number#create"
+  put 'place_numbers/:id' => "place_number#update"
+  delete 'place_numbers/:id' => "place_number#destroy"
+  
   # users
   get "/users" => "users#index"
   get "/users/:id" => "users#show"

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
 
+  post 'group_identification' => "group_identification#create"
+  put 'group_identification/:id' => "group_identification#update"
+  delete 'group_identification/:id' => "group_identification#destroy"
   # users
   get "/users" => "users#index"
   get "/users/:id" => "users#show"

--- a/api/db/migrate/20220123012848_create_group_identifications.rb
+++ b/api/db/migrate/20220123012848_create_group_identifications.rb
@@ -1,0 +1,10 @@
+class CreateGroupIdentifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :group_identifications do |t|
+      t.integer :group_id
+      t.integer :number
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/migrate/20220123030856_create_place_numbers.rb
+++ b/api/db/migrate/20220123030856_create_place_numbers.rb
@@ -1,0 +1,10 @@
+class CreatePlaceNumbers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :place_numbers do |t|
+      t.integer :place_id
+      t.integer :group_identification_id
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_23_012848) do
+ActiveRecord::Schema.define(version: 2022_01_23_030856) do
 
   create_table "assign_group_places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "place_order_id"
@@ -124,6 +124,13 @@ ActiveRecord::Schema.define(version: 2022_01_23_012848) do
     t.integer "place_id"
     t.integer "group_category_id"
     t.boolean "enable"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "place_numbers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "place_id"
+    t.integer "group_identification_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_23_143233) do
+ActiveRecord::Schema.define(version: 2022_01_23_012848) do
 
   create_table "assign_group_places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "place_order_id"
@@ -84,6 +84,13 @@ ActiveRecord::Schema.define(version: 2021_03_23_143233) do
 
   create_table "group_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "group_identifications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "group_id"
+    t.integer "number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/api/test/controllers/group_identification_controller_test.rb
+++ b/api/test/controllers/group_identification_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class GroupIdentificationControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get group_identification_create_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get group_identification_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get group_identification_destroy_url
+    assert_response :success
+  end
+end

--- a/api/test/controllers/place_number_controller_test.rb
+++ b/api/test/controllers/place_number_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class PlaceNumberControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get place_number_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get place_number_show_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get place_number_create_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get place_number_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get place_number_destroy_url
+    assert_response :success
+  end
+end

--- a/api/test/fixtures/group_identifications.yml
+++ b/api/test/fixtures/group_identifications.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  group_id: 
+  number: 
+
+two:
+  group_id: 
+  number: 

--- a/api/test/fixtures/place_numbers.yml
+++ b/api/test/fixtures/place_numbers.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  place_id: 1
+  group_identification_id: 1
+
+two:
+  place_id: 1
+  group_identification_id: 1

--- a/api/test/models/group_identification_test.rb
+++ b/api/test/models/group_identification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GroupIdentificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/api/test/models/place_number_test.rb
+++ b/api/test/models/place_number_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PlaceNumberTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #610
resolve #615

# 概要
<!-- 開発内容の概要を記載 -->
## GroupIdentificaionモデルを追加
カラム
group_id: integer (参加団体id)
number: integer (識別番号)

## PlaceNumberモデルの追加
カラム
place_id: integer (会場id)
group_identification_id: integer (識別番号id)

## （必要かわからないけど）作ったメソッド
```
place = Place.find(1) # 会場を取得
place.groups # その会場の参加団体を取得できる

group = Group.find(1) # 参加団体を取得
group.place # その参加団体が割り当てられている会場を取得
```

## 考えられる会場割り当ての手法
### step1. 参加団体の識別番号登録
api: `[post] /group_identification?group_id=<:group_id>&number=<:識別番号>`
例) 
参加団体 id:1 name: nutfes ...
`[post] /group_identification?group_id=1&number=1`
これで参加団体nutfesは識別番号1になる

### step2. 会場割り当て
各会場に識別番号で参加団体を登録する
api: `[post] /place_number?group_identification_id=<:group_identification_id>&place_id=<:place_id>`
例) 
参加団体 id:1 name: nutfes ...
識別割り当て id:1 group_id: 1 number: 2
会場 id:1 name: 事務棟エリア
`[post] /place_numbers?group_identification_id=1&place_id=1`
これで事務棟エリアに識別番号1の団体が存在し，その識別番号1の参加団体nutfesが割り当てられ，参加団体nutfesは事務棟エリアに存在するという意味をもつ


# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
