### PR TITLE
[mod] slack通知をbotで行えるように変更(#692)

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -34,7 +34,8 @@ gem 'wkhtmltopdf'
 gem 'wkhtmltopdf-binary'
 
 gem 'slack-notifier'
-gem 'dotenv'
+gem 'dotenv-rails'
+gem 'slack-ruby-client'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -78,10 +78,40 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 6.2)
     dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
+    faraday (1.10.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
     ffi (1.15.0)
+    gli (2.21.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (5.0.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -100,6 +130,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multipart-post (2.1.1)
     mysql2 (0.5.3)
     nio4r (2.5.7)
     nokogiri (1.11.3)
@@ -148,10 +179,17 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby2_keywords (0.0.5)
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
     slack-notifier (2.4.0)
+    slack-ruby-client (1.0.0)
+      faraday (>= 1.0)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -183,7 +221,7 @@ DEPENDENCIES
   byebug
   devise
   devise_token_auth
-  dotenv
+  dotenv-rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
@@ -193,6 +231,7 @@ DEPENDENCIES
   rails (~> 6.1.3.1)
   seed-fu
   slack-notifier
+  slack-ruby-client
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -20,12 +20,10 @@ class GroupsController < ApplicationController
     @group = Group.create(group_params)
     render json: fmt(created, @group)
 
-    require 'slack-notifier'
-    # slack Incomming Webhookの設定
-    # 通知内容
-    attachment = {
-      color: "good",
-      type: "mrkdwn",
+    client = Slack::Web::Client.new
+    client.chat_postMessage(
+      token: ENV['BOT_USER_ACCESS_TOKEN'],
+      channel: '#' + ENV['CHANNEL'],
       text: "
       
       参加団体「#{@group.name}」が追加されました
@@ -37,13 +35,7 @@ class GroupsController < ApplicationController
       ーーーーーーーーーーーーーーーー
   
       "
-    }
-
-    notifier = Slack::Notifier.new(
-      ENV['WEBHOOK_URL'],
-      channel: '#' + ENV['CHANNEL']
-    )
-    notifier.ping '', attachments: [ attachment ]    
+    )    
   end
 
   # PATCH/PUT /groups/1
@@ -52,30 +44,22 @@ class GroupsController < ApplicationController
     @group.update(group_params)
     render json: fmt(created, @group, "Updated group id = "+params[:id])
 
-    require 'slack-notifier'
-    # slack Incomming Webhookの設定
-
-    # 通知内容
-    attachment = {
-      color: "warning",
-      type: "mrkdwn",
+    client = Slack::Web::Client.new
+    client.chat_postMessage(
+      token: ENV['BOT_USER_ACCESS_TOKEN'],
+      channel: '#' + ENV['CHANNEL'],
       text: "
-
-      #{@group.name}が編集されました
+      
+      参加団体「#{@group.name}」が編集されました
       ーーーーーーーーーーーーーーーー
       代表者：#{@group.user.name}
       参加形式：#{@group.group_category.name}
       企画名：#{@group.project_name}
       概要：#{@group.activity}
       ーーーーーーーーーーーーーーーー
-
+  
       "
-    }
-    notifier = Slack::Notifier.new(
-      ENV['WEBHOOK_URL'],
-      channel: '#' + ENV['CHANNEL']
-    )
-    notifier.ping '', attachments: [ attachment ]    
+    )    
   end
 
   # DELETE /groups/1
@@ -84,28 +68,22 @@ class GroupsController < ApplicationController
     @group.destroy
     render json: fmt(ok, [], "Deleted group id = "+params[:id])
     
-    require 'slack-notifier'
-    # slack Incomming Webhookの設定
-    # 通知内容
-    attachment = {
-      color: "danger",
-      type: "mrkdwn",
-      text: "#{@group.name}が削除されました
+    client = Slack::Web::Client.new
+    client.chat_postMessage(
+      token: ENV['BOT_USER_ACCESS_TOKEN'],
+      channel: '#' + ENV['CHANNEL'],
+      text: "
+      
+      参加団体「#{@group.name}」が削除されました
       ーーーーーーーーーーーーーーーー
       代表者：#{@group.user.name}
       参加形式：#{@group.group_category.name}
       企画名：#{@group.project_name}
       概要：#{@group.activity}
       ーーーーーーーーーーーーーーーー
-
+  
       "
-    }
-
-    notifier = Slack::Notifier.new(
-      ENV['WEBHOOK_URL'],
-      channel: '#' + ENV['CHANNEL']
-    )
-    notifier.ping '', attachments: [ attachment ]    
+    )        
   end
 
   private


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #692 

# 概要
<!-- 開発内容の概要を記載 -->
- gemファイルに 'slack-ruby-client'を追加。
- gemファイルの'dotenv'を削除、代わりに 'dotenv-rails'追加
- groupsの通知機能をwebhookからbotに変更
# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- api/Gemfile
- api/Gemfile.lock
- api/app/controller/groups_controller.rb

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
