### PR TITLE
useFetchを利用してAPIを叩く

### DIFF
--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
   # GET /groups.json
   def index
     @groups = Group.all
-    render json: fmt(ok, @groups)
+    render json: @groups
   end
 
   # GET /groups/1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     tty: true
-    platform: linux/x86_64 # M1 Mac用
+    #platform: linux/x86_64 # M1 Mac用
 
   api:
     build: ./api
@@ -64,8 +64,8 @@ services:
     build: ./user_front
     container_name: 'GM2-USER-FRONT'
     ports:
-      - "8001:8001"
       - "8002:8002"
+      - "24678:24678"
     command: npm run dev
     volumes:
       - ./user_front:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     stdin_open: true
     tty: true
     environment:
-      - VUE_APP_URL=http://localhost:3000
+      - VUE_APP_URL=http://api:3000
     depends_on:
       - api
 

--- a/user_front/components/Group.vue
+++ b/user_front/components/Group.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+  import axios, { AxiosInstance } from 'axios'
+  import {Group} from '@/types'
+
+  const client: AxiosInstance = axios.create({
+    baseURL: 'http://localhost:3000',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  const groupNameArray = ref<string[]>([])
+
+  client.get('/groups').then((res) => {
+    const groups:Group[] = res.data.data
+    groups.forEach((group:Group)=>{
+      groupNameArray.value.push(group['name'])
+    })
+    console.log(groupNameArray)
+  })
+</script>
+
+<template>
+  <div></div>
+</template>

--- a/user_front/components/Group.vue
+++ b/user_front/components/Group.vue
@@ -1,24 +1,21 @@
 <script lang="ts" setup>
-  import axios, { AxiosInstance } from 'axios'
   import {Group} from '@/types'
 
-  const client: AxiosInstance = axios.create({
-    baseURL: 'http://localhost:3000',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-  const groupNameArray = ref<string[]>([])
+  // baseURLの設定
+  const config = useRuntimeConfig()
 
-  client.get('/groups').then((res) => {
-    const groups:Group[] = res.data.data
-    groups.forEach((group:Group)=>{
-      groupNameArray.value.push(group['name'])
-    })
-    console.log(groupNameArray)
+  // useStateで配列を定義
+  const groupNameArray = useState("groupNameArray", () => [] as string[])
+
+  const {data:groups} = await useFetch<Group[]>(config.baseURL+"/groups")
+  !!groups.value && groups.value.forEach((group:Group)=>{
+    groupNameArray.value.push(group['name'])
   })
+  console.log(groupNameArray.value)
 </script>
 
 <template>
-  <div></div>
+  <div>
+    {{ groupNameArray }}
+  </div>
 </template>

--- a/user_front/layouts/default.vue
+++ b/user_front/layouts/default.vue
@@ -2,5 +2,6 @@
   <div>
   <Header/>
   <Footer />
+  <Group />
   </div>
 </template>

--- a/user_front/nuxt.config.ts
+++ b/user_front/nuxt.config.ts
@@ -11,6 +11,12 @@ export default {
     }
   },
 
+  runtimeConfig: {
+    public: {
+      baseURL: process.env.VUE_APP_URL,
+    },
+  },
+
   modules: ['@nuxtjs/tailwindcss'],
   css: ["@/assets/tailwind.css"]
 }

--- a/user_front/types/group.ts
+++ b/user_front/types/group.ts
@@ -1,0 +1,15 @@
+interface Group {
+  id: number;
+  name: string;
+  activity: string;
+  committee?: string;
+  created_at: string;
+  fes_year_id: number;
+  group_category_id: number;
+  updated_at: string;
+  project_name: string;
+  user_id: number;
+}
+
+export default Group;
+

--- a/user_front/types/index.ts
+++ b/user_front/types/index.ts
@@ -1,0 +1,1 @@
+export type {default as Group} from './group';


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1027 
useFetchを利用してAPIを叩く

# 概要
<!-- 開発内容の概要を記載 -->
- nextでホットリロードをさせるためのportを解放 9970dee69f65d977eb44ee81d3d125c6712f2653
コンソールで大量にエラーが発生していたのはこのポートを解放していなかったのが原因です。
- docker-compose.ymlで環境変数の修正 06620941ad8592b91ab2aa5b09e7edc6bea545d0
http://localhost:3000 だと、SSR的にうまくAPIを叩けなかったのでコンテナのサービス名に変更
- groupsのindexのresponse修正 fe8f0ec422984136943dfdd6a6a9a6499e87ccbc
status codeが入っているとuseFetchとの相性が悪いので削除した。今後影響が特にないなら、`fmt`メソッドは削除したほうが良さそうです。
- baseURLの設定 0e2fae626eb3c45c862a43f099be4b6d33028c5f
nuxt2とは設定方法や呼び出し方は少し変わるみたいです。
- useFetchを利用してAPIを叩く daea12fa7f08f63296faf2af4c0c67155b936a4e
ここまで設定すると簡単にuseFetchは使えそうです。

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/components/Group.vue
- user_front/layouts/default.vue
- user_front/types/group.ts
- user_front/types/index.ts
- api/app/controllers/groups_controller.rb
- docker-compose.yml
- user_front/nuxt.config.ts

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
コンテナを立ち上げて、`localhost:8002`にアクセスして確認できる画面
![image](https://user-images.githubusercontent.com/50622120/215817931-feda343d-fa6b-43eb-9e69-f93df9b7c555.png)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 上記スクショ通りの画面が見れるか
-
-

# 備考

mergeしてもしなくてもどっちでも大丈夫です。
自分が設定したものをそのまま使いたい場合はmergeしてもらって構いません。

