### PR TITLE
物品貸し出し表まとめのPDF出力内容の変更

### DIFF
--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -53,7 +53,7 @@
     <% group.assign_rental_items.each do |assign_rental_item| %>
     <tr>
       <td><%= assign_rental_item.rental_item.name %></td>
-      <td></td>
+      <td><%= assign_rental_item.stocker_place.name %></td>
       <td><%= assign_rental_item.num %></td>
       <td><%= group.fes_year.fes_dates.find_by(days_num: 0)&.date %>(準備日)</td>
       <td><%= group.fes_year.fes_dates.find_by(days_num: 3)&.date %>(片付け日)</td>

--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -21,7 +21,7 @@
       <tr>
         <th rowspan=2>活動時間</th>
         <td><%= group.fes_year.fes_dates.where(days_num: 1).first.nil? ? nil : group.fes_year.fes_dates.where(days_num: 1).first.date %>（1日目）</td>
-        <td>10:00～17:00</td>
+        <td>10:00～18:00</td>
       </tr>
       <tr>
         <td><%= group.fes_year.fes_dates.where(days_num: 2).first.nil? ? nil : group.fes_year.fes_dates.where(days_num: 2).first.date %>（2日目）</td>
@@ -53,7 +53,7 @@
     <% group.assign_rental_items.each do |assign_rental_item| %>
     <tr>
       <td><%= assign_rental_item.rental_item.name %></td>
-      <td><%= assign_rental_item.stocker_place.name %></td>
+      <td></td>
       <td><%= assign_rental_item.num %></td>
       <td><%= group.fes_year.fes_dates.find_by(days_num: 0)&.date %>(準備日)</td>
       <td><%= group.fes_year.fes_dates.find_by(days_num: 3)&.date %>(片付け日)</td>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue1443
<!-- 対応したIssue番号を記載 -->
resolve #1443 

# 概要
<!-- 開発内容の概要を記載 -->
物品貸し出し表まとめのPDFの活動時間の一日目を18時までにする
借りる場所を空欄にする -> 取り消し

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
- output_all_groups_rental_items.pdf.erbの内容を変更する
-
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `file:///C:/Users/takum/Downloads/%E7%89%A9%E5%93%81%E8%B2%B8%E3%81%97%E5%87%BA%E3%81%97%E6%9B%B8%E9%A1%9E_%E7%89%A9%E5%93%81%E6%8C%81%E3%81%A1%E5%87%BA%E3%81%97%E8%A1%A8(%E5%90%84%E5%9B%A3%E4%BD%93%E5%90%91%E3%81%91)%20(1).pdf`
スクリーンショット
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/d377b6d2-206c-496c-b0c2-729f63e56020)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- GM2の管理者ページの基本操作 -> 書類印刷 -> 物品貸し出し表まとめのpdf出力をする
- ダウンロードされたpdfのページにおいて、以下の変更が行われていること
- 参加団体情報の活動時間9月18日(1日目)の時間が10:00～18:00になっていること
- 貸出物品一覧の借りる場所の欄が空白になっていること -> 取り消し


# 備考
