### PR TITLE
cssが崩れて、リロードすると直る問題を修正

### DIFF
--- a/user_front/pages/mypage/edit_user_info/index.vue
+++ b/user_front/pages/mypage/edit_user_info/index.vue
@@ -4,6 +4,7 @@ import { useForm, useField } from "vee-validate";
 import { userDetailSchema } from "~~/utils/validate";
 import { User, UserDetail, EditUser, CurrentUser } from "~~/types/currentUser";
 import { gradeList, GradeWithDepartmentList } from "~/utils/list";
+import { NoScript } from '../../../.nuxt/components';
 
 const config = useRuntimeConfig();
 const router = useRouter();
@@ -184,7 +185,7 @@ const createCurrentDepartmentList = (e: any) => {
   </div>
 </template>
 
-<style>
+<style scoped>
 .error {
   @apply text-red-500 ml-4;
 }
@@ -221,27 +222,30 @@ const createCurrentDepartmentList = (e: any) => {
   padding: 1% 1% 1% 2%;
 }
 
-select,
-input {
+.regist-card input,
+.regist-card select {
   @apply text-left
     p-[1%]
     h-[50px]
     w-[1000px]
-    mt-5
+    mb-5
     rounded-[7px]
     text-lg
     align-top;
 }
-select,
-input:required {
+
+.regist-card input:required,
+.regist-card select {
   border: 1px solid red;
 }
-select,
-input:invalid {
+
+.regist-card input:invalid,
+.regist-cardselect {
   border: 1px solid red;
 }
-select,
-input:valid {
+
+.regist-card input:valid,
+.regist-card select {
   border: 1px solid #333333;
 }
 

--- a/user_front/pages/mypage/password_reset/index.vue
+++ b/user_front/pages/mypage/password_reset/index.vue
@@ -6,14 +6,14 @@ definePageMeta({
   layout: false,
 });
 
-const router = useRouter()
-const config = useRuntimeConfig()
+const router = useRouter();
+const config = useRuntimeConfig();
 
-const password = ref("")
-const password_confirmation = ref("")
+const password = ref("");
+const password_confirmation = ref("");
 
-const submit = () =>{
-  const url = config.APIURL+"/api/v1/current_user/password_reset";
+const submit = () => {
+  const url = config.APIURL + "/api/v1/current_user/password_reset";
   axios
     .post(
       url,
@@ -25,17 +25,15 @@ const submit = () =>{
         headers: {
           "Content-Type": "application/json",
           "access-token": localStorage.getItem("access-token"),
-          "client": localStorage.getItem("client"),
-          "uid": localStorage.getItem("uid"),
+          client: localStorage.getItem("client"),
+          uid: localStorage.getItem("uid"),
         },
       }
     )
-    .then(
-      (response) =>{
-        router.push("MyPage");
-      }
-    )
-}
+    .then((response) => {
+      router.push("MyPage");
+    });
+};
 
 onMounted(async () => {
   loginCheck();
@@ -45,38 +43,47 @@ onMounted(async () => {
 <template>
   <Header />
   <div class="regist-card">
-    <NuxtLink to="/mypage" class="regist-back-link">{{ $t('Mypage.goToMypage') }}</NuxtLink>
+    <NuxtLink to="/mypage" class="regist-back-link">{{
+      $t("Mypage.goToMypage")
+    }}</NuxtLink>
     <div class="reist-title-content">
-      <div class="user-info">{{ $t('User.resetPassword') }}</div>
+      <div class="user-info">{{ $t("User.resetPassword") }}</div>
     </div>
     <div>
-      <input type="password" :placeholder="$t('User.newPassword')" v-model="password" />
-      <input type="password" :placeholder="$t('User.newPasswordConfirm')" v-model="password_confirmation" />
+      <input
+        type="password"
+        :placeholder="$t('User.newPassword')"
+        v-model="password"
+      />
+      <input
+        type="password"
+        :placeholder="$t('User.newPasswordConfirm')"
+        v-model="password_confirmation"
+      />
     </div>
     <div class="regist-button">
-      <button class="regist-submit-button" @click="submit">{{ $t('Button.register') }}</button>
+      <button class="regist-submit-button" @click="submit">
+        {{ $t("Button.register") }}
+      </button>
     </div>
   </div>
 </template>
 
-<style>
+<style scoped>
 .regist-card {
-  @apply
-    w-[1000px]
+  @apply w-[1000px]
     mx-auto;
 }
 
 .reist-title-content {
-  @apply
-    flex
+  @apply flex
     flex-col
     justify-center
     items-center;
 }
 
 .regist-back-link {
-  @apply
-    block
+  @apply block
     text-lg
     text-[#e040fb]
     cursor-pointer
@@ -85,23 +92,19 @@ onMounted(async () => {
 }
 
 .regist-back-link:hover {
-  @apply
-    font-bold
+  @apply font-bold
     text-[#e040fb];
 }
 
 .user-info {
-  @apply
-    text-3xl
+  @apply text-3xl
     font-bold
     mb-6;
   padding: 1% 1% 1% 2%;
 }
 
-select,
-input {
-  @apply
-    text-left
+.regist-card input, .regist-card select {
+  @apply text-left
     p-[1%]
     h-[50px]
     w-[1000px]
@@ -110,28 +113,26 @@ input {
     text-lg
     align-top;
 }
-select,
-input:required {
+
+.regist-card input:required, .regist-card select {
   border: 1px solid red;
 }
-select,
-input:invalid {
+
+.regist-card input:invalid, .regist-card select {
   border: 1px solid red;
 }
-select,
-input:valid {
+
+.regist-card input:valid, .regist-card select {
   border: 1px solid #333333;
 }
 
 .regist-button {
-  @apply
-    text-right
+  @apply text-right
     mb-8;
 }
 
 .regist-submit-button {
-  @apply
-    text-xl
+  @apply text-xl
     text-[#333333]
     bg-[#eceff1]
     font-bold
@@ -142,14 +143,15 @@ input:valid {
     cursor-pointer;
 }
 .regist-submit-button:hover {
-  @apply
-    text-[#333333];
-  background-image: linear-gradient(90deg, rgba(247, 93, 139, 1), rgba(254, 220, 64, 1));
+  @apply text-[#333333];
+  background-image: linear-gradient(
+    90deg,
+    rgba(247, 93, 139, 1),
+    rgba(254, 220, 64, 1)
+  );
 }
-.regist-submit-button:active{
-  @apply
-    text-[#333333];
-  box-shadow: inset 1px 1px 2px #BABECC, inset -1px -1px 2px #FFF;
+.regist-submit-button:active {
+  @apply text-[#333333];
+  box-shadow: inset 1px 1px 2px #babecc, inset -1px -1px 2px #fff;
 }
-
 </style>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1219

# 概要
<!-- 開発内容の概要を記載 -->

- そのページではスタイルをちゃんと当てているのに崩れる
- リロードすると直る

# 原因

1.  まずvueのstyleタグは`scoped`をつけないとグローバルなcssになる
2. edit_user_infoとpassword_resetページで、selectタグとinputタグそのもののスタイルを変えていた
3. 1と2の影響で、全てのページのselectとinputに対して、そのスタイルが当たってしまっていた
4. cssは階層が深いもの（後から書かれたもの）が優先されるので、リロードすると、リレンダリングされてそのページのcssが当たるようになると予想

# 対策

- styleタグを使わない
- 使うなら`<style scoped>`にする
- タグに対してstyleを書かず、classでstyleを表記する

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- mypage/edit_user_info
- mypage/password_reset

# テスト項目
<!-- テストしてほしい内容を記載 -->
- デザイン崩れが発生していた場所がちゃんと治っているか
  - 登録関係のinputやselect
  - 編集・確認のモーダル内のinputやselect

# 備考
