### PR TITLE
書類印刷の物品貸し出し表まとめのPDFが出力できないバグの修正

### DIFF
--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -55,8 +55,8 @@
       <td><%= assign_rental_item.rental_item.name %></td>
       <td><%= assign_rental_item.stocker_place.name %></td>
       <td><%= assign_rental_item.num %></td>
-      <td><%= group.fes_year.fes_dates.where(days_num: 0).nil? ? nil : group.fes_year.fes_dates.where(days_num: 0).first.date %>(準備日)</td>
-      <td><%= group.fes_year.fes_dates.where(days_num: 3).nil? ? nil : group.fes_year.fes_dates.where(days_num: 3).first.date %>(片付け日)</td>
+      <td><%= group.fes_year.fes_dates.find_by(days_num: 0)&.date %>(準備日)</td>
+      <td><%= group.fes_year.fes_dates.find_by(days_num: 3)&.date %>(片付け日)</td>
       <td></td>
     </tr>
     <% end %>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1441 

# 概要
<!-- 開発内容の概要を記載 -->

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
物品申請をしていても、割り当てをしないと貸し出し物品が表示されない状態でPDF出力された
7割り当てをすると `ActionView::Template::Error (undefined method 'date' for nil:NilClass):` というエラーが出て、PDF出力がそもそもできなくなった
ので、以下の部分を修正して動くようになった
`group.fes_year.fes_dates.where(days_num: 0).nil? ? nil : group.fes_year.fes_dates.where(days_num: 0).first.date`
`group.fes_year.fes_dates.where(days_num: 3).nil? ? nil : group.fes_year.fes_dates.where(days_num: 3).first.date`
あとは本番環境でも動くか確認する