### PR TITLE
購入品申請のURLカラムの追加

### DIFF
--- a/admin_view/nuxt-project/pages/purchase_lists/_id.vue
+++ b/admin_view/nuxt-project/pages/purchase_lists/_id.vue
@@ -27,6 +27,10 @@
             <td>{{ purchaseList.group.name }}</td>
           </tr>
           <tr>
+            <th>購入日</th>
+            <td>{{ purchaseList.purchase_list.purchase_date }}</td>
+          </tr>
+          <tr>
             <th>販売食品</th>
             <td>{{ purchaseList.purchase_list_info.food_product }}</td>
           </tr>
@@ -43,20 +47,8 @@
             <td>{{ purchaseList.purchase_list_info.shop }}</td>
           </tr>
           <tr>
-            <th>仕入れ日</th>
-            <td>
-              {{ purchaseList.purchase_list_info.date }} -
-              {{ purchaseList.purchase_list_info.day }} -
-              {{ purchaseList.purchase_list.days_num }}
-            </td>
-          </tr>
-          <tr>
-            <th>仕入れ日</th>
-            <td>
-              {{ purchaseList.purchase_list_info.date }} -
-              {{ purchaseList.purchase_list_info.day }} -
-              {{ purchaseList.purchase_list.days_num }}
-            </td>
+            <th>URL</th>
+            <td>{{ purchaseList.purchase_list.url }}</td>
           </tr>
           <tr>
             <th>登録日時</th>

--- a/admin_view/nuxt-project/pages/purchase_lists/_id.vue
+++ b/admin_view/nuxt-project/pages/purchase_lists/_id.vue
@@ -51,6 +51,14 @@
             </td>
           </tr>
           <tr>
+            <th>仕入れ日</th>
+            <td>
+              {{ purchaseList.purchase_list_info.date }} -
+              {{ purchaseList.purchase_list_info.day }} -
+              {{ purchaseList.purchase_list.days_num }}
+            </td>
+          </tr>
+          <tr>
             <th>登録日時</th>
             <td>{{ purchaseList.purchase_list.created_at | formatDate }}</td>
           </tr>

--- a/user_front/components/RegistInfo/add/Purchase.vue
+++ b/user_front/components/RegistInfo/add/Purchase.vue
@@ -59,7 +59,8 @@ const newFesDateId = ref<number | null>(1);
 const newIsFresh = ref<boolean>(false);
 const newItems = ref<string>("");
 const newPurchaseDate = ref<string>("");
-const newUrl = ref<string>("https://aaa.com");
+//const newUrl = ref<string>("https://aaa.com");
+const newUrl = ref<string>("");
 
 const addPurchaseClose = () => {
   emits("update:addPurchase", false);
@@ -95,7 +96,8 @@ const reset = () => {
   newIsFresh.value = false;
   newItems.value = '';
   newPurchaseDate.value = '';
-  newUrl.value = 'https://aaa.com';
+  //newUrl.value = 'https://aaa.com';
+  newUrl.value = '';
   handleFoodProductId(newFoodProductId.value);
   handleShopId(newShopId.value);
   handleItem(newItems.value);
@@ -182,6 +184,12 @@ const reset = () => {
         :class="{ error_border: purchaseDateError }"
       >
       <div class="error_msg">{{ purchaseDateError }}</div>
+      <div class="text">{{ $t("Purchase.URL") }}</div>
+        <input
+          class="entry"
+          type="text"
+          v-model="newUrl"
+        />
       <div class="flex justify-between mt-8 mx-8">
         <RegistPageButton :text="$t('Button.reset')" @click="reset()" />
         <RegistPageButton

--- a/user_front/components/RegistInfo/edit/Purchase.vue
+++ b/user_front/components/RegistInfo/edit/Purchase.vue
@@ -65,7 +65,6 @@ const newShopId = ref<number | null>(props.shopId);
 const newFesDateId = ref<number | null>(props.fesDateId);
 const newPurchaseDate = ref<string | null>(props.purchaseDate);
 const newUrl = ref<string | null>(props.url);
-
 const purchases = ref<Purchase[]>([]);
 const foodProducts = ref<FoodProduct[]>([]);
 const fesDates = ref<Date[]>([]);
@@ -129,7 +128,9 @@ const reset = () => {
   newShopId.value = null;
   newFesDateId.value = 1;
   newPurchaseDate.value = "";
-  newUrl.value = 'https://aaa.com';
+  //newUrl.value = 'https://aaa.com';
+  newFesDateId.value = null;
+  newUrl.value = "";
   handleFoodProduct(newFoodProductId.value);
   handleShop(newShopId.value);
   handleItem(newName.value);
@@ -218,6 +219,12 @@ const reset = () => {
         :class="{ error_border: purchaseDateError }"
       >
       <div class="error_msg">{{ purchaseDateError }}</div>
+      <div class="text">{{ $t("Purchase.URL") }}</div>
+        <input
+          class="entry"
+          type="text"
+          v-model="newUrl"
+        />
       <div class="flex justify-between mt-8 mx-8">
         <RegistPageButton :text="$t('Button.reset')" @click="reset()" />
         <RegistPageButton

--- a/user_front/locales/en.json
+++ b/user_front/locales/en.json
@@ -287,7 +287,8 @@
     "no": "Processed food",
     "of": "",
     "parchasePlace1": "Place",
-    "parchasePlace2": "of purchase"
+    "parchasePlace2": "of purchase",
+    "URL": "If you bought it online, please enter the URL"
   },
 
   "Validate": {

--- a/user_front/locales/ja.json
+++ b/user_front/locales/ja.json
@@ -286,7 +286,8 @@
     "no": "加工品",
     "of": "の",
     "parchasePlace1": "購入",
-    "parchasePlace2": "場所"
+    "parchasePlace2": "場所",
+    "URL": "ネットで買った場合はURLを記入してください"
   },
 
   "Validate": {

--- a/user_front/types/mypage/registAlarm.ts
+++ b/user_front/types/mypage/registAlarm.ts
@@ -56,6 +56,7 @@ interface PurchaseList{
   items: string
   shop: string
   year: number
+  url: string
 }
 
 export interface Group{


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue1252
<!-- 対応したIssue番号を記載 -->
resolve #1252

# 概要
<!-- 開発内容の概要を記載 -->
- 購入品申請登録時のURLの追加
ネットで購入したときのために、URLを入れられるようにしておく。
<img width="287" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/3e0625e5-8a0b-4f1a-928d-9bbb12820f6e">

- 登録したURL情報を管理者画面で確認できるようにする。
<img width="287" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/0d58d5b0-187d-4eaa-b938-df6f840ed1f4">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- スキーマ変換をしているので`make build db`をすること
- [ ] URLを含めて購入品を登録できるか
- [ ] URLは空値で購入品を登録できるか
- [ ] 編集することができるか
- [ ] 管理者画面で、URL欄があり、空でも情報が入っていても購入情報を見ることができるか

# 備考
