### PR TITLE
登録時の会場申請の時間入力で文字列が入力できてしまう

### DIFF
--- a/user_front/pages/regist/stage/rain.vue
+++ b/user_front/pages/regist/stage/rain.vue
@@ -118,21 +118,21 @@ const skip = () =>{
 
           <div class="flex">
             <p class="label">{{ $t('Stage.performanceTime') }}</p>
-            <input class="form" v-model="registerParams.performanceTime" @change="handlePerformanceTime">
+            <input type="number" min="0" max="120" class="form" v-model="registerParams.performanceTime" @change="handlePerformanceTime">
             <p>min</p>
           </div>
           <div class="text-rose-600">{{ performanceTimeError }}</div>
 
           <div class="flex">
             <p class="label">{{ $t('Stage.preparationTime') }}</p>
-            <input class="form" v-model="registerParams.preparationTime" @change="handlePreparationTime">
+            <input type="number" min="0" max="120" class="form" v-model="registerParams.preparationTime" @change="handlePreparationTime">
             <p>min</p>
           </div>
           <div class="text-rose-600">{{ preparationTimeError }}</div>
 
           <div class="flex">
             <p class="label">{{ $t('Stage.cleanUpTime') }}</p>
-            <input class="form" v-model="registerParams.cleanUpTime" @change="handleCleanUpTime">
+            <input type="number" min="0" max="120" class="form" v-model="registerParams.cleanUpTime" @change="handleCleanUpTime">
             <p>min</p>
           </div>
           <div class="text-rose-600">{{ cleanUpTimeError }}</div>

--- a/user_front/pages/regist/stage/sunny.vue
+++ b/user_front/pages/regist/stage/sunny.vue
@@ -117,21 +117,21 @@ const skip = () =>{
 
           <div class="flex">
             <p class="label">{{ $t('Stage.performanceTime') }}</p>
-            <input class="form" v-model="registerParams.performanceTime" @change="handlePerformanceTime">
+            <input type="number" min="0" max="120" class="form" v-model="registerParams.performanceTime" @change="handlePerformanceTime">
             <p>min</p>
           </div>
           <div class="text-rose-600">{{ performanceTimeError }}</div>
 
           <div class="flex">
             <p class="label">{{ $t('Stage.preparationTime') }}</p>
-            <input class="form" v-model="registerParams.preparationTime" @change="handlePreparationTime">
+            <input type="number" min="0" max="120" class="form" v-model="registerParams.preparationTime" @change="handlePreparationTime">
             <p>min</p>
           </div>
           <div class="text-rose-600">{{ preparationTimeError }}</div>
 
           <div class="flex">
             <p class="label">{{ $t('Stage.cleanUpTime') }}</p>
-            <input class="form" v-model="registerParams.cleanUpTime" @change="handleCleanUpTime">
+            <input type="number" min="0" max="120" class="form" v-model="registerParams.cleanUpTime" @change="handleCleanUpTime">
             <p>min</p>
           </div>
           <div class="text-rose-600">{{ cleanUpTimeError }}</div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1212

# 概要
<!-- 開発内容の概要を記載 -->

- inputタグにtype="number"を追加
- ついでにmin, maxも追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="604" alt="スクリーンショット 2023-05-20 午後2 57 23" src="https://github.com/NUTFes/group-manager-2/assets/46074208/366c7df4-0ddf-4151-9d2a-0d9468a1a3c8">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 登録時に文字列が入力できないことを確認
