### PR TITLE
1回で会場配置図登録

### DIFF
--- a/user_front/pages/regist/venueMap/index.vue
+++ b/user_front/pages/regist/venueMap/index.vue
@@ -33,32 +33,33 @@ const postImageURL = () => {
   selectedFile.value &&
   uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
     pictureName.value = snapshot.ref.name
-  });
-  getDownloadURL(fireRef(storage, pictureName.value)).then((url) => {
-    const postUrl =
-    "/venue_maps?group_id=" +
-    state.groupId;
 
-    useFetch(config.APIURL + postUrl, {
-      method: "POST",
-      params: {
-        picture_name: fileName.value,
-        picture_path: url,
-      },
-      headers: {
-        "Content-Type": "application/json",
-      },
+    getDownloadURL(fireRef(storage, pictureName.value)).then((url) => {
+      const postUrl =
+      "/venue_maps?group_id=" +
+      state.groupId;
+
+      useFetch(config.APIURL + postUrl, {
+        method: "POST",
+        params: {
+          picture_name: fileName.value,
+          picture_path: url,
+        },
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
     })
-  })
-  .then(
-    (response) =>{
-      alert('登録できました')
-      router.push("/mypage");
-    },
-    (error) => {
-      alert('登録できませんでした')
-    }
-  )
+    .then(
+      (response) =>{
+        alert('登録できました')
+        router.push("/mypage");
+      },
+      (error) => {
+        alert('登録できませんでした')
+      }
+    )
+  });
 }
 </script>
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#1267 
<!-- 対応したIssue番号を記載 -->
resolve #1267

# 概要
<!-- 開発内容の概要を記載 -->
会場配置図を登録する際2回登録を押さなければならなかったが、1回押せば登録できるようにした。

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- group-manager-2/user_front/pages/regist/venueMap/index.vue
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- マイページから会場配置図へ行き、画像ファイルを登録する
- 1回でできるか確認する
-

# 備考
