### PR TITLE
PR関係の大改装

### DIFF
--- a/admin_view/nuxt-project/pages/public_relations/_id.vue
+++ b/admin_view/nuxt-project/pages/public_relations/_id.vue
@@ -32,7 +32,9 @@
               <th>ダウンロードパス</th>
               <td>
                 <div v-if='publicRelations.picture_path === null'>未登録</div>
-                <div v-else @click="DownloadPic(publicRelations.picture_path)">{{ publicRelations.picture_path }}</div>
+                <div v-else @click="DownloadPic(publicRelations.picture_path)">
+                  <img :src="publicRelations.picture_path" />
+                </div>
               </td>
             </tr>
             <tr>
@@ -211,5 +213,11 @@ td {
 }
 th {
   width: 30%;
+}
+
+img {
+  width:100%;
+  height: 100%;
+  object-fit: contain;
 }
 </style>

--- a/user_front/pages/mypage/publicRelations/index.vue
+++ b/user_front/pages/mypage/publicRelations/index.vue
@@ -1,82 +1,152 @@
 <script lang="ts" setup>
-import { getDownloadURL, getStorage, ref as fireRef, uploadBytes } from "firebase/storage";
+import {
+  getDownloadURL,
+  getStorage,
+  ref as fireRef,
+  uploadBytes,
+} from "firebase/storage";
 import { loginCheck } from "~~/utils/methods";
+import axios from "axios";
 
-const router = useRouter()
+interface PublicRelation {
+  id: number;
+  group_id: number;
+  picture_name: string;
+  picture_path: string;
+  blurb: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const router = useRouter();
 const config = useRuntimeConfig();
 const state = reactive({
   groupId: 0,
 });
 
-const selectedFile = ref<File|null>(null)
-const fileName = ref<string>('選択してください')
-const pictureName = ref<string>("")
-const blurb = ref<string>("")
+const currentPublicRelation = ref<PublicRelation | null>(null);
+const selectedFile = ref<File | null>(null);
+const selectedFileUrl = ref<string>("");
+const fileName = ref<string>("選択してください");
+const pictureName = ref<string>("");
+const blurb = ref<string>("");
+const isSubmitting = ref<boolean>(false);
 
 const isBlurbOver = computed(() => {
-  return blurb.value.length > 40
-})
+  return blurb.value.length > 40;
+});
 
 onMounted(async () => {
   // ログインしていない場合は/welcomeに遷移させる
-  loginCheck()
+  loginCheck();
   state.groupId = Number(localStorage.getItem("group_id"));
-})
+
+  const getPublicRelationUrl = "/public_relations";
+  axios
+    .get(config.APIURL + getPublicRelationUrl)
+    .then((response) => {
+      const publicRelations: PublicRelation[] = response.data.data;
+      const publicRelation = publicRelations.find(
+        (pr) => pr.group_id === state.groupId
+      );
+      currentPublicRelation.value = publicRelation || null;
+      blurb.value = publicRelation?.blurb || "";
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+});
 
 const fileUpload = (e: Event) => {
-  const target = e.target as HTMLInputElement
-  const files = target.files
-  const file = files![0]
-  selectedFile.value = file
-  fileName.value = file.name
-}
+  const target = e.target as HTMLInputElement;
+  const files = target.files;
+  const file = files![0];
+  selectedFile.value = file;
+  selectedFileUrl.value = URL.createObjectURL(file);
+  fileName.value = file.name;
+};
 
 const storage = getStorage();
 const storageRef = fireRef(storage, fileName.value);
 
 const editImageURL = () => {
   if (blurb.value.length === 0) {
-    alert('PR文を入力してください')
-    return
+    alert("PR文を入力してください");
+    return;
   }
 
-  selectedFile.value &&
-  uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
-    pictureName.value = snapshot.ref.name
-    getDownloadURL(fireRef(storage, pictureName.value))
-    .then((url) => {
-        const postUrl =
-        "/public_relations?group_id=" +
-        state.groupId;
+  // currentPublicRelationがなくて、画像が未選択の場合はエラー
+  if (!selectedFile.value && !currentPublicRelation.value) {
+    alert("画像を選択してください");
+    return;
+  }
 
-        useFetch(config.APIURL + postUrl,{
-          method: "POST",
-          params: {
-            picture_name: fileName.value,
-            picture_path: url,
-            blurb: blurb.value,
-          },
-          headers: {
-            "Content-Type": "application/json",
-          },
+  isSubmitting.value = true;
+  // currentPublicRelationがない場合は新規登録する
+  selectedFile.value &&
+    uploadBytes(storageRef, selectedFile.value).then((snapshot) => {
+      pictureName.value = snapshot.ref.name;
+      getDownloadURL(fireRef(storage, pictureName.value))
+        .then((url) => {
+          const postUrl = "/public_relations?group_id=" + state.groupId;
+
+          useFetch(config.APIURL + postUrl, {
+            method: "POST",
+            params: {
+              picture_name: fileName.value,
+              picture_path: url,
+              blurb: blurb.value,
+            },
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
         })
-    })
-    .then(
-    (response) =>{
-      alert('登録できました')
-      router.push("/mypage");
-    },
-    (error) => {
-      alert('登録できませんでした')
-    })
-  })
-}
+        .then(
+          (response) => {
+            alert("登録しました（画像の反映には数分かかります）");
+            router.push("/mypage");
+          },
+          (error) => {
+            alert("登録できませんでした");
+          }
+        );
+    });
+
+  // 画像は選択してないが、currentPublicRelationがある場合はPR文のみ更新する
+  if (!selectedFile.value && currentPublicRelation.value) {
+    const putUrl = "/public_relations/" + currentPublicRelation.value.id;
+    useFetch(config.APIURL + putUrl, {
+      method: "PUT",
+      params: {
+        blurb: blurb.value,
+        picture_name: currentPublicRelation.value.picture_name,
+        picture_path: currentPublicRelation.value.picture_path,
+      },
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then(
+      (response) => {
+        alert("PR文を更新しました");
+        router.push("/mypage");
+      },
+      (error) => {
+        alert("PR文を更新きませんでした");
+      }
+    );
+  }
+};
 </script>
 
 <template>
-  <NuxtLink to="/mypage" class="ml-4 text-left text-xl text-pink-500 hover:font-bold">{{ $t("RegistInfo.return") }}</NuxtLink>
+  <NuxtLink
+    to="/mypage"
+    class="ml-4 text-left text-xl text-pink-500 hover:font-bold"
+    >{{ $t("RegistInfo.return") }}</NuxtLink
+  >
   <div class="mx-[10%] my-[5%]">
-    <h1 class="text-4xl ">{{ $t("PR.PR") }}</h1>
+    <h1 class="text-4xl">{{ $t("PR.PR") }}</h1>
     <Card>
       <div class="left text-3xl">
         {{ $t("PR.text") }}
@@ -86,10 +156,27 @@ const editImageURL = () => {
       <div class="my-4 items-center">
         <label>
           <span class="text-3xl mr-4">{{ $t("PR.illustration") }}</span>
-          <input type="file" @change="fileUpload">
+          <input type="file" @change="fileUpload" />
         </label>
       </div>
-      <RegistPageButton :text="$t('Button.register')" @click="editImageURL" :disabled="isBlurbOver"></RegistPageButton>
+      <div class="flex flex-col gap-2 my-4">
+        <div
+          v-if="currentPublicRelation"
+          class="flex flex-col items-center gap-2"
+        >
+          <p>現在登録済みの画像</p>
+          <img :src="currentPublicRelation.picture_path" class="w-1/3" />
+        </div>
+        <div v-if="selectedFile" class="flex flex-col items-center gap-2">
+          <p>選択中の画像</p>
+          <img :src="selectedFileUrl" class="w-1/3" />
+        </div>
+      </div>
+      <RegistPageButton
+        :text="$t('Button.register')"
+        @click="editImageURL"
+        :disabled="isBlurbOver || isSubmitting"
+      ></RegistPageButton>
     </Card>
   </div>
 </template>

--- a/user_front/pages/regist/publicRelations/index.vue
+++ b/user_front/pages/regist/publicRelations/index.vue
@@ -9,7 +9,8 @@ const state = reactive({
 });
 const errorMessage = ref("");
 
-const selectedFile = ref<File|null>(null)
+const selectedFile = ref<File | null>(null)
+const selectedFileUrl = ref<string>("")
 const fileName = ref<string>('選択してください')
 const pictureName = ref<string>("")
 const blurb = ref<string>("")
@@ -25,6 +26,7 @@ const fileUpload = (e: Event) => {
   const files = target.files
   const file = files![0]
   selectedFile.value = file
+  selectedFileUrl.value = URL.createObjectURL(file)
   fileName.value = file.name
 }
 
@@ -34,6 +36,12 @@ const storageRef = fireRef(storage, fileName.value);
 const registImageURL = () =>{
   if (blurb.value.length === 0) {
     alert('PR文を入力してください')
+    return
+  }
+
+  // 画像がない場合はalertを出す
+  if (!selectedFile.value) {
+    alert('画像を選択してください')
     return
   }
 
@@ -94,6 +102,10 @@ const isBlurbOver = computed(() => {
             <div class="flex flex-col">
               <input class="form" type="file" @change="fileUpload">
             </div>
+          </div>
+          <div v-if="selectedFileUrl" class="my-4">
+            <p class="w-fit mx-auto">選択した画像</p>
+            <img :src="selectedFileUrl" class="w-1/2 mx-auto">
           </div>
         </div>
       </Card>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1291

# 概要
<!-- 開発内容の概要を記載 -->

- 新規登録のPR文登録
  - 画像を選択してないとアラートを出すように
  - 画像を選択したらその画像を表示するように
- マイページのPR文登録
  - PR文を登録してない場合、PR文と画像両方入力しないとアラートを出すように
  - PR文が登録済みの場合、初期値とその画像を挿入する
  - 画像を選択したら、その画像も表示するように
  - 登録ボタンを押したら、disabledになるように
- 管理者画面のPR文申請
  - 詳細ページで画像が表示されるように

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- pr申請関係（files参照）

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

![pr1](https://github.com/NUTFes/group-manager-2/assets/52590941/024b3a73-236f-43b1-9d01-5b4b76071187)
<img width="1512" alt="スクリーンショット 2023-05-26 21 32 47" src="https://github.com/NUTFes/group-manager-2/assets/52590941/f3e39ecc-c11f-4fdc-8e69-18ac7b28a37e">
<img width="1257" alt="スクリーンショット 2023-05-26 21 49 47" src="https://github.com/NUTFes/group-manager-2/assets/52590941/2917efbd-2b8b-4faf-8ed4-e8b5b75b6ab1">
<img width="781" alt="スクリーンショット 2023-05-26 21 52 13" src="https://github.com/NUTFes/group-manager-2/assets/52590941/8ce116fa-9f66-47c5-9b8d-de524a283be5">
<img width="1262" alt="スクリーンショット 2023-05-26 22 10 18" src="https://github.com/NUTFes/group-manager-2/assets/52590941/b33d1aae-d8cf-4f87-8582-d9dfbb0af8c2">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 新規登録し、PR文登録まで行く
  - 画像を選択せずに登録しようとするとアラートが出るか
  - 画像を選択したら画像が表示されるか
- マイページのPR文登録へ
  - PR文だけの修正ができるか
  - 画像を新たに選択したら、その画像が表示されるか
  - 登録ボタンを押したら、そのボタンがdisabledになるか
    - 画像反映までは数分かかる
- 管理者画面へ
  - PR文申請一覧ページにいき、年度のセレクターをAllに変えて「登録ずみ」のPR文申請をクリックして詳細ページに移動する
  - 画像が表示されるか
- 新たに新規登録をして、**PR文申請を打たずに**マイページへ
  - PR文だけの登録ができないか
    - PR文と画像を入力することで登録できる 

# 備考
