### PR TITLE
物品申請を登録しすぎるとはみ出すバグ修正

### DIFF
--- a/user_front/components/RegistInfo/add/Employee.vue
+++ b/user_front/components/RegistInfo/add/Employee.vue
@@ -52,6 +52,8 @@ const addEmployee = async () => {
 const reset = () => {
   newName.value = ''
   newStudentId.value = ''
+  handleName(newName.value)
+  handleStudentId(newStudentId.value)
 }
 
 </script>

--- a/user_front/components/RegistInfo/add/Food.vue
+++ b/user_front/components/RegistInfo/add/Food.vue
@@ -59,6 +59,9 @@ const reset = () => {
   numFirstDay.value = null;
   numSecondDay.value = null;
   isCooking.value = false;
+  handleDishName(dishName.value);
+  handleNumFirstDay(numFirstDay.value);
+  handleNumSecondDay(numSecondDay.value);
 };
 </script>
 

--- a/user_front/components/RegistInfo/add/Item.vue
+++ b/user_front/components/RegistInfo/add/Item.vue
@@ -133,6 +133,8 @@ const addItem = async () => {
 const reset = () => {
   newItem.value = null;
   newNum.value = null;
+  handleName(newItem.value);
+  handleNum(newNum.value);
 };
 </script>
 

--- a/user_front/components/RegistInfo/add/Power.vue
+++ b/user_front/components/RegistInfo/add/Power.vue
@@ -59,6 +59,11 @@ const reset = () => {
   newManufacturer.value = ''
   newModel.value = ''
   newUrl.value = ''
+  handleItem(newItem.value)
+  handlePower(newPower.value)
+  handleManufacturer(newManufacturer.value)
+  handleModel(newModel.value)
+  handleUrl(newUrl.value)
 }
 </script>
 

--- a/user_front/components/RegistInfo/add/Purchase.vue
+++ b/user_front/components/RegistInfo/add/Purchase.vue
@@ -88,6 +88,11 @@ const reset = () => {
   newShopId.value = null;
   newFesDateId.value = null;
   newIsFresh.value = false;
+  handleFoodProductId(newFoodProductId.value);
+  handleShopId(newShopId.value);
+  handleFesDateId(newFesDateId.value);
+  handleItem(newItems.value);
+  
 };
 </script>
 

--- a/user_front/components/RegistInfo/edit/Employee.vue
+++ b/user_front/components/RegistInfo/edit/Employee.vue
@@ -74,6 +74,8 @@ const editEmployee = async () => {
 const reset = () => {
   newName.value = ''
   newStudentId.value = null
+  handleName(newName.value)
+  handleStudentId(newStudentId.value)
 }
 
 </script>

--- a/user_front/components/RegistInfo/edit/Food.vue
+++ b/user_front/components/RegistInfo/edit/Food.vue
@@ -89,6 +89,9 @@ const reset = () => {
   newIsCooking.value = false;
   newNumFirstDay.value = null;
   newNumSecondDay.value = null;
+  handleDishName(newDishName.value);
+  handleNumFirstDay(newNumFirstDay.value);
+  handleNumSecondDay(newNumSecondDay.value);
 };
 </script>
 

--- a/user_front/components/RegistInfo/edit/Item.vue
+++ b/user_front/components/RegistInfo/edit/Item.vue
@@ -118,6 +118,8 @@ const editItem = async () => {
 const reset = () => {
   newItem.value = null;
   newNum.value = null;
+  handleName(newItem.value);
+  handleNum(newNum.value);
 };
 
 // 物品のidから物品の情報を取得し、物品の貸し出し可能数を返す

--- a/user_front/components/RegistInfo/edit/Place.vue
+++ b/user_front/components/RegistInfo/edit/Place.vue
@@ -2,8 +2,9 @@
 import { Place, PlaceList } from "~~/types/regist/place";
 import { useField, useForm } from "vee-validate";
 import { placeSchema } from "~~/utils/validate";
-const config = useRuntimeConfig();
 import axios from "axios";
+
+const config = useRuntimeConfig();
 
 interface Props {
   id: number | null;
@@ -32,6 +33,7 @@ const { meta, isSubmitting } = useForm({
     first: props.first,
     second: props.second,
     third: props.third,
+    remark: props.remark,
   },
 });
 const { handleChange: handleFirstPlace, errorMessage: firstPlaceError } =
@@ -40,6 +42,8 @@ const { handleChange: handleSecondPlace, errorMessage: secondPlaceError } =
   useField("second");
 const { handleChange: handleThirdPlace, errorMessage: thirdPlaceError } =
   useField("third");
+const { handleChange: handleRemark, errorMessage: remarkError } =
+  useField("remark");
 
 const EATING_AREA = [
   "事務棟エリア",
@@ -52,7 +56,6 @@ const isEatingArea = (place: string) => {
   return EATING_AREA.includes(place);
 };
 
-
 const placeList = ref<PlaceList[]>([]);
 const newFirst = ref<Props["first"]>(props.first);
 const newSecond = ref<Props["second"]>(props.second);
@@ -60,7 +63,7 @@ const newThird = ref<Props["third"]>(props.third);
 const newRemark = ref<Props["remark"]>(props.remark);
 const groupCategoryId = ref<number>();
 const isOverlapPlace = ref(false);
-const group_id = ref()
+const group_id = ref();
 const isDuplicate = computed(() => {
   if (
     newFirst.value === newSecond.value ||
@@ -83,10 +86,12 @@ const closeEditPlace = () => {
 
 onMounted(async () => {
   const placeData = await $fetch<Place>(config.APIURL + "/places");
-  !!placeData.data && placeData.data.forEach((place) => {
-    placeList.value.push(place)
-  })
-  const groupUrl = config.APIURL + "/groups/" + Number(localStorage.getItem("group_id"));
+  !!placeData.data &&
+    placeData.data.forEach((place) => {
+      placeList.value.push(place);
+    });
+  const groupUrl =
+    config.APIURL + "/groups/" + Number(localStorage.getItem("group_id"));
   axios.get(groupUrl).then(async (response) => {
     groupCategoryId.value = response.data.data.group_category_id;
 
@@ -102,7 +107,7 @@ onMounted(async () => {
       }
     });
   });
-})
+});
 
 const editPlace = async () => {
   if (props.id === null) {
@@ -114,10 +119,9 @@ const editPlace = async () => {
         second: newSecond.value,
         third: newThird.value,
         remark: newRemark.value,
-      }
-    })
-  }
-  else{
+      },
+    });
+  } else {
     await useFetch(config.APIURL + "/place_orders/" + props.id, {
       method: "PUT",
       params: {
@@ -126,18 +130,22 @@ const editPlace = async () => {
         second: newSecond.value,
         third: newThird.value,
         remark: newRemark.value,
-      }
-    })
+      },
+    });
   }
-  reloadPlace()
-  closeEditPlace()
-}
+  reloadPlace();
+  closeEditPlace();
+};
 
 const reset = () => {
   newFirst.value = null;
   newSecond.value = null;
   newThird.value = null;
   newRemark.value = "";
+  handleFirstPlace(newFirst.value);
+  handleSecondPlace(newSecond.value);
+  handleThirdPlace(newThird.value);
+  handleRemark(newRemark.value);
 };
 </script>
 
@@ -154,48 +162,50 @@ const reset = () => {
       </div>
     </template>
     <template #form>
-      <div class="text">{{ $t('Place.first') }}</div>
-      <select class="entry" v-model="newFirst" @change="handleFirstPlace" :class="{'error_border': firstPlaceError}">
-        <option
-          v-for="place in placeList"
-          :value="place.id"
-          :key="place.id"
-        >
+      <div class="text">{{ $t("Place.first") }}</div>
+      <select
+        class="entry"
+        v-model="newFirst"
+        @change="handleFirstPlace"
+        :class="{ error_border: firstPlaceError }"
+      >
+        <option v-for="place in placeList" :value="place.id" :key="place.id">
           {{ place.name }}
         </option>
       </select>
       <div class="error_msg">{{ firstPlaceError }}</div>
-      <div class="text">{{ $t('Place.second') }}</div>
-      <select class="entry" v-model="newSecond" @change="handleSecondPlace" :class="{'error_border' :secondPlaceError}">
-        <option
-          v-for="place in placeList"
-          :value="place.id"
-          :key="place.id"
-        >
+      <div class="text">{{ $t("Place.second") }}</div>
+      <select
+        class="entry"
+        v-model="newSecond"
+        @change="handleSecondPlace"
+        :class="{ error_border: secondPlaceError }"
+      >
+        <option v-for="place in placeList" :value="place.id" :key="place.id">
           {{ place.name }}
         </option>
       </select>
       <div class="error_msg">{{ secondPlaceError }}</div>
-      <div class="text">{{ $t('Place.third') }}</div>
-      <select class="entry" v-model="newThird" @change="handleThirdPlace" :class="{'error_border' :thirdPlaceError}">
-        <option
-          v-for="place in placeList"
-          :value="place.id"
-          :key="place.id"
-        >
+      <div class="text">{{ $t("Place.third") }}</div>
+      <select
+        class="entry"
+        v-model="newThird"
+        @change="handleThirdPlace"
+        :class="{ error_border: thirdPlaceError }"
+      >
+        <option v-for="place in placeList" :value="place.id" :key="place.id">
           {{ place.name }}
         </option>
       </select>
       <div class="error_msg">{{ thirdPlaceError }}</div>
-      <div class="text">{{ $t('Place.free') }}</div>
-      <textarea class="entry" v-model="newRemark" @change="handleRemark" :class="{'error_border': remark}"/>
+      <div class="text">{{ $t("Place.free") }}</div>
+      <textarea
+        class="entry"
+        v-model="newRemark"
+        @change="handleRemark"
+        :class="{ error_border: remark }"
+      />
       <div class="error_msg">{{ remarkError }}</div>
-      <div class="flex justify-between mt-8 mx-8">
-        <RegistPageButton :text="$t('Button.reset')" @click="reset()"></RegistPageButton>
-        <RegistPageButton :disabled="!meta.valid || isSubmitting" :text="$t('Button.edit')" @click="editPlace()"></RegistPageButton>
-      </div>
-      <div class="text">追記することがあればこちらにお書きください</div>
-      <textarea class="entry" v-model="newRemark" />
       <p v-if="isOverlapPlace" class="error_msg">
         同じ会場を選択しています。選択し直してください。
       </p>

--- a/user_front/components/RegistInfo/edit/Power.vue
+++ b/user_front/components/RegistInfo/edit/Power.vue
@@ -94,6 +94,11 @@ const reset = () => {
   newManufacturer.value = ''
   newModel.value = ''
   newUrl.value = ''
+  handleItem(newItem.value)
+  handlePower(newPower.value)
+  handleManufacturer(newManufacturer.value)
+  handleModel(newModel.value)
+  handleUrl(newUrl.value)
 }
 
 </script>

--- a/user_front/components/RegistInfo/edit/Purchase.vue
+++ b/user_front/components/RegistInfo/edit/Purchase.vue
@@ -121,6 +121,11 @@ const reset = () => {
   newFoodProductId.value = null;
   newShopId.value = null;
   newFesDateId.value = null;
+  handleFoodProduct(newFoodProductId.value);
+  handleShop(newShopId.value);
+  handleItem(newName.value);
+  handleIsFresh(newIsFresh.value);
+  handleFesDate(newFesDateId.value);
 };
 </script>
 

--- a/user_front/components/RegistInfo/edit/Stage.vue
+++ b/user_front/components/RegistInfo/edit/Stage.vue
@@ -134,6 +134,12 @@ const reset = () => {
   newUseTimeInterval.value = null
   newPrepareTimeInterval.value = null
   newCleanupTimeInterval.value = null
+  handleDate(newStageDateId.value)
+  handleStageFirst(newStageFirst.value)
+  handleStageSecond(newStageSecond.value)
+  handleUseTimeInterval(newUseTimeInterval.value)
+  handlePrepareTimeInterval(newPrepareTimeInterval.value)
+  handleCleanupTimeInterval(newCleanupTimeInterval.value)
 }
 
 const deleteStage = async() => {

--- a/user_front/components/RegistInfo/edit/StageOption.vue
+++ b/user_front/components/RegistInfo/edit/StageOption.vue
@@ -109,6 +109,11 @@ const reset = () => {
   newCameraPermission.value = null
   newLoudSound.value = null
   newStageContent.value = ''
+  handleOwnEquipment(newOwnEquipment.value)
+  handleBgm(newBgm.value)
+  handleCameraPermission(newCameraPermission.value)
+  handleLoudSound(newLoudSound.value)
+  handleStageContent(newStageContent.value)
 }
 
 </script>

--- a/user_front/components/RegistInfo/edit/SubRep.vue
+++ b/user_front/components/RegistInfo/edit/SubRep.vue
@@ -105,6 +105,12 @@ const reset = () => {
   newTel.value = "";
   newEmail.value = "";
   newStudentId.value = null;
+  handleName("");
+  handleDepartmentId("");
+  handleGradeId("");
+  handleTel("");
+  handleMail("");
+  handleStudentId("");
 };
 
 const currentDepartmentList = ref<{ id: number; name: string }[]>([]);

--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -495,7 +495,7 @@ const rentalItemOverlap = computed(() => {
             <p>{{ rentalItemOverlap }} が重複しています</p>
             <p>削除してください</p>
           </div>
-          <div class="flex">
+          <div class="flex flex-wrap gap-4">
             <div v-for="item in rentalOrders" :key="item.toString()">
               <RegistInfoCardItem
                 :group-id="group?.id"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1239
resolve #1241 
resolve #1242 

間違えてpushしてクソデカになっちゃった
reverしてやり直すのも面倒なのでこのままで

# 概要
<!-- 開発内容の概要を記載 -->

- 物品申請を登録しすぎると画面外にはみ出してしまうので、ちゃんと折り返すようにした
- リセットしたら編集・追加ボタンが押せるのを直す
- 会場申請で、リセット・編集ボタンと備考欄が二つずつあるのを直す

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- pages/regist_info

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

<img width="1512" alt="スクリーンショット 2023-05-24 2 42 28" src="https://github.com/NUTFes/group-manager-2/assets/52590941/9e74137a-504f-4f27-9b0f-9c9059ee2faf">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- ログインして登録情報の確認へ移動

- [ ] 物品申請から、4つ以上登録して、ちゃんと折り返すか
- [ ] 各編集で、リセットを押すとちゃんとバリデーションが働くか
- [ ] 各追加で、リセットを押すとちゃんとバリデーションが働くか
- [ ] 会場申請がバグの画像からちゃんと一つにまとまっているか

バグの画像

<img width="1699" alt="スクリーンショット 2023-05-23 11 27 28" src="https://github.com/NUTFes/group-manager-2/assets/52590941/61cebbf2-c0fd-4d49-87fb-ea436962a44a">

# 備考
