### PR TITLE
[mod]登録状態の表示、role_idでの制御の追加(#906)

### DIFF
--- a/admin_view/nuxt-project/pages/assign_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_items/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main-content">
     <SubHeader pageTitle="在庫場所">
-      <CommonButton iconName="add_circle" :on_click="openAddModal">
+      <CommonButton v-if="this.$role(roleID).stocker_places.create" iconName="add_circle" :on_click="openAddModal">
         追加   
       </CommonButton>
     </SubHeader>
@@ -17,12 +17,12 @@
           <tr
             v-for="(stocker_place, index) in stocker_place.data"
             :key="index"
-            @click="() => $router.push({ path: `/stocker_places/` + stocker_place.id })"
+            @click="() => $router.push({ path: `/assign_items/` + stocker_place.id })"
           >
             <td>{{ stocker_place.id }}</td>
             <td>{{ stocker_place.name }}</td>
-            <td>{{ stocker_place.stock_item_status }}</td>
-            <td>{{ stocker_place.assign_item_status }}</td>
+            <td>{{ stocker_place.stock_item_status === 1 ? "未登録" : stocker_place.stock_item_status === 2 ? "登録中" : "登録完了" }}</td>
+            <td>{{ stocker_place.assign_item_status === 1 ? "未登録" : stocker_place.assign_item_status === 2 ? "登録中" : "登録完了" }}</td>
           </tr>
         </template>
       </Table>
@@ -60,7 +60,7 @@
               :key="assignItemStatus.id"
               :value="assignItemStatus.id"
             >
-              {{assignItemStatus.name}}
+              {{ assignItemStatus.name }}
             </option>
           </select>
         </div>
@@ -114,8 +114,6 @@ export default {
       })
       .then((response) => {
         this.stocker_place = response.data;
-        // this.stock_item_status = response.data.stock_item_status;
-        // this.assign_item_status = response.data.assign_item_status;
       });
   },
   computed: {

--- a/admin_view/nuxt-project/plugins/role/developer.js
+++ b/admin_view/nuxt-project/plugins/role/developer.js
@@ -161,4 +161,10 @@ export const developerRole = {
     update: true,
     delete: true,
   },
+  assign_items: {
+    read: true,
+    create: true,
+    update: true,
+    delete: true,
+  },
 }

--- a/admin_view/nuxt-project/plugins/role/manager.js
+++ b/admin_view/nuxt-project/plugins/role/manager.js
@@ -161,4 +161,10 @@ export const managerRole = {
     update: false,
     delete: false,
   },
+  assign_items: {
+    read: true,
+    create: false,
+    update: false,
+    delete: false,
+  },
 }

--- a/admin_view/nuxt-project/plugins/role/user.js
+++ b/admin_view/nuxt-project/plugins/role/user.js
@@ -161,4 +161,10 @@ export const userRole = {
     update: false,
     delete: false,
   },
+  assgin_items: {
+    read: false,
+    create: false,
+    update: false,
+    delete: false,
+  }, 
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #906 

# 概要
<!-- 開発内容の概要を記載 -->
- 登録状態がidによって「未登録」「登録中」「登録完了」の表示になるよう変更。
- role_idで在庫場所の追加権限をdeveloperのみに。
# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- admin_view/nuxt-project/pages/assign_items/index.vue
- admin_view/nuxt-project/plugins/role/developer.js
- admin_view/nuxt-project/plugins/role/manager.js
- admin_view/nuxt-project/plugins/role/user.js
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- ![スクリーンショット (422)](https://user-images.githubusercontent.com/90322124/174782993-42312dcc-9118-4c90-bd8a-8858dc4ddafc.png)

![スクリーンショット (423)](https://user-images.githubusercontent.com/90322124/174783083-41c678af-d447-4fd9-9c41-5bfb57a5fe45.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
