### PR TITLE
【Merge保留】inputフォームの調整（リロードしなくてもCSS適用される）

### DIFF
--- a/user_front/components/RegistInfo/add/Employee.vue
+++ b/user_front/components/RegistInfo/add/Employee.vue
@@ -96,5 +96,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/add/Food.vue
+++ b/user_front/components/RegistInfo/add/Food.vue
@@ -106,5 +106,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/add/Item.vue
+++ b/user_front/components/RegistInfo/add/Item.vue
@@ -118,5 +118,6 @@ const reset = () => {
   border-bottom : solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/add/Power.vue
+++ b/user_front/components/RegistInfo/add/Power.vue
@@ -111,5 +111,6 @@ const reset = () => {
   border-bottom : solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/add/Purchase.vue
+++ b/user_front/components/RegistInfo/add/Purchase.vue
@@ -163,5 +163,6 @@ const reset = () => {
   border-bottom : solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/Employee.vue
+++ b/user_front/components/RegistInfo/edit/Employee.vue
@@ -106,5 +106,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/Food.vue
+++ b/user_front/components/RegistInfo/edit/Food.vue
@@ -123,5 +123,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/Item.vue
+++ b/user_front/components/RegistInfo/edit/Item.vue
@@ -128,5 +128,6 @@ const reset = () => {
   border-bottom : solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/Place.vue
+++ b/user_front/components/RegistInfo/edit/Place.vue
@@ -150,5 +150,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width: 80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/Power.vue
+++ b/user_front/components/RegistInfo/edit/Power.vue
@@ -133,5 +133,6 @@ const reset = () => {
   border-bottom : solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/Purchase.vue
+++ b/user_front/components/RegistInfo/edit/Purchase.vue
@@ -185,5 +185,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width:80%;
 }
 </style>

--- a/user_front/components/RegistInfo/edit/SubRep.vue
+++ b/user_front/components/RegistInfo/edit/SubRep.vue
@@ -150,5 +150,6 @@ const reset = () => {
   border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
+  width: 80%;
 }
 </style>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#1163 
<!-- 対応したIssue番号を記載 -->
resolve #1163 

# 概要
<!-- 開発内容の概要を記載 -->
inputフォームが長かったため短くした

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
- 
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="799" alt="スクリーンショット 2023-05-15 0 14 06" src="https://github.com/NUTFes/group-manager-2/assets/115447919/5fa9670b-1613-44f1-9ccb-f7d4964fad34">
修正前
<img width="513" alt="スクリーンショット 2023-05-15 0 14 17" src="https://github.com/NUTFes/group-manager-2/assets/115447919/51155f51-b773-4f2f-b052-95e636f31aca">
修正後

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 各ページで追加、編集のモーダルを開き、フォームが長くないか確認する。
-
-

# 備考
