### PR TITLE
食品販売団体の物品制御の実装

### DIFF
--- a/user_front/components/RegistInfo/add/Item.vue
+++ b/user_front/components/RegistInfo/add/Item.vue
@@ -174,18 +174,6 @@ const reset = () => {
             {{ $t("Item.outsideGroup") }}
           </label>
         </div>
-        <div v-if="Number(groupCategoryId) === 1">
-          <label>
-            <input
-              type="radio"
-              value="屋外団体"
-              v-model="selectedLocation"
-              :checked="selectedLocation === '屋外団体'"
-              @click="updateSelectedLocation"
-            />
-            {{ $t("Item.outsideGroup") }}
-          </label>
-        </div>
         <div v-if="Number(groupCategoryId) === 3">
           <label>
             <input
@@ -200,20 +188,39 @@ const reset = () => {
         </div>
       </div>
       <div class="text">{{ $t("Item.item") }}</div>
-      <select
-        class="entry"
-        v-model="newItem"
-        @change="handleName"
-        :class="{ error_border: nameError }"
-      >
-        <option
-          v-for="list in selectableItemList"
-          :key="list.id"
-          :value="list.id"
+      <div v-if="Number(groupCategoryId) === 1">
+        <select
+          class="entry"
+          v-model="newItem"
+          @change="handleName"
+          :class="{ error_border: nameError }"
         >
-          {{ list.name }}
-        </option>
-      </select>
+          <option
+            v-for="list in outsideRentableItemList"
+            :key="list.id"
+            :value="list.id"
+          >
+            {{ list.name }}
+          </option>
+        </select>
+      </div>
+      <div v-else>
+        <select
+          class="entry"
+          v-model="newItem"
+          @change="handleName"
+          :class="{ error_border: nameError }"
+        >
+          <option
+            v-for="list in selectableItemList"
+            :key="list.id"
+            :value="list.id"
+          >
+            {{ list.name }}
+          </option>
+        </select>
+      </div>
+
       <div class="error_msg">{{ nameError }}</div>
       <div class="text">{{ $t("Item.number") }}</div>
       <input

--- a/user_front/components/RegistInfo/edit/Item.vue
+++ b/user_front/components/RegistInfo/edit/Item.vue
@@ -195,18 +195,6 @@ const updateSelectedLocation = (event: Event) => {
             {{ $t("Item.outsideGroup") }}
           </label>
         </div>
-        <div v-if="Number(groupCategoryId) === 1">
-          <label>
-            <input
-              type="radio"
-              value="屋外団体"
-              v-model="selectedLocation"
-              :checked="selectedLocation === '屋外団体'"
-              @click="updateSelectedLocation"
-            />
-            {{ $t("Item.outsideGroup") }}
-          </label>
-        </div>
         <div v-if="Number(groupCategoryId) === 3">
           <label>
             <input
@@ -221,20 +209,38 @@ const updateSelectedLocation = (event: Event) => {
         </div>
       </div>
       <div class="text">{{ $t("Item.item") }}</div>
-      <select
-        class="entry"
-        v-model="newItem"
-        @change="handleName"
-        :class="{ error_border: nameError }"
-      >
-        <option
-          v-for="list in selectableItemList"
-          :key="list.id"
-          :value="list.id"
+      <div v-if="Number(groupCategoryId) === 1">
+        <select
+          class="entry"
+          v-model="newItem"
+          @change="handleName"
+          :class="{ error_border: nameError }"
         >
-          {{ list.name }}
-        </option>
-      </select>
+          <option
+            v-for="list in outsideRentableItemList"
+            :key="list.id"
+            :value="list.id"
+          >
+            {{ list.name }}
+          </option>
+        </select>
+      </div>
+      <div v-else>
+        <select
+          class="entry"
+          v-model="newItem"
+          @change="handleName"
+          :class="{ error_border: nameError }"
+        >
+          <option
+            v-for="list in selectableItemList"
+            :key="list.id"
+            :value="list.id"
+          >
+            {{ list.name }}
+          </option>
+        </select>
+      </div>
       <div class="error_msg">{{ nameError }}</div>
       <div class="text">{{ $t("Item.number") }}</div>
       <input

--- a/user_front/components/RegistInfo/edit/Place.vue
+++ b/user_front/components/RegistInfo/edit/Place.vue
@@ -91,16 +91,14 @@ const closeEditPlace = () => {
 
 onMounted(async () => {
   const placeData = await $fetch<Place>(config.APIURL + "/places");
-  !!placeData.data &&
-    placeData.data.forEach((place) => {
-      placeList.value.push(place);
-    });
+  // !!placeData.data &&
+  //   placeData.data.forEach((place) => {
+  //     placeList.value.push(place);
+  //   });
   const groupUrl =
     config.APIURL + "/groups/" + Number(localStorage.getItem("group_id"));
   axios.get(groupUrl).then(async (response) => {
     groupCategoryId.value = response.data.data.group_category_id;
-
-    const placeData = await $fetch<Place>(config.APIURL + "/places");
 
     placeData.data.forEach((place) => {
       if (groupCategoryId.value === 1) {
@@ -113,6 +111,7 @@ onMounted(async () => {
     });
   });
   group_id.value=Number(localStorage.getItem("group_id"))
+  console.log(placeList.value)
 });
 
 const editPlace = async () => {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1366 
- 参加団体が食品団体の時の登録制御を行なった
- 研究室と展示・体験で会場申請のselectで同じ会場が二つ入っているバグの解消

# 概要
<!-- 開発内容の概要を記載 -->
- 食品団体の時は外のみの出店となるので、物品登録も外部に出せる物品だけにした。
<img width="494" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/e7fc0ac5-bab9-41c9-9491-66743a5eb8f8">

- 同じ会場が複数あるバグについて
Listに入れる処理が2つあったので削除しておきました
<img width="677" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/bff1d1d0-d60a-42f5-ad32-41d74f7bdacb">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ]　食品団体にした時に、上記画像のようになっているか
- [x] 食品以外に時は両方選べるか
- [x] ステージ団体はステージの物品だけ選べるか
- [x] 研究室・展示体験・その他の会場申請が正しい数だけ入っているか

# 備考
