### PR TITLE
ステージオプションの編集ができない問題を解決する #1187

### DIFF
--- a/user_front/components/RegistInfo/edit/StageOption.vue
+++ b/user_front/components/RegistInfo/edit/StageOption.vue
@@ -153,7 +153,7 @@ const reset = () => {
       </select>
       <div class="error_msg">{{ loudSoundError }}</div>
       <div class="text">ステージ内容</div>
-      <textarea class="entry" v-model="newStageContent" @chage="handleStageContent" :class="{ 'error_border': stageContentError }"/>
+      <textarea class="entry" v-model="newStageContent" @change="handleStageContent" :class="{ 'error_border': stageContentError }"/>
       <div class="error_msg">{{ stageContentError }}</div>
       <div class="flex justify-between mt-8 mx-8">
         <RegistPageButton text="リセット" @click="reset()"></RegistPageButton>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1187

# 概要
<!-- 開発内容の概要を記載 -->
ユーザーページの参加団体登録・編集ページのステージオプション申請の編集時にステージ内容を書いても編集ボタンをおせなかったバグを解決した
changeがchageとスペルミスしているだけだった

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/components/RegistInfo/edit/StageOption.vue
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`http://localhost:8002/regist_info
スクリーンショット
<img width="1440" alt="スクリーンショット 2023-05-16 22 50 10" src="https://github.com/NUTFes/group-manager-2/assets/115705521/ad112885-7b78-45c7-8a53-9ba1a5967cf4">




# テスト項目
<!-- テストしてほしい内容を記載 -->
- [] ステージオプション登録の編集を行う時、ステージ内容が空欄だとボタンが押せなくて、文字をうつと編集ボタンが押せるようになるのを確認してください
-
-

# 備考
