### PR TITLE
アナウンス文の登録・編集ができない問題の解決

### DIFF
--- a/user_front/pages/mypage/edit_announcement/index.vue
+++ b/user_front/pages/mypage/edit_announcement/index.vue
@@ -1,24 +1,74 @@
 <script lang="ts" setup>
+import axios from "axios";
+
+interface Announcement {
+  id: number;
+  group_id: number;
+  message: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const router = useRouter();
+
+const currentAnnouncement = ref<Announcement>();
 const config = useRuntimeConfig();
 const groupId = ref<number>(0);
-const announcement = ref<string>("");
+const message = ref<string>("");
+
+onMounted(async () => {
+  // ログインしていない場合は/welcomeに遷移させる
+  loginCheck();
+  groupId.value = Number(localStorage.getItem("group_id"));
+
+  const getAnnouncementUrl = "/announcements";
+  axios.get(config.APIURL + getAnnouncementUrl).then((res) => {
+    const announcements = res.data.data;
+    // 同じgroup_idのannouncementを取得
+    currentAnnouncement.value = announcements.find(
+      (announcement: Announcement) => announcement.group_id === groupId.value
+    );
+
+    if (currentAnnouncement.value) {
+      message.value = currentAnnouncement.value.message;
+    }
+  });
+});
 
 const postAnnouncement = () => {
-  if (announcement.value.length === 0) {
+  if (message.value.length === 0) {
     alert("会場アナウンス文を入力してください");
     return;
   }
-  
-  useFetch(config.APIURL + "/announcements", {
-    method: "POST",
-    params: {
-      group_id: groupId.value,
-      message: announcement.value,
-    },
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
+
+  if (currentAnnouncement.value) {
+    const putURl = "/announcements/" + currentAnnouncement.value?.id;
+    axios
+      .put(config.APIURL + putURl, {
+        group_id: groupId.value,
+        message: message.value,
+      })
+      .then((res) => {
+        alert("会場アナウンスを更新しました");
+        router.push("/mypage");
+      })
+      .catch((err) => {
+        alert("会場アナウンスの更新に失敗しました");
+      });
+  } else {
+    const postUrl = "/announcements?group_id=" + groupId.value;
+    axios
+      .post(config.APIURL + postUrl, {
+        message: message.value,
+      })
+      .then((res) => {
+        alert("会場アナウンスを登録しました");
+        router.push("/mypage");
+      })
+      .catch((err) => {
+        alert("会場アナウンスの登録に失敗しました");
+      });
+  }
 };
 </script>
 
@@ -34,7 +84,7 @@ const postAnnouncement = () => {
       <div class="text-left">
         <span class="text-3xl mr-4">{{ $t("Announcement.text") }}</span>
       </div>
-      <textarea class="border-2 w-[60%]" v-model="announcement"></textarea>
+      <textarea class="border-2 w-[60%]" v-model="message"></textarea>
       <RegistPageButton
         :text="$t('Announcement.edit')"
         @click="postAnnouncement"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1290

# 概要
<!-- 開発内容の概要を記載 -->

- マイページのアナウンス文登録から、登録や編集をできるようにした

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- mypage/edit_announcements

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

- 特になし

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 新規登録をしてマイページまでいく
  - マイページのアナウンス文編集から、登録できるか
  - さらに、編集できるか

# 備考
