### PR TITLE
purchase_listsのスキーマの変更

### DIFF
--- a/api/db/fixtures/develop/purchase_list.rb
+++ b/api/db/fixtures/develop/purchase_list.rb
@@ -3,6 +3,8 @@ PurchaseList.seed( :id,
                 shop_id: 1 ,
                 fes_date_id: 1, 
                 items: 'tomato',
-                is_fresh: true
+                is_fresh: true,
+                purchase_date: '2021-05-25',
+                url: 'https://amazon.co.jp'
     }
 ) 

--- a/api/db/migrate/20230525071401_add_column_purchase_lists.rb
+++ b/api/db/migrate/20230525071401_add_column_purchase_lists.rb
@@ -1,0 +1,6 @@
+class AddColumnPurchaseLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :purchase_lists, :purchase_date, :string
+    add_column :purchase_lists, :url, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_14_163559) do
+ActiveRecord::Schema.define(version: 2023_05_25_071401) do
 
   create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "group_id"
@@ -188,6 +188,8 @@ ActiveRecord::Schema.define(version: 2023_05_14_163559) do
     t.boolean "is_fresh"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "purchase_date"
+    t.string "url"
   end
 
   create_table "rentable_items", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1257 

# 概要
<!-- 開発内容の概要を記載 -->
- 購入日時を入れることのできるように`purchase_date:string`を追加
- 購入した食品・物品がネットの時のためにURLカラムを追加した

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `make build db`でスキーマを反映させてください

- [ ] seedsデータで新たに、`purchase_date`と `url`が入っているか
- `docker compose run --rm api rails c`
```
irb(main):001:0> purchase_list = PurchaseList.find(1)
  PurchaseList Load (0.4ms)  SELECT `purchase_lists`.* FROM `purchase_lists` WHERE `purchase_lists`.`id` = 1 LIMIT 1
irb(main):002:0> purchase_list
=> #<PurchaseList id: 1, food_product_id: 1, shop_id: 1, fes_date_id: 1, items: "tomato", is_fresh: true, created_at: "2023-05-21 13:32:23.822641000 +0000", updated_at: "2023-05-25 07:21:49.073195000 +0000", purchase_date: "2021-05-25", url: "https://amazon.co.jp">
```

# 備考
変更ではなく、追加なのでフロント側に影響はないと思います