### PR TITLE
[add]order_infos_api_controller(#763)

### DIFF
--- a/api/app/controllers/api/v1/order_infos_api_controller.rb
+++ b/api/app/controllers/api/v1/order_infos_api_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::OrderInfosApiController < ApplicationController
+
+  def get_order_info_for_admin_view
+    @groups = Group.with_order_info(params[:id])
+    render json: fmt(ok, @groups)
+  end
+
+  # 絞り込み機能
+  def get_refinement_order_infos
+    fes_year_id = params[:fes_year_id].to_i
+    # fes_yesrがALL
+    if fes_year_id == 0
+      @groups = Group.with_order_infos
+      # fes_year_idが指定 
+    elsif fes_year_id != 0
+      @groups = Group.with_order_info_narrow_down_by_fes_year(fes_year_id)
+    end
+
+    if @groups.count == 0
+      render json: fmt(not_found, [], "Not found groups")
+    else 
+      render json: fmt(ok, @groups)
+    end
+  end
+
+  # あいまい検索機能
+  def get_search_order_infos
+    word = params[:word]
+    @groups = Group.with_order_info_narrow_down_by_search_word(word)
+    if @groups.count == 0
+      render json: fmt(not_found, [], "Not found groups")
+    else
+      render json: fmt(ok, @groups)
+    end
+  end
+
+end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -56,6 +56,63 @@ class Group < ApplicationRecord
         }
     end
 
+    ### order_info (申請情報)
+    
+    # 全てのgroupとそれが持つorderを取得する
+    def self.with_order_infos
+      @record = Group.all
+        .map{ 
+          |group| 
+          {   
+            "group": group,
+            "user": group.user.nil? ? nil: group.user,
+            "group_category": group.group_category.nil? ? nil : group.group_category.name,
+            "fes_year": group.fes_year.nil? ? nil : group.fes_year.year_num,
+            "sub_rep": group.sub_rep.nil? ? nil : group.sub_rep.to_info_h,
+            "place_order": group.place_order.nil? ? nil : group.place_order.to_place_name_h,
+            "stage_orders": group.stage_orders.count == 0 ? nil : group.stage_orders.map {
+              |stage_order|
+              { 
+                "stage_order": stage_order.to_info_h
+              }
+            },
+            "stage_common_option": group.stage_common_option.nil? ? nil : group.stage_common_option.to_info_h,
+            "power_orders": group.power_orders.count == 0 ? nil : group.power_orders.map {
+              |power_order|
+              {
+                "power_order": power_order.to_info_h
+              }
+            },
+            "rental_orders": group.rental_orders.count == 0 ? nil : group.rental_orders.map{
+              |rental_order|
+              {
+                "rental_item": rental_order.to_rental_item_info_h,
+              }
+            },
+            "employees": group.employees.count == 0 ? nil : group.employees.map{
+              |employee|
+              {
+                "employee": employee.to_info_h
+              }
+            },
+            "food_products": group.food_products.count == 0 ? nil : group.food_products.map{
+              |food_product|
+              {
+                "food_product": food_product.to_info_h,
+                "purchase_lists": food_product.purchase_lists.map{
+                  |purchase_list|
+                  {
+                    "purchase_list": purchase_list.to_info_h
+                  }
+                }
+              }
+            }
+          } 
+        }
+    end
+
+
+    # 指定したIDのgroupとそれが持つorderを取得する
     def self.with_order_info(group_id)
       group = Group.find(group_id)
       @record = 
@@ -105,6 +162,113 @@ class Group < ApplicationRecord
           }
         }
       return @record
+    end
+
+    # 指定したfes_yearに対応するgroupとそれが持つorderを取得する
+    def self.with_order_info_narrow_down_by_fes_year(fes_year_id)
+      @record = Group.where(groups: {fes_year_id: fes_year_id})
+        .map{ 
+          |group| 
+          {   
+            "group": group,
+            "user": group.user.nil? ? nil: group.user,
+            "group_category": group.group_category.nil? ? nil : group.group_category.name,
+            "fes_year": group.fes_year.nil? ? nil : group.fes_year.year_num,
+            "sub_rep": group.sub_rep.nil? ? nil : group.sub_rep.to_info_h,
+            "place_order": group.place_order.nil? ? nil : group.place_order.to_place_name_h,
+            "stage_orders": group.stage_orders.count == 0 ? nil : group.stage_orders.map {
+              |stage_order|
+              { 
+                "stage_order": stage_order.to_info_h
+              }
+            },
+            "stage_common_option": group.stage_common_option.nil? ? nil : group.stage_common_option.to_info_h,
+            "power_orders": group.power_orders.count == 0 ? nil : group.power_orders.map {
+              |power_order|
+              {
+                "power_order": power_order.to_info_h
+              }
+            },
+            "rental_orders": group.rental_orders.count == 0 ? nil : group.rental_orders.map{
+              |rental_order|
+              {
+                "rental_item": rental_order.to_rental_item_info_h,
+              }
+            },
+            "employees": group.employees.count == 0 ? nil : group.employees.map{
+              |employee|
+              {
+                "employee": employee.to_info_h
+              }
+            },
+            "food_products": group.food_products.count == 0 ? nil : group.food_products.map{
+              |food_product|
+              {
+                "food_product": food_product.to_info_h,
+                "purchase_lists": food_product.purchase_lists.map{
+                  |purchase_list|
+                  {
+                    "purchase_list": purchase_list.to_info_h
+                  }
+                }
+              }
+            }
+          } 
+        }
+    end
+
+    # 検索ワードに対応するgroupとそれが持つorderを取得する
+    def self.with_order_info_narrow_down_by_search_word(word)
+      @record = Group.where("name like ?","%#{word}%")
+        .map{ 
+          |group| 
+          { 
+
+            "group": group,
+            "user": group.user.nil? ? nil: group.user,
+            "group_category": group.group_category.nil? ? nil : group.group_category.name,
+            "fes_year": group.fes_year.nil? ? nil : group.fes_year.year_num,
+            "sub_rep": group.sub_rep.nil? ? nil : group.sub_rep.to_info_h,
+            "place_order": group.place_order.nil? ? nil : group.place_order.to_place_name_h,
+            "stage_orders": group.stage_orders.count == 0 ? nil : group.stage_orders.map {
+              |stage_order|
+              { 
+                "stage_order": stage_order.to_info_h
+              }
+            },
+            "stage_common_option": group.stage_common_option.nil? ? nil : group.stage_common_option.to_info_h,
+            "power_orders": group.power_orders.count == 0 ? nil : group.power_orders.map {
+              |power_order|
+              {
+                "power_order": power_order.to_info_h
+              }
+            },
+            "rental_orders": group.rental_orders.count == 0 ? nil : group.rental_orders.map{
+              |rental_order|
+              {
+                "rental_item": rental_order.to_rental_item_info_h,
+              }
+            },
+            "employees": group.employees.count == 0 ? nil : group.employees.map{
+              |employee|
+              {
+                "employee": employee.to_info_h
+              }
+            },
+            "food_products": group.food_products.count == 0 ? nil : group.food_products.map{
+              |food_product|
+              {
+                "food_product": food_product.to_info_h,
+                "purchase_lists": food_product.purchase_lists.map{
+                  |purchase_list|
+                  {
+                    "purchase_list": purchase_list.to_info_h
+                  }
+                }
+              }
+            }
+          } 
+        }
     end
 
     # 指定したIDのgroupとそのgroup_categoryとfes_yearを取得する

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -136,6 +136,11 @@ Rails.application.routes.draw do
       post "get_search_public_relations" => "public_relations_api#get_search_public_relations"
       get "get_groups_have_no_public_relation" => "groups_api#get_groups_have_no_public_relation"
 
+      #---申請情報ページ
+      get "get_order_info_for_admin_view/:id" => "order_infos_api#get_order_info_for_admin_view"
+      post "get_refinement_order_infos" => "order_infos_api#get_refinement_order_infos"
+      post "get_search_order_infos" => "order_infos_api#get_search_order_infos"
+
       #---開催日
       get "get_refinement_fes_date_by_fes_year/:fes_year_id" => "fes_dates_api#get_refinement_fes_date_by_fes_year"
       get "get_current_fes_dates" => "fes_dates_api#get_current_fes_dates"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #763

# 概要
<!-- 開発内容の概要を記載 -->
groupが持つ申請情報（order）を一覧で出力するAPIを作成した。
apiとしては
・idを指定してそのgroupが持つ申請情報を出力
・fes_yearを指定して絞り込んだgroupが持つ申請情報を出力
・検索wordを指定して絞り込んだgroupが持つ申請情報を出力

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- api/app/models/group.rb
- api/app/controllers/api/v1/order_infos_api_controller.rb
- api/config/routes.rb
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `localhost:3000/api/v1/get_order_info_for_admin_view/:id`にアクセスして対象のグループの申請情報が返ってきているかを確認
- `localhost:3000/api/v1/get_refinement_order_infos`に`fes_year`をpostして対象年のグループの申請情報が返ってくるかを確認
- `localhost:3000/api/v1/get_search_order_infos`に`word`をpostして対象年のグループの申請情報が返ってくるかを確認
-

# 備考
確認画面をどうするかで送る情報をもっと減らしてもよいと思う。