### PR TITLE
[mod] 参加団体登録の制御で新規登録からアクセスできないようにする(#923)

### DIFF
--- a/view/vue-project/src/views/RegistRep.vue
+++ b/view/vue-project/src/views/RegistRep.vue
@@ -110,6 +110,7 @@ export default {
       departmentList: departmentList,
       gradeList: gradeList,
       errorMessage: null,
+      isRegistGroup: null,
     };
   },
   mounted() {
@@ -120,6 +121,19 @@ export default {
       console.log("reject");
       this.$router.push("/");
     }
+    // 制御
+    const settingurl = process.env.VUE_APP_URL + "/user_page_settings";
+    axios
+      .get(settingurl, {
+        headers: {
+          "Content-Type": "application/json",
+          "access-token": localStorage.getItem("access-token"),
+          client: localStorage.getItem("client"),
+        },
+      })
+      .then((response) => {
+        this.isRegistGroup = response.data.data[0].is_regist_group;
+      });
   },
   computed: {
     validationName() {
@@ -258,9 +272,15 @@ export default {
           axios.defaults.headers.common["Content-Type"] = "application/json";
           axios.post(url, params).then(
             () => {
-              this.$store.commit("acceptRegistGroupPermission");
-              this.$store.commit("acceptMypagePermission");
-              this.$router.push("regist_group");
+              if (this.isRegistGroup === true) {
+                this.$store.commit("acceptRegistGroupPermission");
+                this.$store.commit("acceptMypagePermission");
+                this.$router.push("regist_group");
+              } else {
+                this.$store.commit("acceptRegistGroupPermission");
+                this.$store.commit("acceptMypagePermission");
+                this.$router.push("mypage");
+              }
             },
             (error) => {
               this.errorMessage = "ユーザー詳細の登録に失敗しました";


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #923

# 概要
<!-- 開発内容の概要を記載 -->
参加団体の登録の制御に応じて，ユーザーの新規登録の後のフローを変える．
- 参加団体の登録を許可していればユーザー登録の後参加団体登録に行く
- 参加団体の登録を許可していなければユーザー登録の後マイページに行く

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- view/vue-project/src/views/RegistRep.vue
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 参加団体の登録を許可して新規ユーザー登録
- 参加団体の登録を許可しないで新規ユーザー登録
-

# 備考
