### PR TITLE
展示・体験と研究室公開の時は食品申請・物品申請タブを表示しないように設定

### DIFF
--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -330,7 +330,7 @@ const rentalItemOverlap = computed(() => {
             {{ $t("RegistInfo.employees") }}
           </div>
         </li>
-        <li @click="tab = 8">
+        <li v-if="groupCategoryId != 4 && groupCategoryId != 5" @click="tab = 8">
           <div :class="{ select: tab === 8 }" class="title">
             {{
               groupCategoryId === 1


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1234 

# 概要
<!-- 開発内容の概要を記載 -->
展示・体験と研究室公開の時は食品申請と物品申請は不必要なので非表示にするように設定した・

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/pages/regist_info/index.vue
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="707" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/8196dfb0-f3a0-41a1-9374-596a7cd3f8c1">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 展示・体験の時に、食品・物品申請タブが非表示か
- [x] 研究室公開の時に、食品・物品申請タブが非表示か
- [x] 上記以外の時は、適切にタブが表示されているか？
-

# 備考
