### PR TITLE
[Wip]管理者画面で模擬店平面図の表示

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -159,6 +159,11 @@ export default {
           icon: "campaign",
           click: "/announcement",
         },
+        {
+          title: "模擬店平面図申請",
+          icon: "map",
+          click: "/venue_maps",
+        },
       ],
       // 操作系
       operation_items: [

--- a/admin_view/nuxt-project/pages/venue_maps/_id.vue
+++ b/admin_view/nuxt-project/pages/venue_maps/_id.vue
@@ -1,0 +1,195 @@
+<template>
+    <div class="main-content">
+      <SubHeader
+        v-bind:pageTitle="groups.find((group) => group.id === announcement.group_id).name"
+        pageSubTitle="模擬店平面図申請一覧"
+      >
+        <CommonButton
+          v-if="this.$role(this.roleID).announcements.update"
+          iconName="edit"
+          :on_click="openEditModal"
+        >
+          編集
+        </CommonButton>
+        <CommonButton
+          v-if="this.$role(this.roleID).announcements.delete"
+          iconName="delete"
+          :on_click="openDeleteModal"
+        >
+          削除
+        </CommonButton>
+      </SubHeader>
+      <Row>
+        <Card padding="40px 150px" gap="20px">
+          <Row justify="start">
+            <h4>基本情報</h4>
+            <VerticalTable>
+              <tr>
+                <th>ID</th>
+                <td>{{ announcement.id }}</td>
+              </tr>
+              <tr>
+                <th>団体名</th>
+                <td>{{ groups.find((group) => group.id === announcement.group_id).name }}</td>
+              </tr>
+              <tr>
+                <th>ダウンロードパス</th>
+                <td>
+                  <!-- <div v-if='venueMaps.picture_path === null'>未登録</div> -->
+                  <img :src="announcement.picture_path" />
+                  <!-- <div v-else @click="DownloadPic(venueMaps.picture_path)">
+                  </div> -->
+                </td>
+              </tr>
+              <tr>
+                <th>登録日時</th>
+                <td>{{ announcement.created_at | formatDate }}</td>
+              </tr>
+              <tr>
+                <th>編集日時</th>
+                <td>{{ announcement.updated_at | formatDate }}</td>
+              </tr>
+            </VerticalTable>
+          </Row>
+        </Card>
+      </Row>
+
+      <EditModal
+        @close="closeEditModal"
+        v-if="isOpenEditModal"
+        title="模擬店平面図の編集"
+      >
+        <template v-slot:form>
+          <div>
+            <h3>団体名</h3>
+            <select v-model="group_id">
+              <option v-for="group in groups" :key="group.id" :value="group.id">
+                {{ group.name }}
+              </option>
+            </select>
+          </div>
+          <div>
+            <h3>会場名</h3>
+            <input v-model="message" placeholder="入力してください" />
+          </div>
+        </template>
+        <template v-slot:method>
+          <CommonButton iconName="edit" :on_click="edit">登録</CommonButton>
+        </template>
+      </EditModal>
+
+      <DeleteModal
+        @close="closeDeleteModal"
+        v-if="isOpenDeleteModal"
+        title="模擬店平面図の削除"
+      >
+        <template v-slot:method>
+          <YesButton iconName="delete" :on_click="destroy">はい</YesButton>
+          <NoButton iconName="close" :on_click="closeDeleteModal"
+            >いいえ</NoButton
+          >
+        </template>
+      </DeleteModal>
+      <SnackBar v-if="isOpenSnackBar" @close="closeSnackBar">
+        {{ snackMessage }}
+      </SnackBar>
+    </div>
+  </template>
+
+  <script>
+  import { mapState } from "vuex";
+  export default {
+    watchQuery: ["page"],
+    data() {
+      return {
+        announcement: {},
+        groups: [],
+        isOpenEditModal: false,
+        isOpenDeleteModal: false,
+        isOpenSnackBar: false,
+        message: "",
+        snackMessage: "",
+        group_id: 1,
+        routeId: "",
+      };
+    },
+    computed: {
+      ...mapState({
+        roleID: (state) => state.users.role,
+      }),
+    },
+    async asyncData({ $axios, route }) {
+      const routeId = route.params.id;
+      const announcementUrl = "/venue_maps/" + routeId;
+      const groupsUrl = "/groups";
+      const announcementRes = await $axios.$get(announcementUrl);
+      const groupsRes = await $axios.$get(groupsUrl);
+      return {
+        announcement: announcementRes.data,
+        routeId: routeId,
+        groups: groupsRes,
+      };
+    },
+    methods: {
+      openEditModal() {
+        this.group_id = this.announcement.group_id;
+        this.message = this.announcement.message;
+        this.isOpenEditModal = false;
+        this.isOpenEditModal = true;
+      },
+      closeEditModal() {
+        this.isOpenEditModal = false;
+      },
+      openDeleteModal() {
+        this.isOpenDeleteModal = false;
+        this.isOpenDeleteModal = true;
+      },
+      closeDeleteModal() {
+        this.isOpenDeleteModal = false;
+      },
+      openSnackBar(message) {
+        this.snackMessage = message;
+        this.isOpenSnackBar = true;
+        setTimeout(this.closeSnackBar, 2000);
+      },
+      closeSnackBar() {
+        this.isOpenSnackBar = false;
+      },
+      async reload(id) {
+        const url = "/venue_maps/" + id;
+        const res = await this.$axios.$get(url);
+        this.announcement = res.data;
+      },
+      async edit() {
+        const url = "/venue_maps/" + this.routeId + "?message=" + this.message + "&group_id=" + this.group_id;
+
+        await this.$axios.$put(url).then((res) => {
+          this.openSnackBar("模擬店平面図を編集しました");
+          this.message = "";
+          this.group_id = 1;
+          this.reload(res.data.id);
+          this.closeEditModal();
+        });
+      },
+      async destroy() {
+        const delUrl = "/venue_maps/" + this.routeId;
+        await this.$axios.$delete(delUrl);
+        this.$router.push("/venue_maps");
+      },
+    },
+  };
+  </script>
+
+  <style scoped>
+  td {
+    width: 70%;
+  }
+  th {
+    width: 30%;
+  }
+  img {
+    width:100%;
+    height: 100%;
+    object-fit: contain;
+  }
+  </style>

--- a/admin_view/nuxt-project/pages/venue_maps/index.vue
+++ b/admin_view/nuxt-project/pages/venue_maps/index.vue
@@ -1,0 +1,148 @@
+<template>
+    <div class="main-content">
+      <SubHeader pageTitle="模擬店平面図申請一覧">
+        <CommonButton
+          v-if="this.$role(roleID).announcements.create"
+          iconName="add_circle"
+          :on_click="openAddModal"
+        >
+          追加
+        </CommonButton>
+      </SubHeader>
+      <Card width="100%">
+        <Table>
+          <template v-slot:table-header>
+            <th v-for="(header, index) in headers" :key="index">
+              {{ header }}
+            </th>
+          </template>
+          <template v-slot:table-body>
+            <tr
+              v-for="(venueMap, index) in venueMaps"
+              :key="index"
+              @click="
+                () =>
+                  $router.push({
+                    path: `/venue_maps/` + venueMap.id,
+                  })
+              "
+            >
+              <td>{{ venueMap.id }}</td>
+              <td>
+                {{
+                  groups.find((group) => group.id === venueMap.group_id).name
+                }}
+              </td>
+              <td>
+                <div v-if='venueMap.picture_path === null'>未登録</div>
+                <div v-else>登録済み</div>
+              </td>
+            </tr>
+          </template>
+        </Table>
+      </Card>
+
+      <AddModal
+        @close="closeAddModal"
+        v-if="isOpenAddModal"
+        title="模擬店配置図の登録"
+      >
+        <template v-slot:form>
+          <div>
+            <h3>団体名</h3>
+            <select v-model="group_id">
+              <option v-for="group in groups" :key="group.id" :value="group.id">
+                {{ group.name }}
+              </option>
+            </select>
+          </div>
+          <div>
+            <h3>模擬店配置図</h3>
+            <input v-model="message" placeholder="入力してください" />
+          </div>
+        </template>
+        <template v-slot:method>
+          <CommonButton iconName="add_circle" :on_click="submit"
+            >登録</CommonButton
+          >
+        </template>
+      </AddModal>
+      <SnackBar v-if="isOpenSnackBar" @close="closeSnackBar">
+        {{ snackMessage }}
+      </SnackBar>
+    </div>
+  </template>
+
+  <script>
+  import { mapState } from "vuex";
+  export default {
+    watchQuery: ["page"],
+    data() {
+      return {
+        venueMaps: [],
+        groups: [],
+        dialog: false,
+        headers: ["ID", "団体名", "申請状況"],
+        isOpenAddModal: false,
+        isOpenSnackBar: false,
+        message: "",
+        snackMessage: "",
+        group_id: 1,
+      };
+    },
+    async asyncData({ $axios }) {
+      const venueMapsUrl = "/venue_maps";
+      const groupsUrl = "/groups";
+      const venueMapsRes = await $axios.$get(venueMapsUrl);
+      const groupsRes = await $axios.$get(groupsUrl);
+      return {
+        venueMaps: venueMapsRes.data,
+        groups: groupsRes,
+      };
+    },
+    computed: {
+      ...mapState({
+        roleID: (state) => state.users.role,
+      }),
+    },
+    methods: {
+      openAddModal() {
+        this.isOpenAddModal = false;
+        this.isOpenAddModal = true;
+      },
+      closeAddModal() {
+        this.isOpenAddModal = false;
+      },
+      openSnackBar(message) {
+        this.snackMessage = message;
+        this.isOpenSnackBar = true;
+        setTimeout(this.closeSnackBar, 2000);
+      },
+      closeSnackBar() {
+        this.isOpenSnackBar = false;
+      },
+      reload(id) {
+        const url = "/venue_maps/" + id;
+        this.$axios.$get(url).then((response) => {
+          this.announcements.push(response.data);
+        });
+      },
+      async submit() {
+        const url =
+          "/venue_maps/" +
+          "?group_id=" +
+          this.group_id +
+          "&message=" +
+          this.message;
+
+        this.$axios.$post(url).then((response) => {
+          this.openSnackBar("模擬店配置図を登録しました");
+          this.group_id = 1;
+          this.message = "";
+          this.reload(response.data.id);
+          this.closeAddModal();
+        });
+      },
+    },
+  };
+  </script>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1378 

# 概要
<!-- 開発内容の概要を記載 -->
- 管理者画面で模擬店平面図の表示をする
- とりあえずannouncementと同じ感じで登録してる団体が確認できればいい
- 可能であればpublic_relationsと同じ感じで全団体を表示した上で申請済みか否かを確認できるようにする
- また、各団体のダウンロードパスを押して模擬店平面図をダウンロードできるようにしたい

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
- announcementのファイルを参考して書き換えてました。
- `_id.vue` でよく分からなくなったのでとりあえずpushしてます