### PR TITLE
編集完了で通知が来て、mypageに戻るようにする

### DIFF
--- a/user_front/pages/mypage/edit_group/index.vue
+++ b/user_front/pages/mypage/edit_group/index.vue
@@ -77,11 +77,11 @@ const register = () => {
           "group_category_id",
           response.data.data.group_category_id
         );
+        alert('登録できました')
         router.push("/mypage");
       },
       (error) => {
-        console.log("登録できませんでした");
-        return error;
+        alert('登録できませんでした')
       }
     );
 }

--- a/user_front/pages/mypage/edit_group/index.vue
+++ b/user_front/pages/mypage/edit_group/index.vue
@@ -77,7 +77,7 @@ const register = () => {
           "group_category_id",
           response.data.data.group_category_id
         );
-        router.push("/regist/subrep");
+        router.push("/mypage");
       },
       (error) => {
         console.log("登録できませんでした");

--- a/user_front/pages/mypage/edit_user_info/index.vue
+++ b/user_front/pages/mypage/edit_user_info/index.vue
@@ -70,6 +70,7 @@ const editUser = async () => {
     }
   ).then(() => {
     localStorage.setItem("uid", editParams.value.mail || "");
+    alert('登録できました')
     router.push("/mypage");
   });
 };

--- a/user_front/pages/mypage/password_reset/index.vue
+++ b/user_front/pages/mypage/password_reset/index.vue
@@ -32,7 +32,7 @@ const submit = () =>{
     )
     .then(
       (response) =>{
-        router.push("MyPage");
+        router.push("/myPage");
       }
     )
 }

--- a/user_front/pages/mypage/password_reset/index.vue
+++ b/user_front/pages/mypage/password_reset/index.vue
@@ -32,7 +32,11 @@ const submit = () =>{
     )
     .then(
       (response) =>{
-        router.push("/myPage");
+        alert('登録できました')
+        router.push("/mypage");
+      },
+      (error) => {
+        alert('登録できませんでした')
       }
     )
 }

--- a/user_front/pages/regist/announcement/index.vue
+++ b/user_front/pages/regist/announcement/index.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { loginCheck } from "~~/utils/methods";
 
+const router = useRouter()
 const config = useRuntimeConfig();
 const groupId = ref<number>(0)
 const announcement = ref<string>("")
@@ -22,6 +23,11 @@ const postAnnouncement = () => {
       "Content-Type": "application/json",
     },
   })
+  .then(
+    (response) =>{
+      router.push("/myPage");
+    }
+  )
 }
 </script>
 

--- a/user_front/pages/regist/announcement/index.vue
+++ b/user_front/pages/regist/announcement/index.vue
@@ -25,7 +25,11 @@ const postAnnouncement = () => {
   })
   .then(
     (response) =>{
-      router.push("/myPage");
+      alert('登録できました')
+      router.push("/mypage");
+    },
+    (error) => {
+      alert('登録できませんでした')
     }
   )
 }

--- a/user_front/pages/regist/publicRelations/index.vue
+++ b/user_front/pages/regist/publicRelations/index.vue
@@ -54,7 +54,15 @@ const getImageURL = () =>{
         },
       })
     })
-    router.push("/myPage");
+    .then(
+    (response) =>{
+      alert('登録できました')
+      router.push("/mypage");
+    },
+    (error) => {
+      alert('登録できませんでした')
+    }
+  )
 }
 </script>
 

--- a/user_front/pages/regist/publicRelations/index.vue
+++ b/user_front/pages/regist/publicRelations/index.vue
@@ -2,6 +2,7 @@
 import { getDownloadURL, getStorage, ref as fireRef, uploadBytes } from "firebase/storage";
 import { loginCheck } from "~~/utils/methods";
 
+const router = useRouter()
 const config = useRuntimeConfig();
 const state = reactive({
   groupId: 0,
@@ -51,8 +52,9 @@ const getImageURL = () =>{
         headers: {
           "Content-Type": "application/json",
         },
+      })
     })
-  })
+    router.push("/myPage");
 }
 </script>
 

--- a/user_front/pages/regist/venueMap/index.vue
+++ b/user_front/pages/regist/venueMap/index.vue
@@ -59,7 +59,6 @@ const postImageURL = () => {
       alert('登録できませんでした')
     }
   )
-  // router.push("/myPage");
 }
 </script>
 

--- a/user_front/pages/regist/venueMap/index.vue
+++ b/user_front/pages/regist/venueMap/index.vue
@@ -50,7 +50,16 @@ const postImageURL = () => {
       },
     })
   })
-  router.push("/myPage");
+  .then(
+    (response) =>{
+      alert('登録できました')
+      router.push("/mypage");
+    },
+    (error) => {
+      alert('登録できませんでした')
+    }
+  )
+  // router.push("/myPage");
 }
 </script>
 

--- a/user_front/pages/regist/venueMap/index.vue
+++ b/user_front/pages/regist/venueMap/index.vue
@@ -2,6 +2,7 @@
 import { getDownloadURL, getStorage, ref as fireRef, uploadBytes } from "firebase/storage";
 import { loginCheck } from "~~/utils/methods";
 
+const router = useRouter()
 const config = useRuntimeConfig();
 const state = reactive({
   groupId: 0,
@@ -30,13 +31,13 @@ const storageRef = fireRef(storage, fileName.value);
 
 const postImageURL = () => {
   selectedFile.value &&
-    uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
-      pictureName.value = snapshot.ref.name
-    });
+  uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
+    pictureName.value = snapshot.ref.name
+  });
   getDownloadURL(fireRef(storage, pictureName.value)).then((url) => {
     const postUrl =
-      "/venue_maps?group_id=" +
-      state.groupId;
+    "/venue_maps?group_id=" +
+    state.groupId;
 
     useFetch(config.APIURL + postUrl, {
       method: "POST",
@@ -49,6 +50,7 @@ const postImageURL = () => {
       },
     })
   })
+  router.push("/myPage");
 }
 </script>
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1223 

# 概要
<!-- 開発内容の概要を記載 -->
- 各ページでボタンを押したときにmypageに飛ぶようにする
- 成功か失敗かの通知を出す

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/pages/mypage/edit_group/index.vue
- user_front/pages/mypage/edit_user_info/index.vue
- user_front/pages/mypage/password_reset/index.vue
- user_front/pages/regist/announcement/index.vue
- user_front/pages/regist/publicRelations/index.vue
- user_front/pages/regist/venueMap/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/group-manager-2/assets/107479066/9fc30071-8cc5-437b-9920-e4c5d9c3f964)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- http://localhost:8002/mypage/edit_group → 編集 → 登録完了通知 → http://localhost:8002/mypage に飛ぶ
- http://localhost:8002/mypage/password_reset → register → 登録完了通知 → http://localhost:8002/mypage
- http://localhost:8002/regist/announcement → register → 登録完了通知 → http://localhost:8002/mypage
- http://localhost:8002/regist/venueMap → register → 登録完了通知 → http://localhost:8002/mypage
- http://localhost:8002/mypage/password_reset → register → 登録完了通知 → http://localhost:8002/mypage
- passwordとpassword_confirmationが違う時だけ登録失敗通知が出るが、それ以外はすべてのページで登録完了通知だけ出る（他にも登録失敗通知が出る場合があるか分からない、失敗してても完了通知が出ている場合も考えられる）

# 備考
- http://localhost:8002/mypage/edit_group のエラーメッセージとバリデーションがない、削除ボタンがある
- http://localhost:8002/mypage/edit_user_info/index.vue で初期値が入っていない
- http://localhost:8002/mypage/password_reset のエラーメッセージとバリデーションがない
- http://localhost:8002/regist/publicRelations のエラーメッセージとバリデーションがない、登録ボタンを2回押さないと動作しない
- http://localhost:8002/regist/announcement のエラーメッセージとバリデーションがない
- http://localhost:8002/regist/venueMap のエラーメッセージとバリデーションがない、登録ボタンを2回押さないと動作しない