### PR TITLE
mod docker-compose.yml admin_view environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,10 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ROOT_USER: root
-      MYSQL_USER: group-manager-2 # テスト的にユーザーを作ってみる
       MYSQL_PASSWORD: password
     command: --default-authentication-plugin=mysql_native_password
     ports: ["3306:3306"]
     volumes: [mysql-data:/var/lib/mysql]
-    #platform: linux/x86_64 # M1 Mac用
 
   api:
     build: ./api
@@ -28,7 +26,9 @@ services:
     ports: ["8000:8000"]
     command: npm run dev
     volumes: [./admin_view:/app]
-    environment: [VUE_APP_URL=http://localhost:3000]
+    environment:
+      - VUE_APP_URL=http://localhost:3000
+      - VUE_APP_API_URL=http://api:3000
 
   user_front:
     build: ./user_front


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1264 

編集

```
version: '3'
services:
  db:
    image: mysql:8.0
    container_name: 'GM2-DB'
    environment:
      MYSQL_ROOT_PASSWORD: password
      MYSQL_ROOT_USER: root
      MYSQL_USER: group-manager-2 # テスト的にユーザーを作ってみる
      MYSQL_PASSWORD: password
    command: --default-authentication-plugin=mysql_native_password
    ports: ["3306:3306"]
    volumes: [mysql-data:/var/lib/mysql]
    #platform: linux/x86_64 # M1 Mac用

  api:
    build: ./api
    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
    container_name: 'GM2-API'
    volumes: [./api:/myapp]
    ports: ["3000:3000"]
    env_file: [webhook.env]
    depends_on: [db]

  admin_view:
    build: ./admin_view
    container_name: 'GM2-ADMIN-VIEW'
    ports: ["8000:8000"]
    command: npm run dev
    volumes: [./admin_view:/app]
    environment:
      - VUE_APP_URL=http://localhost:3000/
      - VUE_APP_API_URL=http://api:3000/

  user_front:
    build: ./user_front
    container_name: 'GM2-USER-FRONT'
    ports:
      - "8002:8002"
      - "24678:24678"
    command: npm run dev
    volumes: [./user_front:/app]
    environment:
      - VUE_APP_URL=http://api:3000/
      - VUE_APP_API_URL=http://localhost:3000/
    depends_on: [api]

volumes:
  mysql-data:
    driver: local
```
