### PR TITLE
[mod]選択できる貸出物品をステージとそれ以外で分ける

### DIFF
--- a/user_front/components/RegistInfo/add/Item.vue
+++ b/user_front/components/RegistInfo/add/Item.vue
@@ -19,10 +19,17 @@ const emits = defineEmits<Emits>()
 const itemList = ref<ItemList[]>([]);
 
 onMounted(async () => {
-  const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
-  itemData.data.forEach((item) => {
-    itemList.value.push(item);
-  });
+  if (Number(localStorage.getItem("group_category_id")) === 3) {
+    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
+    itemData.data.forEach((item) => {
+      itemList.value.push(item);
+    });
+  } else {
+    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_shop_rentable_items");
+    itemData.data.forEach((item) => {
+      itemList.value.push(item);
+    });
+  }
 })
 
 const newItem = ref<number | null>()

--- a/user_front/components/RegistInfo/edit/Item.vue
+++ b/user_front/components/RegistInfo/edit/Item.vue
@@ -36,10 +36,17 @@ const newItem = ref<Regist['item']>(props.item)
 const newNum = ref<Regist['num']>(props.num)
 
 onMounted(async () => {
-  const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
-  itemData.data.forEach((item) => {
-    itemList.value.push(item);
-  });
+  if (Number(localStorage.getItem("group_category_id")) === 3) {
+    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
+    itemData.data.forEach((item) => {
+      itemList.value.push(item);
+    });
+  } else {
+    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_shop_rentable_items");
+    itemData.data.forEach((item) => {
+      itemList.value.push(item);
+    });
+  }
 })
 
 const editItem = async () => {

--- a/user_front/pages/regist/item/index.vue
+++ b/user_front/pages/regist/item/index.vue
@@ -37,10 +37,17 @@ const state = reactive({
 onMounted(async () => {
   // ログインしていない場合は/welcomeに遷移させる
   loginCheck();
-  const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
-    itemData.data.forEach((item) => {
-      itemList.value.push(item);
-    });
+  if (Number(localStorage.getItem("group_category_id")) === 3 ) {
+    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
+      itemData.data.forEach((item) => {
+        itemList.value.push(item);
+      });
+  } else {
+    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_shop_rentable_items");
+      itemData.data.forEach((item) => {
+        itemList.value.push(item);
+      });
+  }
   state.groupId= Number(localStorage.getItem("group_id"));
 });
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1148 

# 概要
<!-- 開発内容の概要を記載 -->
- 選択できる貸出物品をステージ企画とそれ以外で分けた

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
-
[ステージ企画]
![image](https://github.com/NUTFes/group-manager-2/assets/90322124/69a7e3aa-d761-46eb-8876-d1ae38ad5e6a)

[それ以外]
![スクリーンショット (210)](https://github.com/NUTFes/group-manager-2/assets/90322124/1b8b6a5f-7f5d-47de-b14b-18e8c63eaeb4)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- ステージ企画とそれ以外で選択できる貸出物品が変わるか
- /regist/item, /regist_infoの 追加・編集
-

# 備考
