### PR TITLE
副代表申請の編集モーダルで所属が空値でも編集できる

### DIFF
--- a/api/db/fixtures/develop/news.rb
+++ b/api/db/fixtures/develop/news.rb
@@ -1,5 +1,8 @@
 News.seed( :id,
-    { id: 1,    title: "nutfes-news" ,
-                body: "参加団体管理アプリです．" 
+    { id: 1,    title: "nutfes-news1" ,
+                body: "参加団体管理アプリです．"
+    },
+    { id: 2,    title: "nutfes-news2" ,
+                body: "参加団体管理アプリです2．"
     }
 )

--- a/user_front/components/Mypage/News.vue
+++ b/user_front/components/Mypage/News.vue
@@ -5,7 +5,7 @@ const config = useRuntimeConfig();
 const state = reactive({
   // title: "",
   // body: "",
-  news : [] as News[],
+  news: [] as News[],
   updateDate: [] as string[],
 });
 
@@ -13,10 +13,10 @@ onMounted(async () => {
   const news = await $fetch<News[]>(config.APIURL + "/news");
   state.news = news;
 
-  news.forEach((newsItem)=>{
+  news.forEach((newsItem) => {
     const date = new Date(newsItem.updated_at);
     state.updateDate.push(date.toLocaleDateString("ja-JP"));
-  })
+  });
 });
 </script>
 
@@ -25,19 +25,19 @@ onMounted(async () => {
     <div class="text-slate-900 text-2xl font-bold p-2 bg-slate-200">
       <p>{{ $t("Mypage.notice") }}</p>
     </div>
-    <div class="text-slate-800 flex flex-col gap-1 py-2 px-4" style="max-height: 200px; overflow-y: auto;">
-      <div v-for="newsItem, i in state.news">
-        <div class="border-b-2">
-          <p class="text-xl p-2">{{ newsItem.title }}</p>
-          <p class="text-xs p-2">created:{{ state.updateDate[i] }}</p>
-            <div class="bg-slate-400 mb-8">
-              <p class="text-lg">{{ newsItem.body }}</p>
-            </div>
-          </div>
+    <div
+      class="text-slate-800 flex flex-col gap-4 p-4"
+      style="max-height: 300px; overflow-y: auto"
+    >
+      <div v-for="(newsItem, i) in state.news" class="flex flex-col gap-2">
+        <div class="flex flex-row items-center gap-2 border-b">
+          <p class="text-xl">{{ newsItem.title }}</p>
+          <p class="text-xs">{{ state.updateDate[i] }}</p>
+        </div>
+        <div class="bg-slate-200 p-2 rounded-md">
+          <p class="text-lg">{{ newsItem.body }}</p>
         </div>
       </div>
-      <p class="text-md ml-auto w-fit">
-          {{ $t("Mypage.updateDate") }}:{{ state.updateDate[0] }}
-      </p>
+    </div>
   </div>
 </template>

--- a/user_front/components/RegistInfo/edit/SubRep.vue
+++ b/user_front/components/RegistInfo/edit/SubRep.vue
@@ -119,6 +119,12 @@ const createCurrentDepartmentList = (e: any) => {
     return grade.id === Number(e.target.value);
   })[0].departmentList;
 };
+
+onMounted(() => {
+  if (props.grade_id != null) {
+    createCurrentDepartmentList({ target: { value: props.grade_id } });
+  }
+});
 </script>
 
 <template>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1329 

# 概要
<!-- 開発内容の概要を記載 -->

- Newsのデザイン修正
- 編集モーダルの所属に初期値が入るようにする

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- news
- regist_info

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

![スクリーンショット 2023-05-27 16 19 13](https://github.com/NUTFes/group-manager-2/assets/52590941/d7f97738-4522-4a49-a0f7-480c5d032ed2)
![スクリーンショット 2023-05-27 16 21 12](https://github.com/NUTFes/group-manager-2/assets/52590941/0961ee43-56e1-4304-9380-551d6e681ca5)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- newsのシードデータを変えたので
  - docker compose down -v
  - make build db
  - してください
- newsのデザインが変わっているか
- 副代表が登録してなかったら登録する
- 副代表の編集で、所属に初期値が入っているか 

# 備考
