### PR TITLE
管理者画面の会場アナウンス文申請の表示の修正 

### DIFF
--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main-content">
     <SubHeader
-      v-bind:pageTitle="groups.find((group) => group.id === announcement.group_id).name"
+      v-bind:pageTitle="announcement.group.name"
       pageSubTitle="会場アナウンス文申請一覧"
     >
       <CommonButton
@@ -26,31 +26,31 @@
           <VerticalTable>
             <tr>
               <th>ID</th>
-              <td>{{ announcement.id }}</td>
+              <td>{{ announcement.group.id }}</td>
             </tr>
             <tr>
               <th>参加団体</th>
-              <td>{{ groups.find((group) => group.id === announcement.group_id).name }}</td>
+              <td>{{ announcement.group.name }}</td>
             </tr>
             <tr>
               <th>会場アナウンス文</th>
               <td>
-                <div v-if='announcement.message === ""'>未登録</div>
-                <div v-else>{{ announcement.message }}</div>
+                <div v-if='announcement.announcement.message === ""'>未登録</div>
+                <div v-else>{{ announcement.announcement.message }}</div>
               </td>
             </tr>
             <tr>
               <th>登録日時</th>
               <td>
-                <div v-if='announcement.message === ""'>未登録</div>
-                <div v-else>{{ announcement.created_at | formatDate }}</div>
+                <div v-if='announcement.announcement.message === ""'>未登録</div>
+                <div v-else>{{ announcement.announcement.created_at | formatDate }}</div>
               </td>
             </tr>
             <tr>
               <th>編集日時</th>
               <td>
-                <div v-if='announcement.message === ""'>未登録</div>
-                <div v-else>{{ announcement.updated_at | formatDate }}</div>
+                <div v-if='announcement.announcement.message === ""'>未登録</div>
+                <div v-else>{{ announcement.announcement.updated_at | formatDate }}</div>
               </td>
             </tr>
           </VerticalTable>
@@ -85,7 +85,7 @@
     <DeleteModal
       @close="closeDeleteModal"
       v-if="isOpenDeleteModal"
-      title="会場の削除"
+      title="会場アナウンス文の削除"
     >
       <template v-slot:method>
         <YesButton iconName="delete" :on_click="destroy">はい</YesButton>
@@ -111,10 +111,10 @@ export default {
       isOpenEditModal: false,
       isOpenDeleteModal: false,
       isOpenSnackBar: false,
-      message: "",
-      snackMessage: "",
-      group_id: 1,
-      routeId: "",
+      message: null,
+      snackMessage: null,
+      group_id: null,
+      routeId: null,
     };
   },
   computed: {
@@ -123,21 +123,18 @@ export default {
     }),
   },
   async asyncData({ $axios, route }) {
-    const routeId = route.params.id;
-    const announcementUrl = "/announcements/" + routeId;
-    const groupsUrl = "/groups";
-    const announcementRes = await $axios.$get(announcementUrl);
-    const groupsRes = await $axios.$get(groupsUrl);
+    const routeId = route.path.replace("/announcement/", "");
+    const url = "/api/v1/get_announcement_show_for_admin_view/" + routeId;
+    const res = await $axios.$get(url);
     return {
-      announcement: announcementRes.data,
-      routeId: routeId,
-      groups: groupsRes,
+      announcement: res.data,
+      route: url,
     };
   },
   methods: {
     openEditModal() {
-      this.group_id = this.announcement.group_id;
-      this.message = this.announcement.message;
+      this.group_id = this.announcement.announcement.group_id;
+      this.message = this.announcement.announcement.message;
       this.isOpenEditModal = false;
       this.isOpenEditModal = true;
     },
@@ -160,23 +157,30 @@ export default {
       this.isOpenSnackBar = false;
     },
     async reload(id) {
-      const url = "/announcements/" + id;
+      const url = "/api/v1/get_announcement_show_for_admin_view/" + id;
       const res = await this.$axios.$get(url);
       this.announcement = res.data;
     },
     async edit() {
-      const url = "/announcements/" + this.routeId + "?message=" + this.message + "&group_id=" + this.group_id;
+      const url = 
+      "/announcements/" + 
+      this.announcement.announcement.id + 
+      "?group_id=" + 
+      this.group_id+
+      "&message=" + 
+      this.message;
+      
 
       await this.$axios.$put(url).then((res) => {
         this.openSnackBar("会場アナウンス文を編集しました");
         this.message = "";
-        this.group_id = 1;
+        this.group_id = "";
         this.reload(res.data.id);
         this.closeEditModal();
       });
     },
     async destroy() {
-      const delUrl = "/announcements/" + this.routeId;
+      const delUrl = "/announcements/" + this.announcement.announcement.id;
       await this.$axios.$delete(delUrl);
       this.$router.push("/announcement");
     },

--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -135,7 +135,6 @@ export default {
     openEditModal() {
       this.group_id = this.announcement.announcement.group_id;
       this.message = this.announcement.announcement.message;
-      this.isOpenEditModal = false;
       this.isOpenEditModal = true;
     },
     closeEditModal() {

--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -29,20 +29,29 @@
               <td>{{ announcement.id }}</td>
             </tr>
             <tr>
-              <th>団体名</th>
+              <th>参加団体</th>
               <td>{{ groups.find((group) => group.id === announcement.group_id).name }}</td>
             </tr>
             <tr>
               <th>会場アナウンス文</th>
-              <td>{{ announcement.message }}</td>
+              <td>
+                <div v-if='announcement.message === ""'>未登録</div>
+                <div v-else>{{ announcement.message }}</div>
+              </td>
             </tr>
             <tr>
               <th>登録日時</th>
-              <td>{{ announcement.created_at | formatDate }}</td>
+              <td>
+                <div v-if='announcement.message === ""'>未登録</div>
+                <div v-else>{{ announcement.created_at | formatDate }}</div>
+              </td>
             </tr>
             <tr>
               <th>編集日時</th>
-              <td>{{ announcement.updated_at | formatDate }}</td>
+              <td>
+                <div v-if='announcement.message === ""'>未登録</div>
+                <div v-else>{{ announcement.updated_at | formatDate }}</div>
+              </td>
             </tr>
           </VerticalTable>
         </Row>
@@ -64,7 +73,7 @@
           </select>
         </div>
         <div>
-          <h3>会場名</h3>
+          <h3>会場アナウンス文</h3>
           <input v-model="message" placeholder="入力してください" />
         </div>
       </template>

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -14,7 +14,7 @@
       <template v-slot:refinement>
         <SearchDropDown
           :nameList="yearList"
-          :on_click="refinementPurchaseLists"
+          :on_click="refinementAnnouncements"
           value="year_num"
         >
           {{ refYears }}
@@ -47,14 +47,14 @@
             @click="
               () =>
                 $router.push({
-                  path: `/announcement/` + announcement.id,
+                  path: `/announcement/` + announcement.announcement.id,
                 })
             "
           >
-            <td>{{ announcement.id }}</td>
-            <td>{{groups.name}}</td>
+            <td>{{ announcement.group.id }}</td>
+            <td>{{ announcement.group.name}}</td>
             <td>
-              <div v-if='announcement.message === ""'>未登録</div>
+              <div v-if='announcement.announcement.message === ""'>未登録</div>
               <div v-else>登録済み</div>
             </td>
           </tr>
@@ -185,15 +185,13 @@ export default {
       });
     },
     async refinementAnnouncements(item_id, name_list) {
-      // fes_yearで絞り込むとき
-      if (name_list.toString() == this.yearList.toString()) {
-        this.refYearID = item_id;
-        // ALLの時
-        if (item_id == 0) {
-          this.refYears = "ALL";
-        } else {
-          this.refYears = name_list[item_id - 1].year_num;
-        }
+     // fes_yearで絞り込むとき
+      this.refYearID = item_id;
+      // ALLの時
+      if (item_id == 0) {
+        this.refYears = "ALL";
+      } else {
+        this.refYears = name_list[item_id - 1].year_num;
       }
       this.announcements = [];
       const refUrl =

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -14,7 +14,7 @@
       <template v-slot:refinement>
         <SearchDropDown
           :nameList="yearList"
-          :on_click="refinementAnnouncements"
+          :on_click="refinementPurchaseLists"
           value="year_num"
         >
           {{ refYears }}
@@ -24,7 +24,7 @@
         <SearchBar>
           <input
             v-model="searchText"
-            @keypress.enter="searchAnnouncements"
+            @keypress.enter="searchPurchaseLists"
             type="text"
             size="25"
             placeholder="search"
@@ -52,7 +52,7 @@
             "
           >
             <td>{{ announcement.id }}</td>
-            <td>{{groups.find((group) => group.id === announcement.group_id).name}}</td>
+            <td>{{groups.name}}</td>
             <td>
               <div v-if='announcement.message === ""'>未登録</div>
               <div v-else>登録済み</div>
@@ -198,7 +198,7 @@ export default {
       this.announcements = [];
       const refUrl =
         "/api/v1/get_refinement_announcements?fes_year_id=" +
-        this.refYearID
+        this.refYearID;
       const refRes = await this.$axios.$post(refUrl);
       for (const res of refRes.data) {
         this.announcements.push(res);

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -24,7 +24,7 @@
         <SearchBar>
           <input
             v-model="searchText"
-            @keypress.enter="searchPurchaseLists"
+            @keypress.enter="searchAnnouncements"
             type="text"
             size="25"
             placeholder="search"

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -121,7 +121,7 @@ export default {
     const url =
       "/api/v1/get_refinement_announcements?fes_year_id=" +
       currentYearRes.data.fes_year_id;
-    const announcementsRes = await $axios.$get(url);
+    const announcementsRes = await $axios.$post(url);
     const yearsUrl = "/fes_years";
     const yearsRes = await $axios.$get(yearsUrl);
     const currentYears = yearsRes.data.filter(function (element) {

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -162,7 +162,7 @@ export default {
     reload(id) {
       const reUrl = "/api/v1/get_announcement_show_for_admin_view/" + id;
       this.$axios.get(reUrl).then((res) => {
-        this.announcements.push(res.data);
+        this.announcements.push(res.data.data);
       });
     },
     async submit() {

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -108,7 +108,7 @@ export default {
       dialog: false,
       message: "",
       snackMessage: "",
-      group_id: 1,
+      group_id: "",
       refYears: "Years",
       refYearID: 0,
       searchText: ""
@@ -143,8 +143,8 @@ export default {
   methods: {
 
     async openAddModal() {
-      const groupsUrl = "/api/v1/get_groups_refinemented_by_current_fes_year";
-      const groupRes = await this.$axios.$get(groupsUrl);
+      const groupUrl = "/api/v1/get_groups_refinemented_by_current_fes_year";
+      const groupRes = await this.$axios.$get(groupUrl);
       this.groups = groupRes.data;
       this.isOpenAddModal = true;
     },
@@ -160,24 +160,24 @@ export default {
       this.isOpenSnackBar = false;
     },
     reload(id) {
-      const url = "/api/v1/get_announcement_show_for_admin_view/" + id;
-      this.$axios.$get(url).then((response) => {
-        this.announcements.push(response.data);
+      const reUrl = "/api/v1/get_announcement_show_for_admin_view/" + id;
+      this.$axios.get(reUrl).then((res) => {
+        this.announcements.push(res.data);
       });
     },
     async submit() {
-      const url =
+      const postAnnouncementUrl =
         "/announcements/" +
         "?group_id=" +
         this.group_id +
         "&message=" +
         this.message;
 
-      this.$axios.$post(url).then((response) => {
+      this.$axios.$post(postAnnouncementUrl).then((res) => {
         this.openSnackBar("会場アナウンス文を登録しました");
         this.group_id = "";
         this.message = "";
-        this.reload(response.data.id);
+        this.reload(res.data.id);
         this.closeAddModal();
       });
     },

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -102,7 +102,7 @@ export default {
       headers: ["ID", "参加団体", "申請状況"],
       isOpenAddModal: false,
       isOpenSnackBar: false,
-      groupId: "",
+      group_id: "",
       announcements: [],
       groups: [],
       dialog: false,
@@ -128,14 +128,8 @@ export default {
       return element.id == currentYearRes.data.fes_year_id;
      });
 
-    // const announcementsUrl = "/announcements";
-    const groupsUrl = "/groups";
-    // const announcementsRes = await $axios.$get(announcementsUrl);
-    const groupsRes = await $axios.$get(groupsUrl);
-
     return {
       announcements: announcementsRes.data,
-      groups: groupsRes,
       yearList: yearsRes.data,
       refYearID: currentYearRes.data.fes_year_id,
       refYears: currentYears[0].year_num,
@@ -147,8 +141,11 @@ export default {
     }),
   },
   methods: {
-    openAddModal() {
-      this.isOpenAddModal = false;
+
+    async openAddModal() {
+      const groupsUrl = "/api/v1/get_groups_refinemented_by_current_fes_year";
+      const groupRes = await this.$axios.$get(groupsUrl);
+      this.groups = groupRes.data;
       this.isOpenAddModal = true;
     },
     closeAddModal() {
@@ -163,7 +160,7 @@ export default {
       this.isOpenSnackBar = false;
     },
     reload(id) {
-      const url = "/announcements/" + id;
+      const url = "/api/v1/get_announcement_show_for_admin_view/" + id;
       this.$axios.$get(url).then((response) => {
         this.announcements.push(response.data);
       });
@@ -178,7 +175,7 @@ export default {
 
       this.$axios.$post(url).then((response) => {
         this.openSnackBar("会場アナウンス文を登録しました");
-        this.group_id = 1;
+        this.group_id = "";
         this.message = "";
         this.reload(response.data.id);
         this.closeAddModal();

--- a/admin_view/nuxt-project/pages/employees/_id.vue
+++ b/admin_view/nuxt-project/pages/employees/_id.vue
@@ -110,7 +110,7 @@ export default {
       isOpenEditModal: false,
       isOpenDeleteModal: false,
       isOpenSnackBar: false,
-      grouoId: null,
+      groupId: null,
       name: null,
       studentId: null,
       employee: null,

--- a/admin_view/nuxt-project/pages/employees/_id.vue
+++ b/admin_view/nuxt-project/pages/employees/_id.vue
@@ -169,7 +169,7 @@ export default {
     },
     async edit() {
       const url =
-        "/employees/" +
+        "/employee/" +
         this.employee.employee.id +
         "?group_id=" +
         this.groupId +

--- a/admin_view/nuxt-project/pages/employees/_id.vue
+++ b/admin_view/nuxt-project/pages/employees/_id.vue
@@ -169,14 +169,14 @@ export default {
     },
     async edit() {
       const url =
-        "/employee/" +
+        "/employees/" +
         this.employee.employee.id +
         "?group_id=" +
         this.groupId +
         "&name=" +
         this.name +
         "&student_id=" +
-        this.studentId + 
+        this.studentId +
         "&stool_test_id=" +
         this.stoolTestID;
 

--- a/api/app/controllers/api/v1/announcement_api_controller.rb
+++ b/api/app/controllers/api/v1/announcement_api_controller.rb
@@ -1,0 +1,50 @@
+class Api::V1::announcementsApiController < ApplicationController
+
+    def get_announcement_index_for_admin_view
+      @announcements = Announcement.with_groups
+      render json: fmt(ok, @announcements)
+    end
+  
+    def get_announcement_show_for_admin_view
+      @announcement = Announcement.with_group(params[:id])
+      render json: fmt(ok, @announcement)
+    end
+  
+    def fit_announcement_index_for_admin_view(announcements)
+        announcements.map{
+        |announcement|
+        {
+          "announcement": announcement,
+           "group": announcement.group
+        }
+      }
+    end
+  
+    def get_refinement_announcements
+  
+        fes_year_id = params[:fes_year_id].to_i
+        # 指定なし
+        if fes_year_id == 0
+          @announcements = Announcement.all
+          #fes_year_id指定
+        else
+          @announcements = Announcement.preload(:group).map{ |announcements| announcement if announcement.group.fes_year_id == fes_year_id }.compact
+        end
+      if @announcements.count == 0
+        render json: fmt(not_found, [], "Not found announcements")
+      else
+        render json: fmt(ok, fit_announcement_index_for_admin_view(@announcements))
+      end
+    end
+  
+    #あいまい検索
+    def get_search_announcements
+      word = params[:word]
+      @announcements = Announcement.all.map{ |announcement| announcement if announcement.group.name.include?(word)  }.compact
+      if @announcements.count == 0
+        render json: fmt(not_found, [], "Not found announcements")
+      else
+        render json: fmt(ok, fit_announcements_index_for_admin_view(@announcements))
+      end
+    end
+  end

--- a/api/app/controllers/api/v1/announcements_api_controller.rb
+++ b/api/app/controllers/api/v1/announcements_api_controller.rb
@@ -1,15 +1,15 @@
-class Api::V1::announcementsApiController < ApplicationController
+class Api::V1::AnnouncementsApiController < ApplicationController
 
     def get_announcement_index_for_admin_view
       @announcements = Announcement.with_groups
       render json: fmt(ok, @announcements)
     end
-  
+
     def get_announcement_show_for_admin_view
       @announcement = Announcement.with_group(params[:id])
       render json: fmt(ok, @announcement)
     end
-  
+
     def fit_announcement_index_for_admin_view(announcements)
         announcements.map{
         |announcement|
@@ -19,16 +19,16 @@ class Api::V1::announcementsApiController < ApplicationController
         }
       }
     end
-  
+
     def get_refinement_announcements
-  
+
         fes_year_id = params[:fes_year_id].to_i
         # 指定なし
         if fes_year_id == 0
           @announcements = Announcement.all
           #fes_year_id指定
         else
-          @announcements = Announcement.preload(:group).map{ |announcements| announcement if announcement.group.fes_year_id == fes_year_id }.compact
+          @announcements = Announcement.preload(:group).map{ |announcements| announcements if announcements.group.fes_year_id == fes_year_id }.compact
         end
       if @announcements.count == 0
         render json: fmt(not_found, [], "Not found announcements")
@@ -36,7 +36,7 @@ class Api::V1::announcementsApiController < ApplicationController
         render json: fmt(ok, fit_announcement_index_for_admin_view(@announcements))
       end
     end
-  
+
     #あいまい検索
     def get_search_announcements
       word = params[:word]

--- a/api/app/controllers/api/v1/announcements_api_controller.rb
+++ b/api/app/controllers/api/v1/announcements_api_controller.rb
@@ -40,11 +40,11 @@ class Api::V1::AnnouncementsApiController < ApplicationController
     #あいまい検索
     def get_search_announcements
       word = params[:word]
-      @announcements = Announcement.all.map{ |announcement| announcement if announcement.group.name.include?(word)  }.compact
+      @announcements = Announcement.all.map{ |announcements| announcements if announcements.group.name.include?(word)  }.compact
       if @announcements.count == 0
         render json: fmt(not_found, [], "Not found announcements")
       else
-        render json: fmt(ok, fit_announcements_index_for_admin_view(@announcements))
+        render json: fmt(ok, fit_announcement_index_for_admin_view(@announcements))
       end
     end
   end

--- a/api/app/models/announcement.rb
+++ b/api/app/models/announcement.rb
@@ -7,9 +7,8 @@ def self.with_groups
     .map{
       |announcement|
       {
-        "anouncement": announcement,
+        "announcement": announcement,
         "group": announcement.group
-
       }
     }
 end
@@ -19,13 +18,13 @@ def self.with_group(announcement_id)
   {
     "announcement": announcement,
     "group": announcement.group
-
   }
 end
 
 def to_info_h
   return {
-    "id": self.id
+    "id": self.id,
+    "group_id": self.group_id,
   }
   end
 end

--- a/api/app/models/announcement.rb
+++ b/api/app/models/announcement.rb
@@ -1,6 +1,5 @@
 class Announcement < ApplicationRecord
   belongs_to :group
-  belongs_to :fes_date
 
 def self.with_groups
   @record = Announcement.preload(:group)

--- a/api/app/models/announcement.rb
+++ b/api/app/models/announcement.rb
@@ -1,3 +1,31 @@
 class Announcement < ApplicationRecord
   belongs_to :group
+  belongs_to :fes_date
+
+def self.with_groups
+  @record = Announcement.preload(:group)
+    .map{
+      |announcement|
+      {
+        "anouncement": announcement,
+        "group": announcement.group
+
+      }
+    }
+end
+
+def self.with_group(announcement_id)
+  announcement = Announcement.find(announcement_id)
+  {
+    "announcement": announcement,
+    "group": announcement.group
+
+  }
+end
+
+def to_info_h
+  return {
+    "id": self.id
+  }
+  end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -151,6 +151,12 @@ Rails.application.routes.draw do
       post "get_search_public_relations" => "public_relations_api#get_search_public_relations"
       get "get_groups_have_no_public_relation" => "groups_api#get_groups_have_no_public_relation"
 
+      #---会場アナウンス文申請
+      get "get_announcement_index_for_admin_view" => "announcements_api#get_announcement_index_for_admin_view"
+      get "get_announcement_show_for_admin_view/:id" => "announcements_api#get_announcement_show_for_admin_view"
+      post "get_refinement_announcements" => "announcements_api#get_refinement_announcements"
+      post "get_search_announcements" => "announcements_api#get_search_announcements"
+
       #---申請情報ページ
       get "get_order_info_for_admin_view/:id" => "order_infos_api#get_order_info_for_admin_view"
       post "get_refinement_order_infos" => "order_infos_api#get_refinement_order_infos"

--- a/api/db/fixtures/develop/user_page_setting.rb
+++ b/api/db/fixtures/develop/user_page_setting.rb
@@ -10,11 +10,13 @@ UserPageSetting.seed( :id,
                 is_edit_employee: true,
                 is_edit_food_product: true,
                 is_edit_purchase_list: true,
+                is_edit_announcement: true,
                 add_power_order: true, 
                 add_rental_order: true, 
                 add_employee: true, 
                 add_food_product: true, 
                 add_purchase_list: true, 
+                add_announcement: true, 
                 fes_year_id: 2,
 
             }

--- a/api/db/fixtures/production/user_page_setting.rb
+++ b/api/db/fixtures/production/user_page_setting.rb
@@ -10,11 +10,13 @@ UserPageSetting.seed( :id,
                 is_edit_employee: true,
                 is_edit_food_product: true,
                 is_edit_purchase_list: true,
+                is_edit_announcement: true,
                 add_power_order: true, 
                 add_rental_order: true, 
                 add_employee: true, 
                 add_food_product: true, 
                 add_purchase_list: true, 
+                add_announcement: true,
                 fes_year_id: 1,
             }
 )

--- a/api/db/migrate/20210221070515_create_user_page_settings.rb
+++ b/api/db/migrate/20210221070515_create_user_page_settings.rb
@@ -12,6 +12,7 @@ class CreateUserPageSettings < ActiveRecord::Migration[6.0]
       t.boolean :is_edit_employee
       t.boolean :is_edit_food_product
       t.boolean :is_edit_purchase_list
+      t.boolean :is_edit_announcement
 
       t.timestamps
     end

--- a/api/db/migrate/20210323115616_add_columns_to_user_page_settings.rb
+++ b/api/db/migrate/20210323115616_add_columns_to_user_page_settings.rb
@@ -5,5 +5,6 @@ class AddColumnsToUserPageSettings < ActiveRecord::Migration[6.0]
     add_column :user_page_settings, :add_employee, :boolean
     add_column :user_page_settings, :add_food_product, :boolean
     add_column :user_page_settings, :add_purchase_list, :boolean
+    add_column :user_page_settings, :add_announcement, :boolean
   end
 end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -340,6 +340,7 @@ ActiveRecord::Schema.define(version: 2023_05_25_071401) do
     t.boolean "is_edit_employee"
     t.boolean "is_edit_food_product"
     t.boolean "is_edit_purchase_list"
+    t.boolean "is_edit_announcement"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "add_power_order"
@@ -347,6 +348,7 @@ ActiveRecord::Schema.define(version: 2023_05_25_071401) do
     t.boolean "add_employee"
     t.boolean "add_food_product"
     t.boolean "add_purchase_list"
+    t.boolean "add_announcement"
     t.integer "fes_year_id"
   end
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1405 

# 概要
<!-- 開発内容の概要を記載 -->
-①：表示される内容がid、参加団体、会場アナウンス文申請ではなくid、参加団体、申請状況に変更する
こっちは達成、admin_view/nuxt-project/pages/announcement/_id.vueとadmin_view/nuxt-project/pages/announcement/index.vueの、登録、未登録の条件文と文言を変えた

-②：年と団体カテゴリーの絞り込み、検索機能の追加
こっちがわかりません、admin_view/nuxt-project/pages/announcement/index.vueとapi/app/models/announcement.rbを他の物を見て書き変えてから、api/app/controllers/api/v1/announcement_api_controller.rbを作成してこれも他の物を見て書き変えればできると助言をもらって変えてみましたが、apiを見るのが初めてなのでどこで何をしているのか、この変数は何なのかがわからず、なんで動かないのかもわかりませんでした。
申し訳ないですが、訂正したものを教えてもらえると助かります。

-③：①②を解決したことによる会場アナウンス文申請ページでの編集機能、追加機能、削除機能が使えなくなったことの改善

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
①で変更したファイル
-admin_view/nuxt-project/pages/announcement/_id.vue
-admin_view/nuxt-project/pages/announcement/index.vue

②で変更したファイル
-admin_view/nuxt-project/pages/announcement/index.vue
-api/app/models/announcement.rb
-api/app/controllers/api/v1/announcement_api_controller.rb

③で変更したファイル
-admin_view/nuxt-project/pages/announcement/_id.vue
-admin_view/nuxt-project/pages/announcement/index.vue
-api/app/controllers/api/v1/announcements_api_controller.rb
-api/app/models/announcement.rb
-api/config/routes.rb
-api/db/fixtures/develop/user_page_setting.rb
-api/db/fixtures/production/user_page_setting.rb
-api/db/schema.rb

変えてしまったが、おそらく関係ない
-api/db/migrate/20210221070515_create_user_page_settings.rb
-api/db/migrate/20210323115616_add_columns_to_user_page_settings.rb

ちらっと見るとスペルミスらしきものがあった
-admin_view/nuxt-project/pages/employees/_id.vue


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
-http://localhost:8000/announcement

>検索バーと年絞り込み機能を追加したannouncementページ

![image](https://github.com/NUTFes/group-manager-2/assets/131850959/3c573098-8776-4dfe-bd03-d900298432e7)

>年絞り込み機能が動作しているページ

![image](https://github.com/NUTFes/group-manager-2/assets/131850959/d952b94b-87af-4dea-a069-8ab188a1ad7a)

>参加団体名による検索機能が動作しているページ

![image](https://github.com/NUTFes/group-manager-2/assets/131850959/264f1fac-64d0-4f51-80a0-8bcd4e874f5d)

-http://localhost:8000/announcement/1

>編集機能がうまく動作したページ

![image](https://github.com/NUTFes/group-manager-2/assets/131850959/c920965a-f76b-4087-9b6b-380e2ae1f18a)

>削除機能がうまく動作したページ

![image](https://github.com/NUTFes/group-manager-2/assets/131850959/5855322d-9eee-465e-a5e5-b5bc607fdbb6)


# テスト項目
<!-- テストしてほしい内容を記載 -->
-年による絞り込み機能が使える
-検索バーに団体名の一部を入力すると、それのみを表示できる
-追加機能を使ってアナウンス文申請ができる
-アナウンス文申請ページの要素をクリックして情報を見るページにおいて、編集機能を使ってアナウンス文を変更できる
-アナウンス文申請ページの要素をクリックして情報を見るページにおいて、削除機能を使い、要素を消去することができる

# 備考
