### PR TITLE
[add]user create modal(#887)

### DIFF
--- a/admin_view/nuxt-project/pages/users/index.vue
+++ b/admin_view/nuxt-project/pages/users/index.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="main-content">
     <SubHeader pageTitle="ユーザー一覧">
+      <CommonButton v-if="this.$role(roleID).users.create" iconName="add_circle" :on_click="openAddModal">
+        追加
+      </CommonButton>
     </SubHeader>
 
     <SubSubHeader>
@@ -53,6 +56,80 @@
         </template>
       </Table>
     </Card>
+     
+    <AddModal
+      @close="closeAddModal"
+      v-if="isOpenAddModal"
+      title="ユーザーの追加"
+    >
+      <template v-slot:form>
+        <div>
+          <h3>名前</h3>
+          <input v-model="createName" placeholder="入力してください" />
+        </div>
+        <div>
+          <h3>学籍番号</h3>
+          <input v-model="createStudentId" maxlength="8" placeholder="入力してください" />
+        </div>
+        <div>
+          <h3>メールアドレス</h3>
+          <input v-model="createEmail" placeholder="～@～.～" />
+        </div>
+        <div>
+          <h3>TEL</h3>
+          <input v-model="createTel" maxlength="11" placeholder="ハイフンなし" />
+        </div>
+        <div>
+          <h3>学科</h3>
+          <select v-model="createDepartmentId">
+            <option disabled value="">選択してください</option>
+            <option v-for="department in departmentList" :key="department.id" :value="department.id">
+              {{ department.name }}
+            </option>
+          </select>
+        </div>
+        <div>
+          <h3>学年</h3>
+          <select v-model="createGradeId">
+            <option disabled value="">選択してください</option>
+            <option v-for="grade in gradeList" :key="grade.id" :value="grade.id">
+              {{ grade.name }}
+            </option>
+          </select>
+        </div>
+        <div>
+          <h3>パスワード</h3>
+          <input v-model="createPassword" type="password" placeholder="６文字以上" />
+        </div>
+        <div>
+          <h3>パスワード再確認</h3>
+          <input v-model="createPasswordConfirmation" type="password" placeholder="６文字以上" />
+          <p v-if="createPasswordConfirmation !== '' && createPassword !== createPasswordConfirmation">パスワードが一致しません</p>
+        </div>
+      </template>
+      <template v-slot:method>
+        <CommonButton v-if="
+          createName !== null && createName !== '' &&
+          createStudentId !== null && createStudentId !== '' &&
+          createEmail !== null && createEmail !== '' &&
+          createTel !== null && createTel !== '' &&
+          createDepartmentId !== null &&
+          createGradeId !== null &&
+          createPassword !== null && createPassword !== '' &&
+          createPasswordConfirmation !== null && createPasswordConfirmation !== '' &&
+          createPassword === createPasswordConfirmation
+          "
+          iconName="add_circle" :on_click="simplyUserCreate">登録</CommonButton>
+        <CommonButton v-else iconName="add_circle" disabled :on_click="simplyUserCreate">登録</CommonButton>
+      </template>
+    </AddModal>
+
+    <SnackBar
+      v-if="isOpenSnackBar"
+      @close="closeSnackBar"
+    >
+      {{ message }}
+    </SnackBar>
 
   </div>
 </template>
@@ -69,10 +146,61 @@ export default {
         { id: 2, name: "manager" },
         { id: 3, name: "user" },
       ],
+      departmentList: [
+        { id: 1,  name: "機械創造工学課程" },
+        { id: 2,  name: "電気電子情報工学課程" },
+        { id: 3,  name: "物質材料工学課程" },
+        { id: 4,  name: "環境社会基盤工学課程" },
+        { id: 5,  name: "生物機能工学課程" },
+        { id: 6,  name: "情報・経営システム工学課程" },
+        { id: 7,  name: "機械創造工学専攻" },
+        { id: 8,  name: "電気電子情報工学専攻" },
+        { id: 9,  name: "物質材料工学専攻" },
+        { id: 10, name: "環境社会基盤工学専攻" },
+        { id: 11, name: "生物機能工学専攻" },
+        { id: 12, name: "情報・経営システム工学専攻" },
+        { id: 13, name: "原子力システム安全工学専攻" },
+        { id: 14, name: "システム安全専攻" },
+        { id: 15, name: "技術科学イノベーション専攻" },
+        { id: 16, name: "情報・制御工学専攻" },
+        { id: 17, name: "材料工学専攻" },
+        { id: 18, name: "エネルギー・環境工学専攻" },
+        { id: 19, name: "生物統合工学専攻" },
+        { id: 20, name: "その他" },
+      ],
+      gradeList: [
+        { id : 1,  name: "B1[学部1年]" },
+        { id : 2,  name: "B2[学部2年]" },
+        { id : 3,  name: "B3[学部3年]" },
+        { id : 4,  name: "B4[学部4年]" },
+        { id : 5,  name: "M1[修士1年]" },
+        { id : 6,  name: "M2[修士2年]" },
+        { id : 7,  name: "D1[博士1年]" },
+        { id : 8,  name: "D2[博士2年]" },
+        { id : 9,  name: "D3[博士3年]" },
+        { id : 10, name: "GD1[イノベ1年]" },
+        { id : 11, name: "GD2[イノベ2年]" },
+        { id : 12, name: "GD3[イノベ3年]" },
+        { id : 13, name: "GD4[イノベ4年]" },
+        { id : 14, name: "GD5[イノベ5年]" },
+        { id : 15, name: "その他" },
+      ],
       refRole: "Role",
       refRoleID: 0,
       searchText: "",
       users: [],
+      isOpenAddModal: false,
+      isOpenSnackBar: false,
+      createName: null,
+      createEmail: null,
+      createStudentId: null,
+      createTel: null,
+      createDepartmentId: null,
+      createGradeId: null,
+      createPassword: null,
+      createPasswordConfirmation: null,
+      createUserId: null,
+      createRoleId: 2,
     };
   },
   async asyncData({ $axios }) {
@@ -91,6 +219,21 @@ export default {
     }),
   },
   methods: {
+    openAddModal() {
+      this.isOpenAddModal = false;
+      this.isOpenAddModal = true;
+    },
+    closeAddModal() {
+      this.isOpenAddModal = false;
+    },
+    openSnackBar(message) {
+      this.message = message;
+      this.isOpenSnackBar = true;
+      setTimeout(this.closeSnackBar, 2000);
+    },
+    closeSnackBar() {
+      this.isOpenSnackBar = false;
+    },
     async refinementUsers(item_id, name_list) {
       this.refRoleID = item_id
       if (item_id == 0){
@@ -112,6 +255,44 @@ export default {
       for (const res of refRes.data) {
         this.users.push(res);
       }
+    },
+    async simplyUserCreate() {
+      const simply_user_create_url = "/users/simply_user_create"
+      var simply_user_create_params = {
+          name: this.createName,
+          email: this.createEmail,
+          password: this.createPassword,
+          password_confirmation: this.createPasswordConfirmation,
+          role_id: this.createRoleId
+        };
+      this.$axios.$post(simply_user_create_url, simply_user_create_params).then((response) => {
+        if(response.status.code === 201){
+          this.createUserId = response.data.id;
+          const user_detail_url = "/user_details"
+          var user_detail_params = {
+              student_id: this.createStudentId,
+              tel: this.createTel,
+              department_id: this.createDepartmentId,
+              grade_id: this.createGradeId,
+              user_id: this.createUserId,
+          };
+          this.$axios.$post(user_detail_url, user_detail_params).then((response) => {
+            this.openSnackBar(this.createName + "を追加しました");
+            this.closeAddModal();
+            this.createName = null;
+            this.createEmail = null;
+            this.createStudentId = null;
+            this.createTel = null;
+            this.createDepartmentId = null;
+            this.createGradeId = null;
+            this.createPassword = null;
+            this.createPasswordConfirmation =  null;
+            this.createUserId = null;
+          });
+        }else if(response.status.code === 500){
+          this.openSnackBar("ERROR 失敗しました");
+        }
+      });
     },
   },
 };

--- a/api/app/controllers/users_controller.rb
+++ b/api/app/controllers/users_controller.rb
@@ -111,6 +111,15 @@ class UsersController < ApplicationController
     render json: fmt(ok, [], "Updated password user_id = "+params[:user_id])
   end
 
+  def simply_user_create
+    @user = User.create(simply_user_create_params)
+    if @user.id == nil
+      render json: fmt(internal_server_error, [], "internal_server_error")
+    else 
+      render json: fmt(created, @user)
+    end
+  end
+
   private
 
     def set_user
@@ -127,5 +136,9 @@ class UsersController < ApplicationController
 
     def reset_password_params
       params.permit(:user_id, :password, :password_confirmation)
+    end
+
+    def simply_user_create_params
+      params.permit(:name, :email, :password, :password_confirmation, :role_id)
     end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "/current_user" => "users#get_current_user"
   put "/users/:id" => "users#update"
   delete "/users/:id" => "users#destroy"
+  post "/users/simply_user_create" => "users#simply_user_create"
 
   # ステージ
   get "/sunny/stages" => "stages#show_sunny"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #887

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面のユーザー一覧ページにて新規ユーザーの登録モーダルを作成した。
モーダルは `developer` のみ表示される。
また、 `user_controller` に `simply_user_create` methodを作成した。
当初の考えではdevise_token_authのsign_upをすればよいと思っていたのだが、新規にsign_upすることでログインユーザーが変わるというエラーに遭遇した（おそらくトークン関係）ため、シンプルにユーザーを作成するmethodを作成した。

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- admin_view/nuxt-project/pages/users/index.vue
- api/app/controllers/users_controller.rb
- api/config/routes.rb

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `http://localhost:8000/users`
スクリーンショット
<img width="699" alt="image" src="https://user-images.githubusercontent.com/52201107/172339981-eb47ac07-339f-4b0c-a3b7-29f000469654.png">
<img width="666" alt="image" src="https://user-images.githubusercontent.com/52201107/172340058-16c88716-6ffd-41e4-8741-b994e51f09d2.png">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- `developer`でログインしたときと、`manager`でログインした時でモーダルの表示の有り無しの確認
- 実際にユーザーを作成し、エラーがないかを確認
- ユーザーを作成したあとも、ログインしているアカウントが変更していないかを確認

# 備考
一応調べたけど、既存でシンプルにユーザーを作成するメソッドがあったらごめんなさい。