### PR TITLE
会場アナウンス文のcsv出力機能の実装

### DIFF
--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -8,6 +8,13 @@
       >
         追加
       </CommonButton>
+      <CommonButton
+        v-if="this.$role(roleID).announcements.create"
+        iconName="file_download"
+        :on_click="downloadCSV"
+      >
+        csv
+      </CommonButton>
     </SubHeader>
 
     <SubSubHeader>
@@ -206,6 +213,12 @@ export default {
       for (const res of refRes.data) {
         this.announcements.push(res);
       }
+    },
+    async downloadCSV() {
+      const url =
+        this.$config.apiURL +
+        "/api/v1/get_announcements_csv"
+      window.open(url, "購入品申請_CSV");
     },
   },
 };

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -434,4 +434,20 @@ class Api::V1::OutputCsvController < ApplicationController
     send_data(csv_data, filename:"代表者_#{filename_year}年度.csv")
   end
 
+  def output_announcements_csv
+    @announcements = Announcement.all
+    bom = "\uFEFF"
+    csv_data = CSV.generate(bom) do |csv|
+      column_name = %w(参加団体名 アナウンス文)
+      csv << column_name
+      @announcements.each do |announcement|
+        column_values = [
+          announcement.group.name,
+          announcement.message
+        ]
+        csv << column_values
+      end
+    end
+    send_data(csv_data, filename:"会場アナウンス文.csv")
+  end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -187,6 +187,7 @@ Rails.application.routes.draw do
       get "get_purchase_lists_csv/:fes_year_id" => "output_csv#output_purchase_lists_csv"
       get "get_users_csv/:fes_year_id" => "output_csv#output_users_csv"
       get "get_assign_rental_items_csv/:fes_year_id" => "output_csv#output_assign_rental_items_csv"
+      get "get_announcements_csv" => "output_csv#output_announcements_csv"
 
       # ダッシュボード
       get "dashboard" => "dashboard_api#get_dashboard_info"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1433 

# 概要
<!-- 開発内容の概要を記載 -->
会場アナウンス文のcsv出力機能の実装
- API側の実装
- 管理者画面側のボタンの実装

出力されるカラムは`団体名`と`会場アナウンス文`

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `http://localhost:8000/announcement`
スクリーンショット
- ボタンの実装
<img width="390" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/54b3e889-b276-4b8c-af41-c9fad0a79b66">
- 実際に出力されるcsv
<img width="384" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/50622120/0863fe10-0a99-44f9-9117-286964fd6938">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 会場アナウンス文が適切に出力されるか
-
-

# 備考
今回の実装は年ごとの実装はしていません。登録されている全部の会場アナウンス文を出力するようにしています。(今年度は問題ない)