### PR TITLE
ダッシュボードの参加団体数のグラフ修正

### DIFF
--- a/admin_view/nuxt-project/pages/Chart_Group.vue
+++ b/admin_view/nuxt-project/pages/Chart_Group.vue
@@ -45,7 +45,6 @@ export default {
               },
               ticks: {
                 min: 0,
-                max: 60,
                 fontSize: 12,
                 stepSize: 5,
               },
@@ -66,6 +65,15 @@ export default {
       },
     };
   },
+  methods: {
+    // データの中で最大の値を返す関数
+    findMaxValue(data) {
+      return Math.max(...data);
+    },
+    roundUp5(num) {
+      return Math.ceil(num / 5) * 5;
+    },
+  },
   mounted() {
     this.$axios
       .get("api/v1/dashboard", {
@@ -81,6 +89,10 @@ export default {
         this.data.datasets[0].data[3] = response.data.cate_4_length;
         this.data.datasets[0].data[4] = response.data.cate_5_length;
         this.data.datasets[0].data[5] = response.data.cate_6_length;
+        // データの中で最大の値を取得
+        const maxDataValue = this.findMaxValue(this.data.datasets[0].data);
+        // x軸の最大値を設定
+        this.options.scales.xAxes[0].ticks.max = this.roundUp5(maxDataValue+1);;
         this.renderChart(this.data, this.options);
       });
     this.rate = Number(this.groups_length) + 1;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1435 

# 概要
<!-- 開発内容の概要を記載 -->
- ダッシュボードの参加団体数の横棒グラフの目盛りの最大値が、参加団体数のデータにかかわらず一定（60）だったのを、参加団体数に応じてグラフの横の目盛りが変化するように変更した
- データの目盛りは5の倍数にした
- 最大データとデータの目盛りが一緒にならないように、最大データが5の倍数の時はデータの目盛りは次の5の倍数になるようにした


# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-admin_view/nuxt-project/pages/Chart_Group.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8000/dashboard
- 最大データが9のとき
<img width="770" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/131850959/d473edb5-0006-415d-aae1-907bfc257696">

- http://localhost:8000/dashboard
- 最大データが10のとき
<img width="767" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/131850959/06bf3285-b646-4650-93a1-b2a629aff335">



# テスト項目
<!-- テストしてほしい内容を記載 -->
- 最大データがどんな値でもデータの目盛りが見やすいように自動で変化すること
- データの目盛りが5の倍数であること
- 最大データとデータの目盛りが一緒にならないこと

# 備考
