### PR TITLE
Dev/issue1292

### DIFF
--- a/user_front/components/Container.vue
+++ b/user_front/components/Container.vue
@@ -20,7 +20,7 @@ const group = withDefaults(defineProps<Props>(), {
       <div class="bg-gray-100 tracking-wide">{{ group.name }}</div>
     </div>
     <slot name="tabs"></slot>
-    <div class="min-h-[100vh] w-full bg-gray-200">
+    <div class="min-h-[100vh] w-full bg-gray-200 pb-3">
       <slot name="body"/>
     </div>
   </div>

--- a/user_front/components/RegistInfo/card/Employee.vue
+++ b/user_front/components/RegistInfo/card/Employee.vue
@@ -48,7 +48,7 @@ const openDeleteItem = () => {
           <DeleteButton @click="openDeleteItem()" />
         </div>
       </div>
-      <div class="h-[80%] pt-28 mx-4 text-5xl text-center">
+      <div class="h-[80%] pt-28 ml-5 mx-4 text-5xl text-center truncate hover:text-clip">
         {{ employee.name }}
       </div>
     </template>

--- a/user_front/components/RegistInfo/card/Food.vue
+++ b/user_front/components/RegistInfo/card/Food.vue
@@ -43,7 +43,7 @@ const reloadFood = () => {
 <template>
   <RegistInfoWideCard>
     <template #body>
-      <div class="w-[40%] text-center text-5xl">
+      <div class="w-[40%] ml-8 text-center text-5xl truncate hover:text-clip">
         {{ food.name }}
       </div>
       <RegistInfoDivideBar />

--- a/user_front/components/RegistInfo/card/Food.vue
+++ b/user_front/components/RegistInfo/card/Food.vue
@@ -43,32 +43,32 @@ const reloadFood = () => {
 <template>
   <RegistInfoWideCard>
     <template #body>
-      <div class="w-[40%] ml-8 text-center text-5xl truncate hover:text-clip">
+      <div class="w-[40%] ml-8 text-center text-4xl truncate hover:text-clip">
         {{ food.name }}
       </div>
       <RegistInfoDivideBar />
       <div v-if="groupCategoryId === 1" class="w-[10%] text-center">
-        <p class="text-xl">{{ $t("Food.cook") }}</p>
+        <p class="text-base">{{ $t("Food.cook") }}</p>
         <p class="text-2xl">
           {{ food.isCooking ? $t("Food.yes") : $t("Food.no") }}
         </p>
       </div>
       <RegistInfoDivideBar v-if="groupCategoryId === 1" />
-      <div class="mx-4 text-center text-xl">
+      <div class="mx-4 text-center text-xl w-[9%]">
         <span>{{ $t("Food.sold") }}<br />{{ $t("Food.toBe") }}</span>
       </div>
       ▶
-      <div class="w-[15%] mx-4 text-2xl">
+      <div class="w-[15%] mx-4 text-xl">
         <div class="mr-1">
           {{ $t("Food.firstDay") }}
-          <span class="w-[10%] text-center text-3xl">
+          <span class="w-[10%] text-center text-xl">
             {{ food.firstNum }}
           </span>
           {{ $t("Food.count") }}
         </div>
-        <div class="mr-1">
+        <div class="mr-1 text-xl">
           {{ $t("Food.secondDay") }}
-          <span class="w-[10%] text-center text-3xl">
+          <span class="w-[10%] text-center text-xl">
             {{ food.secondNum }}
           </span>
           {{ $t("Food.count") }}

--- a/user_front/components/RegistInfo/card/Place.vue
+++ b/user_front/components/RegistInfo/card/Place.vue
@@ -51,7 +51,7 @@ const openEditPlace = () => {
           {{ place.place }}
         </div>
         <div class="w-[13%] h-[80%] text-base">{{ $t('Place.free') }}</div>
-          <div class="w-[25%] h-[80%] pr-1 break-normal">
+          <div class="w-[25%] h-[80%] pr-1 break-normal break-words text-ellipsis overflow-hidden">
             {{ place.remark }}
           </div>
       </template>

--- a/user_front/components/RegistInfo/card/Power.vue
+++ b/user_front/components/RegistInfo/card/Power.vue
@@ -42,25 +42,25 @@ const openDeletePower = () => {
   <div class="tracking-widest font-light">
     <RegistInfoWideCard>
       <template #body>
-        <div class="w-[37%] text-center pl-8 text-5xl font-light">
+        <div class="w-[37%] text-center pl-8 text-4xl font-light truncate hover:text-clip">
         {{ props.item }}
       </div>
       <RegistInfoDivideBar />
-      <div class="flex w-28 justify-end m-4 text-center">
+      <div class="flex w-28 justify-end m-4 text-center ml-10">
         <div class="text-6xl font-light">{{ props.power }}</div>
         <div class="mt-12 font-light text-ms">[W]</div>
       </div>
       <RegistInfoDivideBar />
       <div>
         <div class="flex items-center text-lg">
-          <div class="w-20 ">{{ $t('Power.maker') }}</div>
+          <div class="w-20">{{ $t('Power.maker') }}</div>
           <RegistInfoTriangle />
-          <div class="w-32 ">{{ props.manufacturer }}</div>
+          <div class="w-40 truncate hover:text-clip">{{ props.manufacturer }}</div>
         </div>
         <div class="flex items-center">
-          <div class="w-20 h-6">{{ $t('Power.model') }}</div>
+          <div class="w-20 h-6 ">{{ $t('Power.model') }}</div>
           <RegistInfoTriangle />
-          <div class="w-32 break-normal">{{ props.model }}</div>
+          <div class="w-40 break-normal truncate hover:text-clip">{{ props.model }}</div>
         </div>
       </div>
     </template>

--- a/user_front/components/RegistInfo/card/Power.vue
+++ b/user_front/components/RegistInfo/card/Power.vue
@@ -46,8 +46,8 @@ const openDeletePower = () => {
         {{ props.item }}
       </div>
       <RegistInfoDivideBar />
-      <div class="flex w-28 justify-end m-4 text-center ml-10">
-        <div class="text-6xl font-light">{{ props.power }}</div>
+      <div class="flex w-28 justify-end m-4 text-center ml-8">
+        <div class="text-5xl font-light">{{ props.power }}</div>
         <div class="mt-12 font-light text-ms">[W]</div>
       </div>
       <RegistInfoDivideBar />

--- a/user_front/components/RegistInfo/card/Purchase.vue
+++ b/user_front/components/RegistInfo/card/Purchase.vue
@@ -60,7 +60,7 @@ const openDeletePurchase = () => {
           <span class="underline">{{ purchase.foodProduct }}</span
           >の
         </div>
-        <div class="mr-1">
+        <div class="mr-1 truncate hover:text-clip">
           {{ purchase.name }}
         </div>
       </div>

--- a/user_front/components/RegistInfo/card/Purchase.vue
+++ b/user_front/components/RegistInfo/card/Purchase.vue
@@ -76,7 +76,7 @@ const openDeletePurchase = () => {
         >
       </div>
       ▸
-      <div class="w-[20%] mx-4 text-3xl text-center">
+      <div class="w-[20%] mx-4 text-2xl text-center">
         <div class="mr-1 text-center">
           {{ purchase.shop }}
         </div>

--- a/user_front/components/RegistInfo/card/Purchase.vue
+++ b/user_front/components/RegistInfo/card/Purchase.vue
@@ -56,9 +56,12 @@ const openDeletePurchase = () => {
       </div>
       ▸
       <div class="w-[20%] ml-4 text-3xl text-center">
-        <div class="mr-1 my-1 text-xl">
-          <span class="underline">{{ purchase.foodProduct }}</span
-          >の
+        <div class="flex justify-center">
+          <div class="mr-1 my-1 text-xl truncate hover:text-clip">
+            <span class="underline">{{ purchase.foodProduct }}</span
+            >
+          </div>
+          <div class="mt-3 text-sm">の</div>
         </div>
         <div class="mr-1 truncate hover:text-clip">
           {{ purchase.name }}

--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -503,7 +503,7 @@ const rentalItemOverlap = computed(() => {
             <p>削除してください</p>
           </div>
           <div class="flex flex-wrap gap-4">
-            <div class="w-1/4" v-for="item in rentalOrders" :key="item.toString()">
+            <div class="w-fit" v-for="item in rentalOrders" :key="item.toString()">
               <RegistInfoCardItem
                 :group-id="group?.id"
                 :regist="item.rental_item.rental_item"
@@ -525,7 +525,7 @@ const rentalItemOverlap = computed(() => {
         <div v-show="tab === 7" class="flex flex-wrap flex-col">
           <Button class="fixed right-0 bottom-0 m-10 mb-14" @click="openAddEmployee()" />
           <div class="mt--9 flex flex-wrap gap-4">
-            <div class="w-1/4" v-for="e in employee" :key="e.toString()">
+            <div class="w-fit" v-for="e in employee" :key="e.toString()">
               <RegistInfoCardEmployee
                 :group-id="group?.id"
                 :id="e.employee.id"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#1292 
<!-- 対応したIssue番号を記載 -->
resolve #1292 

# 概要
<!-- 開発内容の概要を記載 -->
- カードのcssを修正した
# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/components/RegistInfo/card/Employee.vue
- user_front/components/RegistInfo/card/Food.vue
- user_front/components/RegistInfo/card/Power.vue
- user_front/components/RegistInfo/card/Purchase.vue
- user_front/pages/regist_info/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

powerカード(before)
<img width="768" alt="スクリーンショット 2023-05-26 21 16 23" src="https://github.com/NUTFes/group-manager-2/assets/115447919/7edb0ac7-73a2-4c77-8248-255dfbe7b440">

powerカード(after)
<img width="657" alt="スクリーンショット 2023-05-26 21 38 42" src="https://github.com/NUTFes/group-manager-2/assets/115447919/5f95109c-43c8-4db9-85ea-59d49096cbc5">

Employeeカード(before)
<img width="633" alt="スクリーンショット 2023-05-26 21 13 43" src="https://github.com/NUTFes/group-manager-2/assets/115447919/a377f492-944c-4acd-90e2-66b7c4f32930">

Employeeカード(after)
<img width="418" alt="スクリーンショット 2023-05-26 21 34 16" src="https://github.com/NUTFes/group-manager-2/assets/115447919/9e5ec750-b93c-4bee-b6db-5608199ee34b">

Foodカード(before)
<img width="633" alt="スクリーンショット 2023-05-26 21 09 03" src="https://github.com/NUTFes/group-manager-2/assets/115447919/722d7662-47fd-4de6-ad69-38a4776808fc">

Foodカード(after)
<img width="657" alt="スクリーンショット 2023-05-26 21 35 45" src="https://github.com/NUTFes/group-manager-2/assets/115447919/b9c857c8-7f80-4c3f-8a84-86c1d5f91de4">

Purchaseカード(before)
<img width="689" alt="スクリーンショット 2023-05-26 21 14 17" src="https://github.com/NUTFes/group-manager-2/assets/115447919/f59359aa-6be6-49d7-b976-dabc968d6429">

Purchaseカード(after)
<img width="657" alt="スクリーンショット 2023-05-26 21 38 04" src="https://github.com/NUTFes/group-manager-2/assets/115447919/e46e9689-5d87-4ad7-96ce-43e6d542ffc1">

regist_info/index.vue(before)
カード間が詰まっていた
<img width="1211" alt="スクリーンショット 2023-05-26 21 19 02" src="https://github.com/NUTFes/group-manager-2/assets/115447919/6494c25b-402c-4ae9-a5b1-2012feba3385">

regist_info/index.vue(after)
<img width="1267" alt="スクリーンショット 2023-05-26 21 40 21" src="https://github.com/NUTFes/group-manager-2/assets/115447919/83c5f4b3-f8ce-4d83-ba7d-5cd383cc3c66">


購入品申請の長い食品名を省略
<img width="411" alt="スクリーンショット 2023-05-26 22 04 06" src="https://github.com/NUTFes/group-manager-2/assets/115447919/bc44da68-958f-4992-b526-2aa292642c44">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 従業員、食品、電力、購入品を長い文字列で登録してみる
- カードから文字が飛び出さないか確認する
- 従業員のカードが複数ある場合重ならないか、表示がおかしくないか

# 備考
