### PR TITLE
管理画面で物品一覧の画面のずれを修正

### DIFF
--- a/admin_view/nuxt-project/pages/rental_items/index.vue
+++ b/admin_view/nuxt-project/pages/rental_items/index.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="main-content">
     <SubHeader pageTitle="物品一覧">
-      <CommonButton v-if="this.$role(roleID).places.create" iconName="add_circle" :on_click="openAddModal">
+      <CommonButton
+        v-if="this.$role(roleID).places.create"
+        iconName="add_circle"
+        :on_click="openAddModal"
+      >
         追加
       </CommonButton>
     </SubHeader>
@@ -33,11 +37,7 @@
       </Table>
     </Card>
 
-    <AddModal
-      @close="closeAddModal"
-      v-if="isOpenAddModal"
-      title="物品の追加"
-    >
+    <AddModal @close="closeAddModal" v-if="isOpenAddModal" title="物品の追加">
       <template v-slot:form>
         <div>
           <h3>物品名</h3>
@@ -47,11 +47,7 @@
           <h3>屋内模擬店貸出可否</h3>
           <select v-model="isInsideShopRentable">
             <option disabled value="">選択してください</option>
-            <option
-              v-for="r in isRentableList"
-              :key="r"
-              :value="r.value"
-            >
+            <option v-for="r in isRentableList" :key="r" :value="r.value">
               {{ r.text }}
             </option>
           </select>
@@ -60,11 +56,7 @@
           <h3>屋外模擬店貸出可否</h3>
           <select v-model="isOutsideShopRentable">
             <option disabled value="">選択してください</option>
-            <option
-              v-for="r in isRentableList"
-              :key="r"
-              :value="r.value"
-            >
+            <option v-for="r in isRentableList" :key="r" :value="r.value">
               {{ r.text }}
             </option>
           </select>
@@ -73,11 +65,7 @@
           <h3>ステージ貸出可否</h3>
           <select v-model="isStageRentable">
             <option disabled value="">選択してください</option>
-            <option
-              v-for="r in isRentableList"
-              :key="r"
-              :value="r.value"
-            >
+            <option v-for="r in isRentableList" :key="r" :value="r.value">
               {{ r.text }}
             </option>
           </select>
@@ -89,13 +77,9 @@
         >
       </template>
     </AddModal>
-    <SnackBar
-      v-if="isOpenSnackBar"
-      @close="closeSnackBar"
-    >
+    <SnackBar v-if="isOpenSnackBar" @close="closeSnackBar">
       {{ message }}
     </SnackBar>
-
   </div>
 </template>
 
@@ -104,7 +88,13 @@ import { mapState } from "vuex";
 export default {
   data() {
     return {
-      headers: ["ID", "名前", "模擬店貸出", "ステージ貸出"],
+      headers: [
+        "ID",
+        "名前",
+        "屋内模擬店貸出",
+        "屋外模擬店貸出",
+        "ステージ貸出",
+      ],
       isRentableList: [
         { text: "貸出可能", value: true },
         { text: "貸出不可能", value: false },
@@ -156,12 +146,12 @@ export default {
         "/rental_items/" +
         "?name=" +
         this.name +
-        "&is_inside_rentable=" +
+        "&is_inside_shop_rentable=" +
         this.isInsideShopRentable +
-        "&is_outside_rentable=" +
+        "&is_outside_shop_rentable=" +
         this.isOutsideShopRentable +
         "&is_stage_rentable=" +
-        this.isStageRentable
+        this.isStageRentable;
 
       this.$axios.$post(url).then((response) => {
         this.openSnackBar(response.data.name + "を追加しました");


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1227

# 概要
<!-- 開発内容の概要を記載 -->
- 管理画面で物品一覧の画面のずれを修正
  - 屋内・屋外模擬店の貸出カラムを追加することで解決
- 物品追加時にエラーが出てたのでついでに修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8000/rental_items
### Before
![スクリーンショット 2023-05-23 0 09 19](https://github.com/NUTFes/group-manager-2/assets/71711872/10790584-306b-4948-b4af-e12b3c3a73e6)

### After
![スクリーンショット 2023-05-23 0 08 34](https://github.com/NUTFes/group-manager-2/assets/71711872/cb8f32c1-dd62-459e-85e3-fd0bd17e8953)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] http://localhost:8000/rental_items でテーブルのずれが修正されているか
