### PR TITLE
管理者画面の割り当ての追加で団体名を表示させる

### DIFF
--- a/admin_view/nuxt-project/pages/assign_items/_id.vue
+++ b/admin_view/nuxt-project/pages/assign_items/_id.vue
@@ -421,7 +421,7 @@ export default {
       stockerItems: stockerItemsRes.data.stocker_items,
 			placeName: stockerItemsRes.data.stocker_place,
       assignRentalItems: assignRentalItemsRes.data,
-      groups: groupsRes.data,
+      groups: groupsRes,
       allRentableItems: allRentableItemsRes.data,
       insideRentableItems: insideRentableItemsRes.data,
       outsideRentableItems: outsideRentableItemsRes.data,


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1375 

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面の割り当ての追加で団体名がプルダウンで表示されなかったので修正した

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="1680" alt="スクリーンショット 2023-06-11 17 27 10" src="https://github.com/NUTFes/group-manager-2/assets/107479066/b9013f32-e873-49cb-afd0-40c62b35e703">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者画面の`http://localhost:8000/assign_items` でどれかの場所の割り当て追加モーダルを開いて、団体名がプルダウンで表示される
-

# 備考
