### PR TITLE
[wip]編集ページ画面とページ遷移機能の完成

### DIFF
--- a/user_front/pages/edit_group.vue
+++ b/user_front/pages/edit_group.vue
@@ -13,8 +13,6 @@
         <input
           id="group"
           type="text"
-          v-model="groupName"
-          @change="validationGroup"
         />
       </div>
       <div class="regist-card-content-question">
@@ -22,23 +20,15 @@
         <input
           id="project"
           type="text"
-          v-model="projectName"
-          @change="validationProject"
         />
       </div>
       <div class="regist-card-content-question">
         <div class="regist-card-content-question-label">カテゴリ</div>
         <select
-          v-model="groupCategoryId"
-          @change="validationCategory"
           id="category"
         >
-          <option
-            v-for="item in groupCategoryList"
-            :value="item.id"
-            :key="item.id"
-          >
-            {{ item.name }}
+          <option>
+            カテゴリ
           </option>
         </select>
       </div>
@@ -47,16 +37,14 @@
         <input
           id="activity"
           type="text"
-          v-model="activity"
-          @change="validationActivity"
         />
       </div>
     </div>
     <div class="regist-button">
-      <button @click="register" class="regist-submit-button">編集する</button>
+      <button class="regist-submit-button">編集する</button>
     </div>
     <div class="delete-button">
-      <button @click="destroy" class="regist-submit-button">
+      <button class="regist-submit-button">
         参加団体を削除する
       </button>
     </div>
@@ -101,8 +89,9 @@
 }
 
 .regist-card-content {
+  @apply
+    mt-[2%];
   border: solid 1px #d3d3d3;
-  margin-top: 2%;
   padding: 5% 1% 5% 1%;
 }
 

--- a/user_front/pages/edit_group.vue
+++ b/user_front/pages/edit_group.vue
@@ -1,0 +1,182 @@
+<script lang="ts" setup>
+</script>
+
+<template>
+  <div class="regidt-card">
+    <NuxtLink to="/mypage" class="regist-back-link">マイページへ</NuxtLink>
+    <div class="reist-title-content">
+      <div class="regist-title">参加団体の編集</div>
+    </div>
+    <div class="regist-card-content">
+      <div class="regist-card-content-question">
+        <div class="regist-card-content-question-label">団体名</div>
+        <input
+          id="group"
+          type="text"
+          v-model="groupName"
+          @change="validationGroup"
+        />
+      </div>
+      <div class="regist-card-content-question">
+        <div class="regist-card-content-question-label">企画名</div>
+        <input
+          id="project"
+          type="text"
+          v-model="projectName"
+          @change="validationProject"
+        />
+      </div>
+      <div class="regist-card-content-question">
+        <div class="regist-card-content-question-label">カテゴリ</div>
+        <select
+          v-model="groupCategoryId"
+          @change="validationCategory"
+          id="category"
+        >
+          <option
+            v-for="item in groupCategoryList"
+            :value="item.id"
+            :key="item.id"
+          >
+            {{ item.name }}
+          </option>
+        </select>
+      </div>
+      <div class="regist-card-content-question">
+        <div class="regist-card-content-question-label">活動内容</div>
+        <input
+          id="activity"
+          type="text"
+          v-model="activity"
+          @change="validationActivity"
+        />
+      </div>
+    </div>
+    <div class="regist-button">
+      <button @click="register" class="regist-submit-button">編集する</button>
+    </div>
+    <div class="delete-button">
+      <button @click="destroy" class="regist-submit-button">
+        参加団体を削除する
+      </button>
+    </div>
+  </div>
+
+</template>
+
+<style>
+.regidt-card {
+  @apply
+    w-[1000px]
+    mx-auto;
+}
+
+.reist-title-content {
+  @apply
+    flex
+    flex-col
+    justify-center
+    items-center;
+}
+
+.regist-back-link {
+  @apply
+    block
+    text-lg
+    font-bold
+    text-[#e040fb]
+    cursor-pointer
+    mt-5
+    ;
+}
+
+.regist-title {
+  @apply
+    w-[1000px]
+    text-2xl
+    font-bold
+    bg-[#eceff1]
+    mt-[2%];
+  padding: 1% 1% 1% 2%;
+}
+
+.regist-card-content {
+  border: solid 1px #d3d3d3;
+  margin-top: 2%;
+  padding: 5% 1% 5% 1%;
+}
+
+.regist-card-content-question {
+  @apply
+    text-center
+    w-[800px]
+    mb-[3%]
+    mx-auto;
+}
+
+.regist-card-content-question-label {
+  @apply
+    text-lg
+    text-left
+    mb-[1%];
+}
+
+select,
+input {
+  @apply
+    text-left
+    p-[1%]
+    h-[50px]
+    w-[800px]
+    rounded-[7px]
+    text-lg
+    align-top;
+}
+select,
+input:required {
+  border: 1px solid red;
+}
+select,
+input:invalid {
+  border: 1px solid red;
+}
+select,
+input:valid {
+  border: 1px solid #333333;
+}
+
+.regist-button {
+  @apply
+    text-right;
+}
+.delete-button {
+  @apply
+    text-center
+    mb-8;
+}
+
+
+.regist-submit-button {
+  @apply
+    text-xl
+    text-[#333333]
+    bg-[#eceff1]
+    font-bold
+    rounded-[5px]
+    mt-[2%]
+    py-[1%]
+    px-[5%]
+    cursor-pointer;
+}
+.regist-submit-button:hover {
+  @apply
+    text-[#333333];
+  background-image: linear-gradient(90deg, rgba(247, 93, 139, 1), rgba(254, 220, 64, 1));
+}
+.regist-submit-button:active{
+  @apply
+    text-[#333333];
+  box-shadow: inset 1px 1px 2px #BABECC, inset -1px -1px 2px #FFF;
+}
+
+</style>

--- a/user_front/pages/edit_group.vue
+++ b/user_front/pages/edit_group.vue
@@ -11,6 +11,7 @@
       <div class="regist-card-content-question">
         <div class="regist-card-content-question-label">団体名</div>
         <input
+          class="input"
           id="group"
           type="text"
         />
@@ -18,6 +19,7 @@
       <div class="regist-card-content-question">
         <div class="regist-card-content-question-label">企画名</div>
         <input
+          class="input"
           id="project"
           type="text"
         />
@@ -25,6 +27,7 @@
       <div class="regist-card-content-question">
         <div class="regist-card-content-question-label">カテゴリ</div>
         <select
+          class="input"
           id="category"
         >
           <option>
@@ -35,6 +38,7 @@
       <div class="regist-card-content-question">
         <div class="regist-card-content-question-label">活動内容</div>
         <input
+          class="input"
           id="activity"
           type="text"
         />
@@ -110,8 +114,8 @@
     mb-[1%];
 }
 
-select,
-input {
+
+.input {
   @apply
     text-left
     p-[1%]
@@ -119,18 +123,16 @@ input {
     w-[800px]
     rounded-[7px]
     text-lg
-    align-top;
+    align-top
+    box-border;
 }
-select,
-input:required {
+.input:required {
   border: 1px solid red;
 }
-select,
-input:invalid {
+.input:invalid {
   border: 1px solid red;
 }
-select,
-input:valid {
+.input:valid {
   border: 1px solid #333333;
 }
 

--- a/user_front/pages/edit_group.vue
+++ b/user_front/pages/edit_group.vue
@@ -102,6 +102,7 @@
 .regist-card-content-question {
   @apply
     text-center
+    h-[86px]
     w-[800px]
     mb-[3%]
     mx-auto;

--- a/user_front/pages/edit_user_info.vue
+++ b/user_front/pages/edit_user_info.vue
@@ -1,0 +1,109 @@
+<script lang="ts" setup>
+</script>
+
+<template>
+  <div class="regist-card">
+    <NuxtLink to="/mypage" class="regist-back-link">マイページへ</NuxtLink>
+    <div class="reist-title-content">
+      <div class="user-info">ユーザ情報変更</div>
+    </div>
+    <div>
+      <input type="text" placeholder="フルネーム">
+      <input type="email" placeholder="メールアドレス">
+      <input type="number" placeholder="学籍番号８桁">
+      <input type="tel" placeholder="TEL">
+    </div>
+    <div class="regist-button">
+      <button class="regist-submit-button" @click="submit">登録</button>
+    </div>
+  </div>
+</template>
+
+<style>
+.regist-card {
+  @apply
+    w-[1000px]
+    mx-auto;
+}
+
+.reist-title-content {
+  @apply
+    flex
+    flex-col
+    justify-center
+    items-center;
+}
+
+.regist-back-link {
+  @apply
+    block
+    text-lg
+    font-bold
+    text-[#e040fb]
+    cursor-pointer
+    mt-5;
+}
+
+.user-info {
+  @apply
+    text-3xl
+    font-bold
+    mb-6;
+  padding: 1% 1% 1% 2%;
+}
+
+select,
+input {
+  @apply
+    text-left
+    p-[1%]
+    h-[50px]
+    w-[1000px]
+    mb-5
+    rounded-[7px]
+    text-lg
+    align-top;
+}
+select,
+input:required {
+  border: 1px solid red;
+}
+select,
+input:invalid {
+  border: 1px solid red;
+}
+select,
+input:valid {
+  border: 1px solid #333333;
+}
+
+.regist-button {
+  @apply
+    text-right
+    mb-8;
+}
+
+.regist-submit-button {
+  @apply
+    text-xl
+    text-[#333333]
+    bg-[#eceff1]
+    font-bold
+    rounded-[5px]
+    mt-[2%]
+    py-[1%]
+    px-[5%]
+    cursor-pointer;
+}
+.regist-submit-button:hover {
+  @apply
+    text-[#333333];
+  background-image: linear-gradient(90deg, rgba(247, 93, 139, 1), rgba(254, 220, 64, 1));
+}
+.regist-submit-button:active{
+  @apply
+    text-[#333333];
+  box-shadow: inset 1px 1px 2px #BABECC, inset -1px -1px 2px #FFF;
+}
+
+</style>

--- a/user_front/pages/edit_user_info.vue
+++ b/user_front/pages/edit_user_info.vue
@@ -14,7 +14,7 @@
       <input type="tel" placeholder="TEL">
     </div>
     <div class="regist-button">
-      <button class="regist-submit-button" @click="submit">登録</button>
+      <button class="regist-submit-button">登録</button>
     </div>
   </div>
 </template>

--- a/user_front/pages/password_reset.vue
+++ b/user_front/pages/password_reset.vue
@@ -1,0 +1,107 @@
+<script lang="ts" setup>
+</script>
+
+<template>
+  <div class="regist-card">
+    <NuxtLink to="/mypage" class="regist-back-link">マイページへ</NuxtLink>
+    <div class="reist-title-content">
+      <div class="user-info">パスワード再設定</div>
+    </div>
+    <div>
+      <input type="password" placeholder="新しいパスワードを入力">
+      <input type="password" placeholder="新しいパスワードの再入力">
+    </div>
+    <div class="regist-button">
+      <button class="regist-submit-button" @click="submit">登録</button>
+    </div>
+  </div>
+</template>
+
+<style>
+.regist-card {
+  @apply
+    w-[1000px]
+    mx-auto;
+}
+
+.reist-title-content {
+  @apply
+    flex
+    flex-col
+    justify-center
+    items-center;
+}
+
+.regist-back-link {
+  @apply
+    block
+    text-lg
+    font-bold
+    text-[#e040fb]
+    cursor-pointer
+    mt-5;
+}
+
+.user-info {
+  @apply
+    text-3xl
+    font-bold
+    mb-6;
+  padding: 1% 1% 1% 2%;
+}
+
+select,
+input {
+  @apply
+    text-left
+    p-[1%]
+    h-[50px]
+    w-[1000px]
+    mb-5
+    rounded-[7px]
+    text-lg
+    align-top;
+}
+select,
+input:required {
+  border: 1px solid red;
+}
+select,
+input:invalid {
+  border: 1px solid red;
+}
+select,
+input:valid {
+  border: 1px solid #333333;
+}
+
+.regist-button {
+  @apply
+    text-right
+    mb-8;
+}
+
+.regist-submit-button {
+  @apply
+    text-xl
+    text-[#333333]
+    bg-[#eceff1]
+    font-bold
+    rounded-[5px]
+    mt-[2%]
+    py-[1%]
+    px-[5%]
+    cursor-pointer;
+}
+.regist-submit-button:hover {
+  @apply
+    text-[#333333];
+  background-image: linear-gradient(90deg, rgba(247, 93, 139, 1), rgba(254, 220, 64, 1));
+}
+.regist-submit-button:active{
+  @apply
+    text-[#333333];
+  box-shadow: inset 1px 1px 2px #BABECC, inset -1px -1px 2px #FFF;
+}
+
+</style>

--- a/user_front/pages/password_reset.vue
+++ b/user_front/pages/password_reset.vue
@@ -12,7 +12,7 @@
       <input type="password" placeholder="新しいパスワードの再入力">
     </div>
     <div class="regist-button">
-      <button class="regist-submit-button" @click="submit">登録</button>
+      <button class="regist-submit-button">登録</button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1058 

# 概要
<!-- 開発内容の概要を記載 -->
- edit_group.vueとedit_info.vueとpassword_reset.vueの作成
- 編集ページ画面の表示
- 編集ページからmypageへの画面遷移の完成

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/pages/edit_group.vue
- user_front/pages/edit_user_info.vue
- user_front/pages/password_reset.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- http://localhost:8002/mypageで、「参加団体情報の編集」「ユーザ情報編集」「パスワード変更」を押したときそれぞれのページに遷移すること
- それぞれのページにある「マイページへ」を押した時に、http://localhost:8002/mypageに遷移されること


# 備考
- 「ユーザ情報編集」「パスワード変更」でリロードしないとinputタグのtailwindcssが読み込まれない