### PR TITLE
[fix] 電力申請のapi修正

### DIFF
--- a/api/app/controllers/api/v1/power_orders_api_controller.rb
+++ b/api/app/controllers/api/v1/power_orders_api_controller.rb
@@ -26,29 +26,22 @@ class Api::V1::PowerOrdersApiController < ApplicationController
     fes_year_id = params[:fes_year_id].to_i
     power = params[:power].to_i
     group_category_id = params[:group_category_id].to_i
-    # 両方ともALL
-    if fes_year_id == 0 && power == 0
-      @power_orders = PowerOrder.all
-      #fes_year_idだけ指定
-    elsif fes_year_id != 0 && power == 0 
-      @power_orders = PowerOrder.preload(:group).map{ |power_order| power_order if power_order.group.fes_year_id == fes_year_id }.compact 
-      #rental_item_idだけ指定
-    elsif fes_year_id == 0 && power != 0
-      @power_orders = PowerOrder.preload(:group).where("(power >= ?)", power)
-      #両方とも指定
-    else
-      @power_orders = PowerOrder.preload(:group).where("(power >= ?)", power).map{ |power_order| power_order if power_order.group.fes_year_id == fes_year_id }.compact
-    end
 
-    if group_category_id == 0
-      @power_orders = PowerOrder.all
-    else
-      @power_orders = PowerOrder.preload(:group).map{ |power_order| power_order if power_order.group.group_category_id == group_category_id }.compact 
+    # fes_year_id, power, category_idで絞り込み
+    @power_orders = PowerOrder.all
+    if fes_year_id != 0
+      @power_orders = @power_orders.preload(:group).map{ |power_order| power_order if power_order.group.fes_year_id == fes_year_id }.compact
+    end
+    if power != 0
+      @power_orders = @power_orders.preload(:group).where("power >= ?", power)
+    end
+    if group_category_id != 0
+      @power_orders = @power_orders.preload(:group).map{ |power_order| power_order if power_order.group.group_category_id == group_category_id }.compact
     end
 
     if @power_orders.count == 0
       render json: fmt(not_found, [], "Not found power_orders")
-    else 
+    else
       render json: fmt(ok, fit_power_order_index_for_admin_view(@power_orders))
     end
   end


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1391 

# 概要
<!-- 開発内容の概要を記載 -->

- 管理画面で電力申請の絞り込みができていなかったので修正
  - APIを確認すると、絞り込み自体はできていた
  - category_idの絞り込みで、category_id=0の場合に、PowerOrder.allにしてしまっていた

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 管理者画面の電力申請で絞り込めるか

# 備考
