### PR TITLE
PR文とアナウンス文にバリデーションをつける

### DIFF
--- a/user_front/locales/en.json
+++ b/user_front/locales/en.json
@@ -72,7 +72,8 @@
     "PR": "PR for brochure",
     "select": "Please select",
     "text": "PR statement(About 40 characters)",
-    "illustration": "illustration"
+    "illustration": "illustration",
+    "over": "It is over 40 characters"
   },
 
   "Announcement": {

--- a/user_front/locales/ja.json
+++ b/user_front/locales/ja.json
@@ -72,7 +72,8 @@
     "PR": "パンフレット用PR",
     "select": "選択してください",
     "text": "PR文(40文字程度)",
-    "illustration": "イラスト"
+    "illustration": "イラスト",
+    "over": "40文字を超えています"
   },
 
   "Announcement": {

--- a/user_front/pages/mypage/edit_announcement/index.vue
+++ b/user_front/pages/mypage/edit_announcement/index.vue
@@ -1,10 +1,14 @@
 <script lang="ts" setup>
-
 const config = useRuntimeConfig();
-const groupId = ref<number>(0)
-const announcement = ref<string>("")
+const groupId = ref<number>(0);
+const announcement = ref<string>("");
 
 const postAnnouncement = () => {
+  if (announcement.value.length === 0) {
+    alert("会場アナウンス文を入力してください");
+    return;
+  }
+  
   useFetch(config.APIURL + "/announcements", {
     method: "POST",
     params: {
@@ -14,20 +18,27 @@ const postAnnouncement = () => {
     headers: {
       "Content-Type": "application/json",
     },
-  })
-}
+  });
+};
 </script>
 
 <template>
-  <NuxtLink to="/mypage" class="ml-4 text-left text-pink-500 text-2xl hover:font-bold">{{ $t('RegistInfo.return') }}</NuxtLink>
+  <NuxtLink
+    to="/mypage"
+    class="ml-4 text-left text-pink-500 text-2xl hover:font-bold"
+    >{{ $t("RegistInfo.return") }}</NuxtLink
+  >
   <div class="mx-[10%] my-[5%]">
-    <h1 class="text-4xl ">{{ $t('Announcement.editAnnouncement') }}</h1>
+    <h1 class="text-4xl">{{ $t("Announcement.editAnnouncement") }}</h1>
     <Card>
       <div class="text-left">
-        <span class="text-3xl mr-4">{{ $t('Announcement.text') }}</span>
+        <span class="text-3xl mr-4">{{ $t("Announcement.text") }}</span>
       </div>
       <textarea class="border-2 w-[60%]" v-model="announcement"></textarea>
-      <RegistPageButton :text="$t('Announcement.edit')" @click="postAnnouncement"></RegistPageButton>
+      <RegistPageButton
+        :text="$t('Announcement.edit')"
+        @click="postAnnouncement"
+      ></RegistPageButton>
     </Card>
   </div>
 </template>

--- a/user_front/pages/mypage/publicRelations/index.vue
+++ b/user_front/pages/mypage/publicRelations/index.vue
@@ -13,6 +13,10 @@ const fileName = ref<string>('選択してください')
 const pictureName = ref<string>("")
 const blurb = ref<string>("")
 
+const isBlurbOver = computed(() => {
+  return blurb.value.length > 40
+})
+
 onMounted(async () => {
   // ログインしていない場合は/welcomeに遷移させる
   loginCheck()
@@ -73,13 +77,14 @@ const editImageURL = () =>{
         {{ $t("PR.text") }}
       </div>
       <textarea class="border-2 w-[60%]" v-model="blurb"></textarea>
+      <p v-if="isBlurbOver" class="text-red-500 text-sm">{{ $t("PR.over") }}</p>
       <div class="my-4 items-center">
         <label>
           <span class="text-3xl mr-4">{{ $t("PR.illustration") }}</span>
           <input type="file" @change="fileUpload">
         </label>
       </div>
-      <RegistPageButton :text="$t('Button.register')" @click="editImageURL"></RegistPageButton>
+      <RegistPageButton :text="$t('Button.register')" @click="editImageURL" :disabled="isBlurbOver"></RegistPageButton>
     </Card>
   </div>
 </template>

--- a/user_front/pages/mypage/publicRelations/index.vue
+++ b/user_front/pages/mypage/publicRelations/index.vue
@@ -34,7 +34,12 @@ const fileUpload = (e: Event) => {
 const storage = getStorage();
 const storageRef = fireRef(storage, fileName.value);
 
-const editImageURL = () =>{
+const editImageURL = () => {
+  if (blurb.value.length === 0) {
+    alert('PR文を入力してください')
+    return
+  }
+
   selectedFile.value &&
   uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
     pictureName.value = snapshot.ref.name

--- a/user_front/pages/regist/announcement/index.vue
+++ b/user_front/pages/regist/announcement/index.vue
@@ -13,6 +13,11 @@ onMounted(async () => {
 })
 
 const postAnnouncement = () => {
+  if (announcement.value.length === 0) {
+    alert('会場アナウンス文を入力してください')
+    return
+  }
+
   useFetch(config.APIURL + "/announcements", {
     method: "POST",
     params: {

--- a/user_front/pages/regist/publicRelations/index.vue
+++ b/user_front/pages/regist/publicRelations/index.vue
@@ -67,6 +67,10 @@ const skip = () => {
 const back = () => {
   router.push("/regist/announcement");
 };
+
+const isBlurbOver = computed(() => {
+  return blurb.value.length > 40
+})
 </script>
 
 <template>
@@ -79,6 +83,7 @@ const back = () => {
             <p class="label">{{ $t("PR.text") }}</p>
             <div class="flex flex-col">
               <textarea class="form" v-model="blurb"></textarea>
+              <p v-if="isBlurbOver" class="text-red-500">{{ $t("PR.over") }}</p>
             </div>
             <p class="label">{{ $t("PR.illustration") }}</p>
             <div class="flex flex-col">
@@ -96,6 +101,7 @@ const back = () => {
         <RegistPageButton
           :text="$t('Button.register')"
           @click="registImageURL"
+          :disabled="isBlurbOver"
         ></RegistPageButton>
         <RegistPageButton
           :text="$t('Button.skip')"

--- a/user_front/pages/regist/publicRelations/index.vue
+++ b/user_front/pages/regist/publicRelations/index.vue
@@ -32,6 +32,11 @@ const storage = getStorage();
 const storageRef = fireRef(storage, fileName.value);
 
 const registImageURL = () =>{
+  if (blurb.value.length === 0) {
+    alert('PR文を入力してください')
+    return
+  }
+
   selectedFile.value &&
   uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
     pictureName.value = snapshot.ref.name


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1275 
resolve #1278 

# 概要
<!-- 開発内容の概要を記載 -->

- PR文の登録ページにバリデーションを追加
- 編集ページにバリデーションを追加
- アナウンス文の登録・編集の空値処理を追加

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- localsに文言追加
- mypage/publicRelations
- regist/publicRelations

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

<img width="1250" alt="スクリーンショット 2023-05-26 16 50 57" src="https://github.com/NUTFes/group-manager-2/assets/52590941/3307d2e0-4344-4638-ba5d-845aa00b9098">

<img width="936" alt="スクリーンショット 2023-05-26 16 51 21" src="https://github.com/NUTFes/group-manager-2/assets/52590941/3342d7b4-e581-4e2c-8999-44a76b0f32de">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 新規登録からPR文登録まで行き、バリデーションが発生するか
- PR文編集にいき、バリデーションが発生するか

# 備考
