### PR TITLE
管理者ページに会場アナウンスのページを追加

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -154,6 +154,11 @@ export default {
           icon: "badge",
           click: "/public_relations",
         },
+        {
+          title: "会場アナウンス文申請",
+          icon: "campaign",
+          click: "/announcement",
+        },
       ],
       // 操作系
       operation_items: [

--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="main-content">
+    <SubHeader
+      v-bind:pageTitle="groups.find((group) => group.id === announcement.group_id).name"
+      pageSubTitle="会場アナウンス文申請一覧"
+    >
+      <CommonButton
+        v-if="this.$role(this.roleID).announcements.update"
+        iconName="edit"
+        :on_click="openEditModal"
+      >
+        編集
+      </CommonButton>
+      <CommonButton
+        v-if="this.$role(this.roleID).announcements.delete"
+        iconName="delete"
+        :on_click="openDeleteModal"
+      >
+        削除
+      </CommonButton>
+    </SubHeader>
+    <Row>
+      <Card padding="40px 150px" gap="20px">
+        <Row justify="start">
+          <h4>基本情報</h4>
+          <VerticalTable>
+            <tr>
+              <th>ID</th>
+              <td>{{ announcement.id }}</td>
+            </tr>
+            <tr>
+              <th>団体名</th>
+              <td>{{ groups.find((group) => group.id === announcement.group_id).name }}</td>
+            </tr>
+            <tr>
+              <th>会場アナウンス文</th>
+              <td>{{ announcement.message }}</td>
+            </tr>
+            <tr>
+              <th>登録日時</th>
+              <td>{{ announcement.created_at | formatDate }}</td>
+            </tr>
+            <tr>
+              <th>編集日時</th>
+              <td>{{ announcement.updated_at | formatDate }}</td>
+            </tr>
+          </VerticalTable>
+        </Row>
+      </Card>
+    </Row>
+
+    <EditModal
+      @close="closeEditModal"
+      v-if="isOpenEditModal"
+      title="会場アナウンス文の編集"
+    >
+      <template v-slot:form>
+        <div>
+          <h3>団体名</h3>
+          <select v-model="group_id">
+            <option v-for="group in groups" :key="group.id" :value="group.id">
+              {{ group.name }}
+            </option>
+          </select>
+        </div>
+        <div>
+          <h3>会場名</h3>
+          <input v-model="message" placeholder="入力してください" />
+        </div>
+      </template>
+      <template v-slot:method>
+        <CommonButton iconName="edit" :on_click="edit">登録</CommonButton>
+      </template>
+    </EditModal>
+
+    <DeleteModal
+      @close="closeDeleteModal"
+      v-if="isOpenDeleteModal"
+      title="会場の削除"
+    >
+      <template v-slot:method>
+        <YesButton iconName="delete" :on_click="destroy">はい</YesButton>
+        <NoButton iconName="close" :on_click="closeDeleteModal"
+          >いいえ</NoButton
+        >
+      </template>
+    </DeleteModal>
+    <SnackBar v-if="isOpenSnackBar" @close="closeSnackBar">
+      {{ snackMessage }}
+    </SnackBar>
+  </div>
+</template>
+
+<script>
+import { mapState } from "vuex";
+export default {
+  watchQuery: ["page"],
+  data() {
+    return {
+      announcement: {},
+      groups: [],
+      isOpenEditModal: false,
+      isOpenDeleteModal: false,
+      isOpenSnackBar: false,
+      message: "",
+      snackMessage: "",
+      group_id: 1,
+      routeId: "",
+    };
+  },
+  computed: {
+    ...mapState({
+      roleID: (state) => state.users.role,
+    }),
+  },
+  async asyncData({ $axios, route }) {
+    const routeId = route.params.id;
+    const announcementUrl = "/announcements/" + routeId;
+    const groupsUrl = "/groups";
+    const announcementRes = await $axios.$get(announcementUrl);
+    const groupsRes = await $axios.$get(groupsUrl);
+    return {
+      announcement: announcementRes.data,
+      routeId: routeId,
+      groups: groupsRes,
+    };
+  },
+  methods: {
+    openEditModal() {
+      this.group_id = this.announcement.group_id;
+      this.message = this.announcement.message;
+      this.isOpenEditModal = false;
+      this.isOpenEditModal = true;
+    },
+    closeEditModal() {
+      this.isOpenEditModal = false;
+    },
+    openDeleteModal() {
+      this.isOpenDeleteModal = false;
+      this.isOpenDeleteModal = true;
+    },
+    closeDeleteModal() {
+      this.isOpenDeleteModal = false;
+    },
+    openSnackBar(message) {
+      this.snackMessage = message;
+      this.isOpenSnackBar = true;
+      setTimeout(this.closeSnackBar, 2000);
+    },
+    closeSnackBar() {
+      this.isOpenSnackBar = false;
+    },
+    async reload(id) {
+      const url = "/announcements/" + id;
+      const res = await this.$axios.$get(url);
+      this.announcement = res.data;
+    },
+    async edit() {
+      const url = "/announcements/" + this.routeId + "?message=" + this.message + "&group_id=" + this.group_id;
+
+      await this.$axios.$put(url).then((res) => {
+        this.openSnackBar("会場アナウンス文を編集しました");
+        this.message = "";
+        this.group_id = 1;
+        this.reload(res.data.id);
+        this.closeEditModal();
+      });
+    },
+    async destroy() {
+      const delUrl = "/announcements/" + this.routeId;
+      await this.$axios.$delete(delUrl);
+      this.$router.push("/announcement");
+    },
+  },
+};
+</script>
+
+<style scoped>
+td {
+  width: 70%;
+}
+th {
+  width: 30%;
+}
+</style>

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="main-content">
+    <SubHeader pageTitle="会場アナウンス文申請一覧">
+      <CommonButton
+        v-if="this.$role(roleID).announcements.create"
+        iconName="add_circle"
+        :on_click="openAddModal"
+      >
+        追加
+      </CommonButton>
+    </SubHeader>
+
+    <Card width="100%">
+      <Table>
+        <template v-slot:table-header>
+          <th v-for="(header, index) in headers" :key="index">
+            {{ header }}
+          </th>
+        </template>
+        <template v-slot:table-body>
+          <tr
+            v-for="(announcement, index) in announcements"
+            :key="index"
+            @click="
+              () =>
+                $router.push({
+                  path: `/announcement/` + announcement.id,
+                })
+            "
+          >
+            <td>{{ announcement.id }}</td>
+            <td>
+              {{
+                groups.find((group) => group.id === announcement.group_id).name
+              }}
+            </td>
+            <td>{{ announcement.message }}</td>
+          </tr>
+        </template>
+      </Table>
+    </Card>
+
+    <AddModal
+      @close="closeAddModal"
+      v-if="isOpenAddModal"
+      title="会場アナウンス文の登録"
+    >
+      <template v-slot:form>
+        <div>
+          <h3>団体名</h3>
+          <select v-model="group_id">
+            <option v-for="group in groups" :key="group.id" :value="group.id">
+              {{ group.name }}
+            </option>
+          </select>
+        </div>
+        <div>
+          <h3>会場アナウンス文</h3>
+          <input v-model="message" placeholder="入力してください" />
+        </div>
+      </template>
+      <template v-slot:method>
+        <CommonButton iconName="add_circle" :on_click="submit"
+          >登録</CommonButton
+        >
+      </template>
+    </AddModal>
+    <SnackBar v-if="isOpenSnackBar" @close="closeSnackBar">
+      {{ snackMessage }}
+    </SnackBar>
+  </div>
+</template>
+
+<script>
+import { mapState } from "vuex";
+export default {
+  watchQuery: ["page"],
+  data() {
+    return {
+      announcements: [],
+      groups: [],
+      dialog: false,
+      headers: ["ID", "団体名", "会場アナウンス文"],
+      isOpenAddModal: false,
+      isOpenSnackBar: false,
+      message: "",
+      snackMessage: "",
+      group_id: 1,
+    };
+  },
+  async asyncData({ $axios }) {
+    const announcementsUrl = "/announcements";
+    const groupsUrl = "/groups";
+    const announcementsRes = await $axios.$get(announcementsUrl);
+    const groupsRes = await $axios.$get(groupsUrl);
+    return {
+      announcements: announcementsRes.data,
+      groups: groupsRes,
+    };
+  },
+  computed: {
+    ...mapState({
+      roleID: (state) => state.users.role,
+    }),
+  },
+  methods: {
+    openAddModal() {
+      this.isOpenAddModal = false;
+      this.isOpenAddModal = true;
+    },
+    closeAddModal() {
+      this.isOpenAddModal = false;
+    },
+    openSnackBar(message) {
+      this.snackMessage = message;
+      this.isOpenSnackBar = true;
+      setTimeout(this.closeSnackBar, 2000);
+    },
+    closeSnackBar() {
+      this.isOpenSnackBar = false;
+    },
+    reload(id) {
+      const url = "/announcements/" + id;
+      this.$axios.$get(url).then((response) => {
+        this.announcements.push(response.data);
+      });
+    },
+    async submit() {
+      const url =
+        "/announcements/" +
+        "?group_id=" +
+        this.group_id +
+        "&message=" +
+        this.message;
+
+      this.$axios.$post(url).then((response) => {
+        this.openSnackBar("会場アナウンス文を登録しました");
+        this.group_id = 1;
+        this.message = "";
+        this.reload(response.data.id);
+        this.closeAddModal();
+      });
+    },
+  },
+};
+</script>

--- a/admin_view/nuxt-project/plugins/role/developer.js
+++ b/admin_view/nuxt-project/plugins/role/developer.js
@@ -167,4 +167,10 @@ export const developerRole = {
     update: true,
     delete: true,
   },
-}
+  announcements: {
+    read: true,
+    create: true,
+    update: true,
+    delete: true,
+  },
+};

--- a/admin_view/nuxt-project/plugins/role/manager.js
+++ b/admin_view/nuxt-project/plugins/role/manager.js
@@ -167,4 +167,10 @@ export const managerRole = {
     update: false,
     delete: false,
   },
-}
+  announcements: {
+    read: true,
+    create: false,
+    update: false,
+    delete: false,
+  },
+};

--- a/admin_view/nuxt-project/plugins/role/user.js
+++ b/admin_view/nuxt-project/plugins/role/user.js
@@ -166,5 +166,11 @@ export const userRole = {
     create: false,
     update: false,
     delete: false,
-  }, 
-}
+  },
+  announcements: {
+    read: false,
+    create: false,
+    update: false,
+    delete: false,
+  },
+};

--- a/api/db/fixtures/develop/announcement.rb
+++ b/api/db/fixtures/develop/announcement.rb
@@ -1,0 +1,7 @@
+Announcement.seed( :id,
+  {
+    id: 1,
+    group_id: 1,
+    message: 'announcement test'
+  },
+)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1262 

# 概要
<!-- 開発内容の概要を記載 -->

- 管理者ページに、会場アナウンス文の申請ページを追加した

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- admin_view/nuxt-project/components/Menu.vue
- admin_view/nuxt-project/pages/announcement/_id.vue
- admin_view/nuxt-project/pages/announcement/index.vue
- admin_view/nuxt-project/plugins/role/developer.js
- admin_view/nuxt-project/plugins/role/ の権限関係

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8000/announcement
<img width="1512" alt="スクリーンショット 2023-05-26 0 37 49" src="https://github.com/NUTFes/group-manager-2/assets/52590941/2da37b50-34a2-4cf2-9828-37a9c68560d4">

<img width="1512" alt="スクリーンショット 2023-05-26 0 38 00" src="https://github.com/NUTFes/group-manager-2/assets/52590941/568fd502-e09e-49f5-8021-8a830938d811">


# テスト項目
<!-- テストしてほしい内容を記載 -->

- [x] 会場アナウンス文申請一覧が見れるか
- [x] 会場アナウンス文が登録できるか
- [x] 会場アナウンス文の詳細ページが見れるか
- [x] 会場アナウンス文の詳細ページから、編集と削除ができるか

# 備考
