### PR TITLE
新規登録で物販選択時に販売物品登録ページで調理の有無欄を削除

### DIFF
--- a/user_front/pages/regist/food/index.vue
+++ b/user_front/pages/regist/food/index.vue
@@ -118,7 +118,13 @@ const decrement = (idx: number) => {
 <template>
   <div class="mx-[20%] my-[5%]">
     <Card>
-      <h1 class="text-3xl">{{ $t("Food.registFood") }}</h1>
+      <h1 class="text-3xl">
+        {{
+          state.groupCategoryId === 1
+            ? $t("Food.registFood")
+            : $t("SaleGoods.registSaleGoods")
+        }}
+      </h1>
       <Card border="none" align="center">
         <div
           v-for="(field, idx) in foodValidate"
@@ -126,7 +132,13 @@ const decrement = (idx: number) => {
           class="border rounded-md p-2 flex flex-col gap-4 items-center"
         >
           <div class="grid grid-cols-2 gap-y-2">
-            <p class="label">{{ $t("Food.name") }}</p>
+            <p class="label">
+              {{
+                state.groupCategoryId === 1
+                  ? $t("Food.name")
+                  : $t("SaleGoods.name")
+              }}
+            </p>
             <div class="flex flex-col">
               <Field
                 :id="`name${idx}`"
@@ -139,8 +151,10 @@ const decrement = (idx: number) => {
                 :name="`foods[${idx}].dishName`"
               />
             </div>
-            <p class="label">{{ $t("Food.cook") }}</p>
-            <div class="flex flex-col">
+            <p v-if="state.groupCategoryId === 1" class="label">
+              {{ $t("Food.cook") }}
+            </p>
+            <div v-if="state.groupCategoryId === 1" class="flex flex-col">
               <select
                 style="width: 180px"
                 v-model="registerParams[idx].isCooking"
@@ -157,6 +171,7 @@ const decrement = (idx: number) => {
                 :name="`foods[${idx}].numFirstDay`"
                 class="form"
                 v-model="registerParams[idx].numFirstDay"
+                type="number"
               />
               <ErrorMessage
                 class="text-rose-600 text-sm"
@@ -170,6 +185,7 @@ const decrement = (idx: number) => {
                 :name="`foods[${idx}].numSecondDay`"
                 class="form"
                 v-model="registerParams[idx].numSecondDay"
+                type="number"
               />
               <ErrorMessage
                 class="text-rose-600 text-sm"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1233 

# 概要
<!-- 開発内容の概要を記載 -->
団体登録の参加形式が 模擬店(物品販売) だった場合に販売物品登録ページで調理の有無欄を削除

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8002/regist/food

<img width="874" alt="スクリーンショット 2023-05-23 23 10 46" src="https://github.com/NUTFes/group-manager-2/assets/71711872/c9a3b2e0-ccc1-4328-bbc7-27911f022d12">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 新規登録の参加形式を 模擬店(物品販売) にして、販売物品の登録ページで調理の有無欄がなくなっているか
- [x] 正常に販売物品が登録できるか
- [x] タイトルや input の左側にある語句が `販売食品` → `販売物品` のようになっているか
