### PR TITLE
ダッシュボードで参加団体数を表示

### DIFF
--- a/admin_view/nuxt-project/components/GroupsCard.vue
+++ b/admin_view/nuxt-project/components/GroupsCard.vue
@@ -1,0 +1,54 @@
+<template>
+    <Card width="" height="" padding="0" flexGrow="0" border="0px">
+      <div class="groups-card-content">
+        <h1>{{ dashboardData.groups_length }}</h1>
+        <Row>
+        <Tag primaryColor="#ff6384" secondaryColor="rgba(255, 99, 132, 0.2)"
+          >{{ dashboardData.cate_1_length }}  食品販売</Tag
+        >
+        <Tag primaryColor="#36a2eb" secondaryColor="rgba(54, 162, 235, 0.2)"
+          >{{ dashboardData.cate_2_length}}  物販販売</Tag
+        >
+        <Tag primaryColor="#ffce56" secondaryColor="rgba(255, 206, 86, 0.2)"
+          >{{ dashboardData.cate_3_length }}  ステージ企画</Tag
+        >
+        <Tag primaryColor="#4bc0c0" secondaryColor="rgba(75, 192, 192, 0.2)"
+          >{{ dashboardData.cate_4_length}}  展示・体験</Tag
+        >
+        <Tag primaryColor="#9966ff" secondaryColor="rgba(153, 102, 255, 0.2)"
+          >{{ dashboardData.cate_5_length }}  研究室公開</Tag
+          >
+        <Tag primaryColor="#ff9f40" secondaryColor="rgba(255, 159, 64, 0.2)"
+          >{{ dashboardData.cate_6_length }}  その他</Tag
+        >
+      </Row>
+      </div>
+      <hr />
+    </Card>
+  </template>
+  <script>
+  import axios from "axios";
+  export default {
+    watchQuery: ["page"],
+    props: {
+      dashboardData: {
+        type: Object,
+        required: false,
+      },
+    },
+  };
+  </script>
+  <style>
+  .groups-card-content {
+    font-size: 60px;
+    width: 400px;
+    height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    flex-flow: column;
+    gap: 20px;
+  }
+  </style>
+  

--- a/admin_view/nuxt-project/pages/Chart_Group.vue
+++ b/admin_view/nuxt-project/pages/Chart_Group.vue
@@ -45,7 +45,7 @@ export default {
               },
               ticks: {
                 min: 0,
-                max: 30,
+                max: 60,
                 fontSize: 12,
                 stepSize: 5,
               },
@@ -53,8 +53,16 @@ export default {
           ],
         },
 				tooltips: {
-					enabled: false,
-				}
+					enabled: true,
+          callbacks:{
+            label: function(tooltipItems) {
+              if(tooltipItems.xLabel == "0"){
+                return "";
+              }
+              return  tooltipItems.xLabel ;
+            },
+          },
+				},
       },
     };
   },

--- a/admin_view/nuxt-project/pages/dashboard.vue
+++ b/admin_view/nuxt-project/pages/dashboard.vue
@@ -2,12 +2,19 @@
   <div class="main-content">
     <SubHeader pageTitle="ダッシュボード" />
     <Row>
-      <Card>
+      <Card width="300px" gap="10px">
         <Row justify="start">
-          <h4>参加団体</h4>
+          <h4>参加団体数</h4>
         </Row>
         <hr />
-        <Chart1 :styles="myStyles" />
+        <Row>
+          <Card width="" height="" padding="0" flexGrow="0" border="0px">
+           <GroupsCard v-bind:dashboardData="dashboard_data" :styles="myStyles"/>
+          </Card>
+          <Card width="" height="" padding="0" flexGrow="0" border="0px">
+            <Chart1 :styles="myStyles" />
+          </Card>
+        </Row>
       </Card>
       <UsersCard v-bind:dashboardData="dashboard_data" />
     </Row>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1415 

# 概要
<!-- 開発内容の概要を記載 -->
GM2の管理者画面のダッシュボードに参加団体総数（その内訳）を付け加えた
GM2の管理者画面のダッシュボードの参加団体数のグラフで、グラフにカーソルをホバーさせると、それぞれの団体数がわかるようにした

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-admin_view/nuxt-project/components/GroupsCard.vue
-admin_view/nuxt-project/pages/Chart_Group.vue
-admin_view/nuxt-project/pages/dashboard.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
http://localhost:8000/dashboard
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/72272a62-537e-4d66-9946-7361a2188948)

# テスト項目
<!-- テストしてほしい内容を記載 -->
-ダッシュボードがスクリーンショット通りのデザインで表示されている
-本番環境に行った際に、データがきちんと反映されている
-

# 備考
