### PR TITLE
ステージ企画/展示・体験/研究室公開の購入品申請を非表示にする

### DIFF
--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -341,7 +341,7 @@ const rentalItemOverlap = computed(() => {
             }}
           </div>
         </li>
-        <li @click="tab = 9">
+        <li v-if="groupCategoryId != 3 && groupCategoryId != 4 && groupCategoryId != 5" @click="tab = 9">
           <div :class="{ select: tab === 9 }" class="title">
             {{ $t("RegistInfo.purchase") }}
           </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1281 

# 概要
<!-- 開発内容の概要を記載 -->
registInfoでステージ企画/展示・体験/研究室公開の購入品申請を非表示にする

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/pages/regist_info/index.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 団体登録のカテゴリーがステージ企画の時、http://localhost:8002/regist_infoで購入品が非表示になっている
- 団体登録のカテゴリーが展示・体験の時、http://localhost:8002/regist_infoで購入品が非表示になっている
- 団体登録のカテゴリーが研究室公開の時、http://localhost:8002/regist_infoで購入品が非表示になっている

# 備考
