### PR TITLE
登録情報が見れないバグの修正

### DIFF
--- a/user_front/components/RegistInfo/card/Purchase.vue
+++ b/user_front/components/RegistInfo/card/Purchase.vue
@@ -48,7 +48,7 @@ const openDeletePurchase = () => {
   <RegistInfoWideCard>
     <template #body>
       <div class="w-[10%] mx-4 text-center text-2xl">
-        <span>{{ $t('Purchase.parchase') }}</span>
+        <span>{{ $t('Purchase.purchase') }}</span>
       </div>
       ▸
       <div class="w-[20%] ml-4 text-3xl text-center">

--- a/user_front/locales/en.json
+++ b/user_front/locales/en.json
@@ -196,7 +196,8 @@
     "item": "Necessary items",
     "number": "number of pieces required",
     "count": "",
-    "overlapItem": "The item is duplicated"
+    "overlapItem": "The item is duplicated",
+    "maxNum": "pieces can be rented"
   },
 
   "Power":{

--- a/user_front/locales/en.json
+++ b/user_front/locales/en.json
@@ -1,14 +1,14 @@
 {
   "language": "Language",
 
-  "Header":{
+  "Header": {
     "header": "NUTFES2023",
     "logOut": "Log Out"
   },
 
   "Footer": "©︎NUTFES Executive Committee",
 
-  "Button":{
+  "Button": {
     "reset": "reset",
     "register": "register",
     "edit": "edit",
@@ -19,7 +19,7 @@
     "request": "request"
   },
 
-  "Welcome":{
+  "Welcome": {
     "welcome": "Welcome to NUTFES",
     "mail": "Email Address",
     "password": "Password",
@@ -49,7 +49,7 @@
     "regist9Details": "Please register the material name, where it is purchased, the date of purchase, and whether it is raw or not."
   },
 
-  "Mypage":{
+  "Mypage": {
     "goToMypage": "Go to Mypage",
     "userName": "",
     "greeting1": "Thank you very much for participating in NUTFES.",
@@ -66,25 +66,25 @@
     "updateDate": "update date"
   },
 
-  "PR":{
+  "PR": {
     "regitstPR": "Registration of PR for brochure",
     "select": "Please select",
     "text": "PR statement(About 40 characters)",
     "illustration": "illustration"
   },
 
-  "Announcement":{
+  "Announcement": {
     "regitstAnnouncemant": "Registration of venue announcement text",
     "text": "Announcement text at the venue"
   },
 
-  "VenueMap":{
+  "VenueMap": {
     "regitstVenueMap": "Registration of Venue MAP",
     "select": "Please select",
     "map": "layout plan(pdf,png,jpg only)"
   },
 
-  "RegistInfo":{
+  "RegistInfo": {
     "return": "Return to Mypage",
     "registAndEdit": "Group Registration and Editing Page",
     "subrepresentative": "Subrepresentative",
@@ -98,7 +98,7 @@
     "purchase": "Purchase"
   },
 
-  "User":{
+  "User": {
     "registRepresentative": "Representative Registration",
     "name": "name",
     "studentId": "student id",
@@ -119,7 +119,7 @@
     "newPasswordConfirm": "Retype new password (for confirmation)"
   },
 
-  "Group":{
+  "Group": {
     "editGroup": "Edit group Information",
     "registGroup": "Registration of group",
     "groupName": "group name",
@@ -128,7 +128,7 @@
     "activityDetails": "Activity Details"
   },
 
-  "Stage":{
+  "Stage": {
     "registStageSunny": "Registration of stage on a sunny day",
     "registStageRain": "Registration of stage on a rainy day",
     "editStage": "Edit stage",
@@ -142,7 +142,7 @@
     "cleanUpTime": "clean-up time"
   },
 
-  "StageOption":{
+  "StageOption": {
     "registStageOption": "Registration of stage Details",
     "editStageOption": "Edit Stage Details",
     "privateProperty": "Whether equipment in possession are used or not",
@@ -163,7 +163,7 @@
     "content": "Stage Contents"
   },
 
-  "Subrep":{
+  "Subrep": {
     "registSubrepresentative": "Registration of subrepresentative",
     "editSubrepresentative": "Edit subrepresentative",
     "name": "name",
@@ -175,7 +175,7 @@
     "details": "details"
   },
 
-  "Place":{
+  "Place": {
     "registPlace": "Registration of places",
     "editPlace": "edit places",
     "first": "first choice",
@@ -188,7 +188,7 @@
     "eatingArea": "If you participate in the food sales, the place will be narrowed down"
   },
 
-  "Item":{
+  "Item": {
     "registItem": "Registration of loaned items",
     "addItem": "Additional loaned items",
     "deleteItem": "Deletion of loaned items",
@@ -197,10 +197,13 @@
     "number": "number of pieces required",
     "count": "",
     "overlapItem": "The item is duplicated",
-    "maxNum": "pieces can be rented"
+    "maxNum": "pieces can be rented",
+    "insideGroup": "Indoor group",
+    "outsideGroup": "Outdoor Group",
+    "stageGroup": "Stage Group"
   },
 
-  "Power":{
+  "Power": {
     "registPower": "Registration of power",
     "addPower": "Additional power",
     "deletePower": "Deletion power",
@@ -212,7 +215,7 @@
     "URL": "product URL"
   },
 
-  "Employees":{
+  "Employees": {
     "registEmployees": "Registration of employees",
     "deleteEmployees": "Deletion of employee",
     "addEmployees": "Adding Employees",
@@ -221,7 +224,7 @@
     "studentId": "studentId"
   },
 
-  "Food":{
+  "Food": {
     "registFood": "Registration of foods for sale",
     "addFood": "Additional foods for sale",
     "deleteFood": "Deletion foods for sale",
@@ -240,7 +243,7 @@
     "toBe": "of products to be sold"
   },
 
-  "Purchase":{
+  "Purchase": {
     "registPurchase": "Registration of purchased Products",
     "addPurchase": "Add purchased Products",
     "deletePurchase": "Deletion of purchased Products",
@@ -259,7 +262,7 @@
     "parchasePlace2": "of purchase"
   },
 
-  "Validate":{
+  "Validate": {
     "type": "Please type",
     "singleEight": "Please enter 8 single-byte numbers.",
     "leastEight": "Please enter at least 8 digits",
@@ -273,7 +276,7 @@
     "select": "Please select"
   },
 
-  "List":{
+  "List": {
     "food": "Food booth (food sales)",
     "goods": "Vendor booth (goods sales)",
     "stage": "Stage Project",

--- a/user_front/locales/ja.json
+++ b/user_front/locales/ja.json
@@ -196,7 +196,8 @@
     "item": "貸出物品",
     "number": "数量",
     "count": "個",
-    "overlapItem": "貸出物品が重複しています"
+    "overlapItem": "貸出物品が重複しています",
+    "maxNum": "個まで貸し出し可能です"
   },
 
   "Power":{

--- a/user_front/locales/ja.json
+++ b/user_front/locales/ja.json
@@ -1,14 +1,14 @@
 {
   "language": "言語",
 
-  "Header":{
+  "Header": {
     "header": "技大祭2023",
     "logOut": "ログアウト"
   },
 
   "Footer": "©︎長岡技術科学大学技大祭実行員会",
 
-  "Button":{
+  "Button": {
     "reset": "リセット",
     "register": "登録",
     "edit": "編集",
@@ -19,7 +19,7 @@
     "request": "申請"
   },
 
-  "Welcome":{
+  "Welcome": {
     "welcome": "ようこそ技大祭へ",
     "mail": "メールアドレス",
     "password": "パスワード",
@@ -49,7 +49,7 @@
     "regist9Details": "あなたの団体の購入材料名、購入場所、購入日、生ものか否かの登録をしてください。"
   },
 
-  "Mypage":{
+  "Mypage": {
     "goToMypage": "マイページへ",
     "userName": "様",
     "greeting1": "技大祭に参加していただき誠にありがとうございます。",
@@ -66,25 +66,25 @@
     "updateDate": "更新日"
   },
 
-  "PR":{
+  "PR": {
     "regitstPR": "パンフレット用PRの登録",
     "select": "選択してください",
     "text": "PR文(40文字程度)",
     "illustration": "イラスト"
   },
 
-  "Announcement":{
+  "Announcement": {
     "regitstAnnouncemant": "会場アナウンス文の登録",
     "text": "会場アナウンス文"
   },
 
-  "VenueMap":{
+  "VenueMap": {
     "regitstVenueMap": "会場配置図の登録",
     "select": "選択してください",
     "map": "配置図(pdf,png,jpgのみ)"
   },
 
-  "RegistInfo":{
+  "RegistInfo": {
     "return": "マイページに戻る",
     "registAndEdit": "参加団体登録・編集ページ",
     "subrepresentative": "副代表申請",
@@ -98,7 +98,7 @@
     "purchase": "購入品申請"
   },
 
-  "User":{
+  "User": {
     "registRepresentative": "代表者登録",
     "name": "氏名",
     "studentId": "学籍番号",
@@ -119,7 +119,7 @@
     "newPasswordConfirm": "新しいパスワードの再入力(確認用)"
   },
 
-  "Group":{
+  "Group": {
     "editGroup": "参加団体情報の編集",
     "registGroup": "団体登録",
     "groupName": "団体名",
@@ -128,7 +128,7 @@
     "activityDetails": "活動内容"
   },
 
-  "Stage":{
+  "Stage": {
     "registStageSunny": "晴天時のステージ登録",
     "registStageRain": "雨天時のステージ登録",
     "editStage": "ステージ編集",
@@ -142,7 +142,7 @@
     "cleanUpTime": "片付け時間"
   },
 
-  "StageOption":{
+  "StageOption": {
     "registStageOption": "ステージ詳細の登録",
     "editStageOption": "ステージ詳細の編集",
     "privateProperty": "所持機器の使用の有無",
@@ -163,7 +163,7 @@
     "content": "ステージ内容"
   },
 
-  "Subrep":{
+  "Subrep": {
     "registSubrepresentative": "副代表登録",
     "editSubrepresentative": "副代表の編集",
     "name": "氏名",
@@ -175,7 +175,7 @@
     "details": "詳細情報"
   },
 
-  "Place":{
+  "Place": {
     "registPlace": "実施場所の登録",
     "editPlace": "実施場所の編集",
     "first": "第一希望",
@@ -188,7 +188,7 @@
     "eatingArea": "模擬店(食品販売) での参加をする場合、実施場所が絞られます"
   },
 
-  "Item":{
+  "Item": {
     "registItem": "貸出物品の登録",
     "addItem": "貸出物品の追加",
     "deleteItem": "貸出物品の削除",
@@ -197,10 +197,13 @@
     "number": "数量",
     "count": "個",
     "overlapItem": "貸出物品が重複しています",
-    "maxNum": "個まで貸し出し可能です"
+    "maxNum": "個まで貸し出し可能です",
+    "insideGroup": "屋内団体",
+    "outsideGroup": "屋外団体",
+    "stageGroup": "ステージ団体"
   },
 
-  "Power":{
+  "Power": {
     "registPower": "使用電力の登録",
     "addPower": "使用電力の追加",
     "deletePower": "使用電力の削除",
@@ -212,7 +215,7 @@
     "URL": "製品URL"
   },
 
-  "Employees":{
+  "Employees": {
     "registEmployees": "従業員登録",
     "addEmployees": "従業員の追加",
     "deleteEmployees": "従業員の削除",
@@ -221,7 +224,7 @@
     "studentId": "学籍番号"
   },
 
-  "Food":{
+  "Food": {
     "registFood": "販売食品の登録",
     "addFood": "販売食品の追加",
     "deleteFood": "販売食品の削除",
@@ -240,7 +243,7 @@
     "toBe": "予定数"
   },
 
-  "Purchase":{
+  "Purchase": {
     "registPurchase": "購入品の登録",
     "addPurchase": "購入品の追加",
     "deletePurchase": "購入品の削除",
@@ -259,7 +262,7 @@
     "parchasePlace2": "場所"
   },
 
-  "Validate":{
+  "Validate": {
     "type": "入力してください",
     "singleEight": "半角数字8桁で入力してください",
     "leastEight": "8桁以上入力してください",
@@ -273,7 +276,7 @@
     "select": "選択してください"
   },
 
-  "List":{
+  "List": {
     "food": "模擬店(食品販売)",
     "goods": "模擬店(物品販売)",
     "stage": "ステージ企画",

--- a/user_front/pages/regist/item/index.vue
+++ b/user_front/pages/regist/item/index.vue
@@ -107,7 +107,9 @@ const registerItem = async () => {
       getMaxValueByItemId(registerParams[i].rentalItemId) <
       registerParams[i].num
     ) {
-      alert("貸し出し可能個数を超過している物品があるので修正してください。");
+      alert(
+        "貸し出し可能個数を超過している物品があるので修正してください。\nPlease correct the number of items that have exceeded the number of items available for loan."
+      );
       return;
     }
     const uniqueRentalItems = new Set();
@@ -258,7 +260,7 @@ const updateSelectedLocation = (event: Event) => {
           </div>
           <p>
             {{ getMaxValueByItemId(registerParams[idx].rentalItemId) }}
-            個まで貸し出し可能です
+            {{ $t("Item.maxNum") }}
           </p>
           <ErrorMessage class="text-rose-600" :name="`items[${idx}].itemNum`" />
 

--- a/user_front/pages/regist/item/index.vue
+++ b/user_front/pages/regist/item/index.vue
@@ -185,7 +185,7 @@ const updateSelectedLocation = (event: Event) => {
       <Card border="none" align="end" gap="20px">
         <div class="flex gap-3">
           <div v-if="Number(state.groupCategoryId) !== 3">
-            <label>
+            <label class="mr-2">
               <input
                 type="radio"
                 value="屋内団体"
@@ -193,7 +193,7 @@ const updateSelectedLocation = (event: Event) => {
                 :checked="selectedLocation === '屋内団体'"
                 @click="updateSelectedLocation"
               />
-              屋内団体
+              {{ $t('Item.insideGroup') }}
             </label>
             <label>
               <input
@@ -203,7 +203,7 @@ const updateSelectedLocation = (event: Event) => {
                 :checked="selectedLocation === '屋外団体'"
                 @click="updateSelectedLocation"
               />
-              屋外団体
+              {{ $t('Item.outsideGroup') }}
             </label>
           </div>
           <div v-if="Number(state.groupCategoryId) === 3">
@@ -215,7 +215,7 @@ const updateSelectedLocation = (event: Event) => {
                 :checked="selectedLocation === 'ステージ団体'"
                 @click="updateSelectedLocation"
               />
-              ステージ団体
+              {{ $t('Item.stageGroup') }}
             </label>
           </div>
         </div>

--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -274,7 +274,7 @@ const isRentalItemOverlap = computed(() => {
 
 // rentalOrdersで被っているものの名前を取得
 const rentalItemOverlap = computed(() => {
-  if (!rentalOrders.value) return '';
+  if (!rentalOrders.value) return "";
   const rentalOrder = rentalOrders.value.map((rentalOrder) => {
     return rentalOrder.rental_item.name;
   });
@@ -283,72 +283,77 @@ const rentalItemOverlap = computed(() => {
   const rentalOrderArray2 = rentalOrderArray.filter((rentalOrder) => {
     return rentalOrderSet.has(rentalOrder);
   });
-  return rentalOrderArray2.join(' / ');
+  return rentalOrderArray2.join(" / ");
 });
 </script>
 
 <template>
-<Container :name="group?.name">
-  <template #tabs>
-    <ul class="flex">
-      <li @click="tab = 1">
-        <div :class="{ select: tab === 1 }" class="title">{{ $t('RegistInfo.subrepresentative') }}</div>
-      </li>
-      <li v-if="groupCategoryId !== 3" @click="tab = 2">
-        <div :class="{ select: tab === 2 }" class="title">{{ $t('RegistInfo.place') }}</div>
-      </li>
-      <li v-if="groupCategoryId === 3" @click="tab = 3">
-        <div :class="{ select: tab === 3 }" class="title">{{ $t('RegistInfo.stage') }}</div>
-      </li>
-      <li v-if="groupCategoryId === 3" @click="tab = 4">
-        <div :class="{ select: tab === 4 }" class="title">{{ $t('RegistInfo.stageOption') }}</div>
-      </li>
-      <li @click="tab = 5">
-        <div :class="{ select: tab === 5 }" class="title">{{ $t('RegistInfo.power') }}</div>
-      </li>
-      <li @click="tab = 6">
-        <div :class="{ select: tab === 6 }" class="title">{{ $t('RegistInfo.item') }}</div>
-      </li>
-      <li @click="tab = 7">
-        <div :class="{ select: tab === 7 }" class="title">{{ $t('RegistInfo.employees') }}</div>
-      </li>
-      <li @click="tab = 8">
-        <div :class="{ select: tab === 8 }" class="title">{{ $t('RegistInfo.food') }}</div>
-      </li>
-      <li @click="tab = 9">
-        <div :class="{ select: tab === 9 }" class="title">{{ $t('RegistInfo.purchase') }}</div>
-      </li>
-    </ul>
-  </template>
-  <template #body>
-    <div class="ml-12 pt-4">
-      <!-- 副代表申請  -->
-      <div v-show="tab === 1">
-        <RegistInfoCardSubRep
-          :group-id="group?.id"
-          :id="subRep?.id"
-          :name="subRep?.name"
-          :department="subRep?.department"
-          :department_id="subRep?.department_id"
-          :grade="subRep?.grade"
-          :grade_id="subRep?.grade_id"
-          :studentId="subRep?.student_id"
-          :email="subRep?.email"
-          :tel="subRep?.tel"
-          @reload-sub-rep="reload"
-        />
-      </div>
-
-      <!-- 会場申請 group_category_id !== ３ -->
-      <div v-show="tab === 2">
-        <div class="mb-4">
-          <RegistInfoCardPlace
-            :id="placeOrder?.place_order.id"
-            :regist="placeOrder?.place_order"
-            :n="1"
-            :place="placeOrder?.first"
-            :remark="placeOrder?.remark"
-            @reload-place="reload"
+  <Container :name="group?.name">
+    <template #tabs>
+      <ul class="flex">
+        <li @click="tab = 1">
+          <div :class="{ select: tab === 1 }" class="title">
+            {{ $t("RegistInfo.subrepresentative") }}
+          </div>
+        </li>
+        <li v-if="groupCategoryId !== 3" @click="tab = 2">
+          <div :class="{ select: tab === 2 }" class="title">
+            {{ $t("RegistInfo.place") }}
+          </div>
+        </li>
+        <li v-if="groupCategoryId === 3" @click="tab = 3">
+          <div :class="{ select: tab === 3 }" class="title">
+            {{ $t("RegistInfo.stage") }}
+          </div>
+        </li>
+        <li v-if="groupCategoryId === 3" @click="tab = 4">
+          <div :class="{ select: tab === 4 }" class="title">
+            {{ $t("RegistInfo.stageOption") }}
+          </div>
+        </li>
+        <li @click="tab = 5">
+          <div :class="{ select: tab === 5 }" class="title">
+            {{ $t("RegistInfo.power") }}
+          </div>
+        </li>
+        <li @click="tab = 6">
+          <div :class="{ select: tab === 6 }" class="title">
+            {{ $t("RegistInfo.item") }}
+          </div>
+        </li>
+        <li @click="tab = 7">
+          <div :class="{ select: tab === 7 }" class="title">
+            {{ $t("RegistInfo.employees") }}
+          </div>
+        </li>
+        <li @click="tab = 8">
+          <div :class="{ select: tab === 8 }" class="title">
+            {{ $t("RegistInfo.food") }}
+          </div>
+        </li>
+        <li @click="tab = 9">
+          <div :class="{ select: tab === 9 }" class="title">
+            {{ $t("RegistInfo.purchase") }}
+          </div>
+        </li>
+      </ul>
+    </template>
+    <template #body>
+      <div class="ml-12 pt-4">
+        <!-- 副代表申請  -->
+        <div v-show="tab === 1">
+          <RegistInfoCardSubRep
+            :group-id="group?.id"
+            :id="subRep?.id"
+            :name="subRep?.name"
+            :department="subRep?.department"
+            :department_id="subRep?.department_id"
+            :grade="subRep?.grade"
+            :grade_id="subRep?.grade_id"
+            :studentId="subRep?.student_id"
+            :email="subRep?.email"
+            :tel="subRep?.tel"
+            @reload-sub-rep="reload"
           />
         </div>
 
@@ -467,7 +472,7 @@ const rentalItemOverlap = computed(() => {
         <!-- 物品申請 -->
         <div v-show="tab === 6" class="flex flex-wrap flex-col">
           <div v-if="isRentalItemOverlap" class="text-red-500">
-            <p>{{rentalItemOverlap}} が重複しています</p>
+            <p>{{ rentalItemOverlap }} が重複しています</p>
             <p>削除してください</p>
           </div>
           <div class="flex">
@@ -563,7 +568,6 @@ const rentalItemOverlap = computed(() => {
           />
         </div>
       </div>
-    </div>
     </template>
   </Container>
 </template>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1207 
- https://github.com/NUTFes/group-manager-2/issues/1207

# 概要
<!-- 開発内容の概要を記載 -->
MyPage後の登録情報が見れないバグを修正
原因は https://github.com/NUTFes/group-manager-2/pull/1208/files#diff-6368c2978541f7ece1cd5022ef9c790bbc6e58b1baac687676c159ff369eebcdL342-L351 の選択箇所でした
追加で、新規登録の物品登録時に英語対応できてない箇所があったので、その対応もしました


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

### [登録情報](http://localhost:8002/regist_info)

<img width="1395" alt="スクリーンショット 2023-05-18 19 10 31" src="https://github.com/NUTFes/group-manager-2/assets/71711872/45e6f2d8-6b87-4cb4-b18b-efc91fc8d075">

### [新規登録の物品登録時](http://localhost:8002/regist/item)
<img width="1395" alt="スクリーンショット 2023-05-18 19 09 21" src="https://github.com/NUTFes/group-manager-2/assets/71711872/2f384e78-21c2-4d3b-b471-c1f52f67254e">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 新規登録もしくはマイページに遷移し、登録情報が全て確認できるか
- [x] 新規登録の物品登録時に日本語の箇所がないか

# 備考
