### PR TITLE
[fix]団体登録の連打で複数登録できる問題の修正

### DIFF
--- a/user_front/pages/regist/group/index.vue
+++ b/user_front/pages/regist/group/index.vue
@@ -47,6 +47,9 @@ onMounted(async () => {
 })
 
 const registerCategory = async () => {
+
+  isSubmitting.value = true;
+  
   await $fetch<Group>(config.APIURL + "/groups", {
     method: "POST",
     params: {
@@ -105,7 +108,7 @@ const registerCategory = async () => {
         </Card>
         <Row>
           <RegistPageButton :text="$t('Button.reset')" @click="reset" variant="danger"></RegistPageButton>
-          <RegistPageButton :disabled='!meta.valid || isSubmitting' :text="$t('Button.register')" @click.once="registerCategory"></RegistPageButton>
+          <RegistPageButton :disabled='!meta.valid || isSubmitting' :text="$t('Button.register')" @click="registerCategory"></RegistPageButton>
         </Row>
       </Card>
     </div>

--- a/user_front/pages/regist/group/index.vue
+++ b/user_front/pages/regist/group/index.vue
@@ -105,7 +105,7 @@ const registerCategory = async () => {
         </Card>
         <Row>
           <RegistPageButton :text="$t('Button.reset')" @click="reset" variant="danger"></RegistPageButton>
-          <RegistPageButton :disabled='!meta.valid || isSubmitting' :text="$t('Button.register')" @click="registerCategory"></RegistPageButton>
+          <RegistPageButton :disabled='!meta.valid || isSubmitting' :text="$t('Button.register')" @click.once="registerCategory"></RegistPageButton>
         </Row>
       </Card>
     </div>

--- a/user_front/pages/regist/user/index.vue
+++ b/user_front/pages/regist/user/index.vue
@@ -241,7 +241,7 @@ const createCurrentDepartmentList = (e: any) => {
           <RegistPageButton
             :disabled="!meta.valid || isSubmitting"
             :text="$t('Button.register')"
-            @click="registUser"
+            @click.once="registUser"
           >
           </RegistPageButton>
         </Row>

--- a/user_front/pages/regist/user/index.vue
+++ b/user_front/pages/regist/user/index.vue
@@ -69,6 +69,9 @@ const login = () => {
 };
 
 const registUser = async () => {
+
+  isSubmitting.value = true;
+  
   await $fetch<User>(config.APIURL + "/api/auth", {
     method: "POST",
     params: {
@@ -241,7 +244,7 @@ const createCurrentDepartmentList = (e: any) => {
           <RegistPageButton
             :disabled="!meta.valid || isSubmitting"
             :text="$t('Button.register')"
-            @click.once="registUser"
+            @click="registUser"
           >
           </RegistPageButton>
         </Row>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue1418
<!-- 対応したIssue番号を記載 -->
resolve #1418 

# 概要
<!-- 開発内容の概要を記載 -->
ユーザーが新規登録して，団体登録と代表者登録をときに，登録ボタンを連打しても一回しか反応しないように修正した．


# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- user_front/pages/regist/group/index.vue
- user_front/pages/regist/user/index.vue
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/group-manager-2/assets/95607264/f6c300ac-7f81-4306-8966-87c7b67d1198)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- ユーザーの新規登録をし，団体登録，代表者登録の登録ボタンを連打しても問題ないか
- admin画面で，団体が1つだけ登録されているか
-

# 備考
ボタン連打による複数回登録は，団体登録，代表者登録の2つを修正したが，ほかにも複数回登録ができる箇所があるかは不明．
