### PR TITLE
admin_viewでお知らせが表示されないエラーを解決

### DIFF
--- a/admin_view/nuxt-project/pages/news/index.vue
+++ b/admin_view/nuxt-project/pages/news/index.vue
@@ -78,7 +78,7 @@ export default {
   },
   async asyncData({ $axios }) {
     const newsUrl = "/news";
-    const newsRes = await $axios.$get(newsUrl);
+    const newsRes = await $axios.get(newsUrl);
     return {
       news: newsRes.data,
     };


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1349

# 概要
<!-- 開発内容の概要を記載 -->
admin_viewでお知らせが表示されないエラーを解決

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `http://localhost:8000/news`
スクリーンショット
<img width="1403" alt="スクリーンショット 2023-05-27 午後7 17 45" src="https://github.com/NUTFes/group-manager-2/assets/46074208/d265ae93-7f17-452b-bb47-cd4f59b3c76b">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- newsが登録できて表示できること
