### PR TITLE
stage団体時の物品販売のタブを非表示

### DIFF
--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -330,7 +330,7 @@ const rentalItemOverlap = computed(() => {
             {{ $t("RegistInfo.employees") }}
           </div>
         </li>
-        <li v-if="groupCategoryId != 4 && groupCategoryId != 5" @click="tab = 8">
+        <li v-if="groupCategoryId != 3 && groupCategoryId != 4 && groupCategoryId != 5" @click="tab = 8">
           <div :class="{ select: tab === 8 }" class="title">
             {{
               groupCategoryId === 1


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1248 

# 概要
<!-- 開発内容の概要を記載 -->
stage団体時は物品販売を行わないので、物品販売タブを非表示にした。

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/pages/regist_info/index.vue
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/group-manager-2/assets/50622120/c225f2cf-1a18-4719-bb39-eafe9c13e69f)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] stage団体時に物品販売のタブが表示されていないか
-
-

# 備考
