### PR TITLE
管理者画面からの物品申請で選択できる物品の修正

### DIFF
--- a/admin_view/nuxt-project/pages/rental_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/rental_orders/_id.vue
@@ -129,7 +129,7 @@ export default {
     async openEditModal() {
       this.rentalItemID = this.rentalOrder.rental_order.rental_item_id;
       this.num = this.rentalOrder.rental_order.num;
-      const rentableItemsUrl = "/api/v1/get_rentable_items";
+      const rentableItemsUrl = "/api/v1/get_all_rentable_items";
       const resRentableItems = await this.$axios.$get(rentableItemsUrl);
       this.rentableItemList = resRentableItems.data;
       this.isOpenEditModal = true;

--- a/admin_view/nuxt-project/pages/rental_orders/index.vue
+++ b/admin_view/nuxt-project/pages/rental_orders/index.vue
@@ -240,7 +240,7 @@ export default {
       const groupUrl = "/api/v1/get_groups_refinemented_by_current_fes_year";
       const resGroups = await this.$axios.$get(groupUrl);
       this.groupList = resGroups.data;
-      const rentableItemsUrl = "/api/v1/get_rentable_items";
+      const rentableItemsUrl = "/api/v1/get_all_rentable_items";
       const resRentableItems = await this.$axios.$get(rentableItemsUrl);
       this.rentableItemList = resRentableItems.data;
       this.isOpenAddModal = true;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1384

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面から物品申請、および物品申請の編集をしようとすると、物品選択の時に机と椅子の2つしか表示されないのを全て表示するように修正した
# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- admin_view/nuxt-project/pages/rental_orders/index.vue
- admin_view/nuxt-project/pages/rental_orders/_id.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/44cb3ee6-baf4-468a-836a-35b5d7466adc)
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/a54b24b4-0304-40c4-96db-ba6baeb195d0)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- `http://localhost:8000/rental_orders`で、追加ボタンを押し、物品の選択で全て表示されるのを確認してほしい
- `http://localhost:8000/rental_orders/1`で、編集ボタンを押し、物品の選択で全て表示されるのを確認してほしい
-

# 備考
