### PR TITLE
団体登録後の物品の登録・編集時にバリデーションを追加(#1206)

### DIFF
--- a/user_front/components/RegistInfo/add/Item.vue
+++ b/user_front/components/RegistInfo/add/Item.vue
@@ -1,57 +1,123 @@
 <script lang="ts" setup>
-import { Item, ItemList } from "@/types/regist/item"
-import { useField, useForm } from 'vee-validate'
-import { editItemSchema } from '~/utils/validate'
-const config = useRuntimeConfig()
+import { Item, ItemList } from "@/types/regist/item";
+import { useField, useForm } from "vee-validate";
+import { editItemSchema } from "~/utils/validate";
+const config = useRuntimeConfig();
 
 const { meta, isSubmitting } = useForm({
   validationSchema: editItemSchema,
-})
-const { handleChange: handleName, errorMessage: nameError } = useField('itemNameId')
-const { handleChange: handleNum, errorMessage: numError } = useField('itemNum')
+});
+const { handleChange: handleName, errorMessage: nameError } =
+  useField("itemNameId");
+const { handleChange: handleNum, errorMessage: numError } = useField("itemNum");
 
 interface Props {
-  groupId: number | null
+  groupId: number | null;
 }
 
 interface Emits {
-  (e: 'update:addItem', isAddItem: boolean): void
-  (e: 'reloadItem', v: null): void
+  (e: "update:addItem", isAddItem: boolean): void;
+  (e: "reloadItem", v: null): void;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   groupId: null,
-})
+});
 
-const emits = defineEmits<Emits>()
-const itemList = ref<ItemList[]>([]);
+const emits = defineEmits<Emits>();
+
+const groupCategoryId = Number(localStorage.getItem("group_category_id"));
+const insideRentableItemList = ref<ItemList[]>([]);
+const outsideRentableItemList = ref<ItemList[]>([]);
+// 場所と物品を制限するための変数
+const selectedLocation = ref<string>("屋内団体");
+const selectableItemList = ref<ItemList[]>([]);
 
 onMounted(async () => {
   if (Number(localStorage.getItem("group_category_id")) === 3) {
-    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
+    const itemData = await $fetch<Item>(
+      config.APIURL + "/api/v1/get_stage_rentable_items"
+    );
     itemData.data.forEach((item) => {
-      itemList.value.push(item);
+      selectableItemList.value.push(item);
     });
   } else {
-    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_shop_rentable_items");
-    itemData.data.forEach((item) => {
-      itemList.value.push(item);
+    const insideRentableItemData = await $fetch<Item>(
+      config.APIURL + "/api/v1/get_inside_shop_rentable_items"
+    );
+    insideRentableItemData.data.forEach((item) => {
+      insideRentableItemList.value.push(item);
+    });
+    const outsideRentableItemData = await $fetch<Item>(
+      config.APIURL + "/api/v1/get_outside_shop_rentable_items"
+    );
+    outsideRentableItemData.data.forEach((item) => {
+      outsideRentableItemList.value.push(item);
+    });
+    insideRentableItemList.value.forEach((item) => {
+      selectableItemList.value.push(item);
     });
   }
-})
+});
 
-const newItem = ref<number | null>()
-const newNum = ref<number | null>()
+// 物品のidから物品の情報を取得し、物品の貸し出し可能数を返す
+const getMaxValueByItemId = (id: number) => {
+  const items = selectableItemList.value.find((item) => item.id === id);
+
+  let maxValue = 0;
+  if (selectedLocation.value === "屋外団体" && items?.name === "テント") {
+    maxValue = 1;
+  } else if (
+    selectedLocation.value === "屋外団体" &&
+    (items?.name === "机" || items?.name === "椅子")
+  ) {
+    maxValue = 20;
+  } else {
+    maxValue = 99;
+  }
+  return maxValue;
+};
+
+const updateSelectedLocation = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  switch (target.value) {
+    case "屋内団体":
+      selectableItemList.value = [];
+      insideRentableItemList.value.forEach((item) => {
+        selectableItemList.value.push(item);
+      });
+      break;
+    case "屋外団体":
+      selectableItemList.value = [];
+      outsideRentableItemList.value.forEach((item) => {
+        selectableItemList.value.push(item);
+      });
+      break;
+  }
+};
+
+const newItem = ref<number | null>();
+const newNum = ref<number | null>();
 
 const addItemClose = () => {
-  emits('update:addItem', false)
-}
+  emits("update:addItem", false);
+};
 
 const reloadItem = () => {
-  emits('reloadItem', null)
-}
+  emits("reloadItem", null);
+};
 
 const addItem = async () => {
+  // 貸し出し可能物品個数のチェック
+  const itemId = newItem.value as number;
+  const itemNum = newNum.value as number;
+  if (getMaxValueByItemId(itemId) < itemNum) {
+    alert(
+      "貸し出し可能個数を超過している物品があるので修正してください。\nPlease correct the number of items that have exceeded the number of items available for loan."
+    );
+    return;
+  }
+
   await useFetch(config.APIURL + "/rental_orders", {
     method: "POST",
     params: {
@@ -59,43 +125,97 @@ const addItem = async () => {
       rental_item_id: newItem.value,
       num: newNum.value,
     },
-  })
-  reloadItem()
-  addItemClose()
+  });
+  reloadItem();
+  addItemClose();
 };
 
 const reset = () => {
-  newItem.value = null
-  newNum.value = null
-}
-
+  newItem.value = null;
+  newNum.value = null;
+};
 </script>
 
 <template>
   <Modal :title="$t('Item.addItem')">
     <template #close>
       <div class="flex justify-end">
-        <button @click="addItemClose()" class="hover:text-black hover:opacity-75"
-        >✖</button>
+        <button
+          @click="addItemClose()"
+          class="hover:text-black hover:opacity-75"
+        >
+          ✖
+        </button>
       </div>
     </template>
     <template #form>
-      <div class="text">{{ $t('Item.item') }}</div>
-      <select class="entry" v-model="newItem" @change="handleName" :class="{'error_border': nameError}">
+      <div class="flex mt-4 gap-3 justify-end">
+        <div v-if="Number(groupCategoryId) !== 3">
+          <label class="mr-2">
+            <input
+              type="radio"
+              value="屋内団体"
+              v-model="selectedLocation"
+              :checked="selectedLocation === '屋内団体'"
+              @click="updateSelectedLocation"
+            />
+            {{ $t("Item.insideGroup") }}
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="屋外団体"
+              v-model="selectedLocation"
+              :checked="selectedLocation === '屋外団体'"
+              @click="updateSelectedLocation"
+            />
+            {{ $t("Item.outsideGroup") }}
+          </label>
+        </div>
+        <div v-if="Number(groupCategoryId) === 3">
+          <label>
+            <input
+              type="radio"
+              value="ステージ団体"
+              v-model="selectedLocation"
+              :checked="selectedLocation === 'ステージ団体'"
+              @click="updateSelectedLocation"
+            />
+            {{ $t("Item.stageGroup") }}
+          </label>
+        </div>
+      </div>
+      <div class="text">{{ $t("Item.item") }}</div>
+      <select
+        class="entry"
+        v-model="newItem"
+        @change="handleName"
+        :class="{ error_border: nameError }"
+      >
         <option
-          v-for="list in itemList"
+          v-for="list in selectableItemList"
           :key="list.id"
           :value="list.id"
-        >{{ list.name }}
+        >
+          {{ list.name }}
         </option>
       </select>
       <div class="error_msg">{{ nameError }}</div>
-      <div class="text">{{ $t('Item.number') }}</div>
-      <input class="entry" v-model="newNum" @change="handleNum" :class="{'error_border': numError}">
+      <div class="text">{{ $t("Item.number") }}</div>
+      <input
+        class="entry"
+        v-model="newNum"
+        @change="handleNum"
+        :class="{ error_border: numError }"
+      />
       <div class="error_msg">{{ numError }}</div>
       <div class="flex justify-between mt-8 mx-8">
         <RegistPageButton :text="$t('Button.reset')" @click="reset()" />
-        <RegistPageButton :disabled="!meta.valid || isSubmitting" :text="$t('Button.add')" @click="addItem()" />
+        <RegistPageButton
+          :disabled="!meta.valid || isSubmitting"
+          :text="$t('Button.add')"
+          @click="addItem()"
+        />
       </div>
     </template>
   </Modal>
@@ -103,10 +223,10 @@ const reset = () => {
 
 <style scoped>
 .error_msg {
-  @apply mx-[10%] text-rose-600
+  @apply mx-[10%] text-rose-600;
 }
 .error_border {
-  @apply border-2 border-rose-600
+  @apply border-2 border-rose-600;
 }
 .text {
   margin: 3% 10% 0%;
@@ -114,8 +234,8 @@ const reset = () => {
 .entry {
   margin: 0% 10%;
   border: 1px solid silver;
-  border-top : solid 1px #717171;
-  border-bottom : solid 1px #e0e0e0;
+  border-top: solid 1px #717171;
+  border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
 }

--- a/user_front/components/RegistInfo/edit/Item.vue
+++ b/user_front/components/RegistInfo/edit/Item.vue
@@ -1,68 +1,98 @@
 <script lang="ts" setup>
-import { Item, ItemList } from "@/types/regist/item"
-import { useField, useForm } from 'vee-validate'
-import { editItemSchema } from '~/utils/validate'
+import { Item, ItemList } from "@/types/regist/item";
+import { useField, useForm } from "vee-validate";
+import { editItemSchema } from "~/utils/validate";
 const config = useRuntimeConfig();
 
 interface Regist {
-  groupId: number | null
-  id: number | null
-  item: number | null
-  num: number | null
+  groupId: number | null;
+  id: number | null;
+  item: number | null;
+  num: number | null;
 }
 
 const props = withDefaults(defineProps<Regist>(), {
   groupId: null,
   id: null,
   item: null,
-  num: null
-})
+  num: null,
+});
 const { meta, isSubmitting } = useForm({
   validationSchema: editItemSchema,
   initialValues: {
     itemNameId: props.item,
-    itemNum: props.num
-  }
-})
-const { handleChange: handleName, errorMessage: nameError } = useField('itemNameId')
-const { handleChange: handleNum, errorMessage: numError } = useField('itemNum')
-
+    itemNum: props.num,
+  },
+});
+const { handleChange: handleName, errorMessage: nameError } =
+  useField("itemNameId");
+const { handleChange: handleNum, errorMessage: numError } = useField("itemNum");
 
 interface Emits {
-  (e: 'update:editItem', isEditItem: boolean): void
-  (e: 'reloadItem', v: null): void
+  (e: "update:editItem", isEditItem: boolean): void;
+  (e: "reloadItem", v: null): void;
 }
 
-const emits = defineEmits<Emits>()
+const emits = defineEmits<Emits>();
 
 const closeEditItem = () => {
-  emits('update:editItem', false)
-}
+  emits("update:editItem", false);
+};
 
 const reloadItem = () => {
-  emits('reloadItem', null)
-}
-const itemList = ref<ItemList[]>([]);
+  emits("reloadItem", null);
+};
 
-const newItem = ref<Regist['item']>(props.item)
-const newNum = ref<Regist['num']>(props.num)
+const groupCategoryId = Number(localStorage.getItem("group_category_id"));
+const insideRentableItemList = ref<ItemList[]>([]);
+const outsideRentableItemList = ref<ItemList[]>([]);
+
+const newItem = ref<Regist["item"]>(props.item);
+const newNum = ref<Regist["num"]>(props.num);
+
+// 場所と物品を制限するための変数
+const selectedLocation = ref<string>("屋内団体");
+const selectableItemList = ref<ItemList[]>([]);
 
 onMounted(async () => {
   if (Number(localStorage.getItem("group_category_id")) === 3) {
-    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_stage_rentable_items");
+    const itemData = await $fetch<Item>(
+      config.APIURL + "/api/v1/get_stage_rentable_items"
+    );
     itemData.data.forEach((item) => {
-      itemList.value.push(item);
+      selectableItemList.value.push(item);
     });
   } else {
-    const itemData = await $fetch<Item>(config.APIURL + "/api/v1/get_shop_rentable_items");
-    itemData.data.forEach((item) => {
-      itemList.value.push(item);
+    const insideRentableItemData = await $fetch<Item>(
+      config.APIURL + "/api/v1/get_inside_shop_rentable_items"
+    );
+    insideRentableItemData.data.forEach((item) => {
+      insideRentableItemList.value.push(item);
+    });
+    const outsideRentableItemData = await $fetch<Item>(
+      config.APIURL + "/api/v1/get_outside_shop_rentable_items"
+    );
+    outsideRentableItemData.data.forEach((item) => {
+      outsideRentableItemList.value.push(item);
+    });
+    insideRentableItemList.value.forEach((item) => {
+      selectableItemList.value.push(item);
     });
   }
-})
+});
 
 const editItem = async () => {
-  if (props.id === null){
+  // 貸し出し可能物品個数のチェック
+  const itemId = newItem.value as number;
+  const itemNum = newNum.value as number;
+  if (getMaxValueByItemId(itemId) < itemNum) {
+    alert(
+      "貸し出し可能個数を超過している物品があるので修正してください。\nPlease correct the number of items that have exceeded the number of items available for loan."
+    );
+    return;
+  }
+
+  if (props.id === null) {
     await useFetch(config.APIURL + "/rental_orders", {
       method: "POST",
       params: {
@@ -70,8 +100,8 @@ const editItem = async () => {
         rental_item_id: newItem.value,
         num: newNum.value,
       },
-    })
-  }else{
+    });
+  } else {
     await useFetch(config.APIURL + "/rental_orders" + "/" + props.id, {
       method: "PUT",
       params: {
@@ -79,44 +109,138 @@ const editItem = async () => {
         rental_item_id: newItem.value,
         num: newNum.value,
       },
-    })
+    });
   }
-  reloadItem()
-  closeEditItem()
+  reloadItem();
+  closeEditItem();
 };
 
 const reset = () => {
-  newItem.value = null
-  newNum.value = null
-}
+  newItem.value = null;
+  newNum.value = null;
+};
 
+// 物品のidから物品の情報を取得し、物品の貸し出し可能数を返す
+const getMaxValueByItemId = (id: number) => {
+  const items = selectableItemList.value.find((item) => item.id === id);
+
+  let maxValue = 0;
+  if (selectedLocation.value === "屋外団体" && items?.name === "テント") {
+    maxValue = 1;
+  } else if (
+    selectedLocation.value === "屋外団体" &&
+    (items?.name === "机" || items?.name === "椅子")
+  ) {
+    maxValue = 20;
+  } else {
+    maxValue = 99;
+  }
+  return maxValue;
+};
+
+const updateSelectedLocation = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  switch (target.value) {
+    case "屋内団体":
+      selectableItemList.value = [];
+      insideRentableItemList.value.forEach((item) => {
+        selectableItemList.value.push(item);
+      });
+      break;
+    case "屋外団体":
+      selectableItemList.value = [];
+      outsideRentableItemList.value.forEach((item) => {
+        selectableItemList.value.push(item);
+      });
+      break;
+  }
+};
 </script>
 
 <template>
   <Modal :title="$t('Item.editItem')">
     <template #close>
       <div class="flex justify-end">
-        <button @click="closeEditItem()" class="hover:text-black hover:opacity-75"
-        >✖</button>
+        <button
+          @click="closeEditItem()"
+          class="hover:text-black hover:opacity-75"
+        >
+          ✖
+        </button>
       </div>
     </template>
     <template #form>
-      <div class="text">{{ $t('Item.item') }}</div>
-      <select class="entry" v-model="newItem" @change="handleName" :class="{'error_border': nameError}">
+      <div class="flex mt-4 gap-3 justify-end">
+        <div v-if="Number(groupCategoryId) !== 3">
+          <label class="mr-2">
+            <input
+              type="radio"
+              value="屋内団体"
+              v-model="selectedLocation"
+              :checked="selectedLocation === '屋内団体'"
+              @click="updateSelectedLocation"
+            />
+            {{ $t("Item.insideGroup") }}
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="屋外団体"
+              v-model="selectedLocation"
+              :checked="selectedLocation === '屋外団体'"
+              @click="updateSelectedLocation"
+            />
+            {{ $t("Item.outsideGroup") }}
+          </label>
+        </div>
+        <div v-if="Number(groupCategoryId) === 3">
+          <label>
+            <input
+              type="radio"
+              value="ステージ団体"
+              v-model="selectedLocation"
+              :checked="selectedLocation === 'ステージ団体'"
+              @click="updateSelectedLocation"
+            />
+            {{ $t("Item.stageGroup") }}
+          </label>
+        </div>
+      </div>
+      <div class="text">{{ $t("Item.item") }}</div>
+      <select
+        class="entry"
+        v-model="newItem"
+        @change="handleName"
+        :class="{ error_border: nameError }"
+      >
         <option
-          v-for="list in itemList"
+          v-for="list in selectableItemList"
           :key="list.id"
           :value="list.id"
-        >{{ list.name }}
+        >
+          {{ list.name }}
         </option>
       </select>
       <div class="error_msg">{{ nameError }}</div>
-      <div class="text">{{ $t('Item.number') }}</div>
-      <input type="number" class="entry" v-model="newNum" @change="handleNum" :class="{'error_border': numError}"/>
+      <div class="text">{{ $t("Item.number") }}</div>
+      <input
+        type="number"
+        class="entry"
+        v-model="newNum"
+        @change="handleNum"
+        :class="{ error_border: numError }"
+      />
       <div class="error_msg">{{ numError }}</div>
       <div class="flex justify-between mt-8 mx-8">
-        <RegistPageButton :text="$t('Button.reset')" @click="reset()"></RegistPageButton>
-        <RegistPageButton :disabled="!meta.valid || isSubmitting" :text="$t('Button.edit')" @click="editItem()"></RegistPageButton>
+        <RegistPageButton
+          :text="$t('Button.reset')"
+          @click="reset()"
+        ></RegistPageButton>
+        <RegistPageButton
+          :disabled="!meta.valid || isSubmitting"
+          :text="$t('Button.edit')"
+          @click="editItem()"
+        ></RegistPageButton>
       </div>
     </template>
   </Modal>
@@ -124,10 +248,10 @@ const reset = () => {
 
 <style scoped>
 .error_msg {
-  @apply mx-[10%] text-rose-600
+  @apply mx-[10%] text-rose-600;
 }
 .error_border {
-  @apply border-2 border-rose-600
+  @apply border-2 border-rose-600;
 }
 .text {
   margin: 3% 10% 0%;
@@ -135,8 +259,8 @@ const reset = () => {
 .entry {
   margin: 0% 10%;
   border: 1px solid silver;
-  border-top : solid 1px #717171;
-  border-bottom : solid 1px #e0e0e0;
+  border-top: solid 1px #717171;
+  border-bottom: solid 1px #e0e0e0;
   border-radius: 5px;
   background-color: white;
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1206 

# 概要
<!-- 開発内容の概要を記載 -->
ユーザ・団体登録後の物品の登録・編集時にバリデーションを追加しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8002/regist_info の 物品タブ

https://github.com/NUTFes/group-manager-2/assets/71711872/7e96d339-c079-4957-91be-428642d22cb5

# テスト項目
<!-- テストしてほしい内容を記載 -->
http://localhost:8002/regist_info の物品タブにおいて登録・編集にて同様の
- 登録
  - [x] `屋外団体` を選択後 `机` を選択し、数量を `20` より多く入力して登録ボタンを押すとAlertが出て物品が登録できないか
  - [x] `屋外団体` を選択後 `椅子` を選択し、数量を `20` より多く入力して登録ボタンを押すとAlertが出て物品が登録できないか
  - [x] `屋外団体` を選択後 `テント` を選択し、数量を `1` より多く入力して登録ボタンを押すとAlertが出て物品が登録できないか
- 編集
  - [x] `屋外団体` を選択後 `机` を選択し、数量を `20` より多く入力して編集ボタンを押すとAlertが出て物品が登録できないか
  - [x] `屋外団体` を選択後 `椅子` を選択し、数量を `20` より多く入力して編集ボタンを押すとAlertが出て物品が登録できないか
  - [x] `屋外団体` を選択後 `テント` を選択し、数量を `1` より多く入力して編集ボタンを押すとAlertが出て物品が登録できないか

# 備考
編集モーダルを開いた時にのデフォルトが屋内団体になっており、選択していたものと異なるものを選択してしまう挙動になってしまっていますが、屋内・屋外のどちらを選択しているかを保存するカラムがないのでこうなってしまってます。