### PR TITLE
ステージ申請絞り込みの初期読み込み時にデータが表示されない問題を解消

### DIFF
--- a/admin_view/nuxt-project/pages/stage_orders/index.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/index.vue
@@ -88,7 +88,7 @@
               <div v-if="venueMaps[index].venue_map === null">未登録</div>
               <div v-else>登録済み</div>
             </td>
-            <td v-else>会場配置図が存在しません</td>
+            <td v-else>会場配置図を読み込めません</td>
           </tr>
         </template>
       </Table>

--- a/admin_view/nuxt-project/pages/stage_orders/index.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/index.vue
@@ -84,10 +84,11 @@
             <td>{{ stageOrder.stage_order_info.date }}</td>
             <td>{{ stageOrder.stage_order_info.stage_first }}</td>
             <td>{{ stageOrder.stage_order_info.stage_second }}</td>
-            <td v-if="venueMaps != null">
+            <td v-if="venueMaps[index]">
               <div v-if="venueMaps[index].venue_map === null">未登録</div>
               <div v-else>登録済み</div>
             </td>
+            <td v-else>会場配置図が存在しません</td>
           </tr>
         </template>
       </Table>
@@ -359,6 +360,7 @@ export default {
       refYearID: currentYearRes.data.fes_year_id,
       refYears: currentYears[0].year_num,
       stageList: stagesRes.data,
+      venueMaps: venueMaps,
     };
   },
   mounted() {

--- a/api/app/controllers/api/v1/stage_orders_api_controller.rb
+++ b/api/app/controllers/api/v1/stage_orders_api_controller.rb
@@ -21,71 +21,44 @@ class Api::V1::StageOrdersApiController < ApplicationController
     }
   end
 
-  #絞り込み機能 
+  #絞り込み機能
   def get_refinement_stage_orders
-    fes_year_id = params[:fes_year_id].to_i 
-    days_num = params[:days_num].to_i 
-    stage_id = params[:stage_id].to_i 
+    fes_year_id = params[:fes_year_id].to_i
+    days_num = params[:days_num].to_i
+    stage_id = params[:stage_id].to_i
     is_sunny = params[:is_sunny].to_i
     # 晴れ希望 0: 指定なし(ALL) 1: はい 2: いいえ
     is_sunny_list = [nil, true, false]
 
-    # 絞り込みなし
-    if fes_year_id == 0 && days_num == 0 && stage_id == 0 && is_sunny == 0
-      @stage_orders = StageOrder.all
-    # fes_year_idで絞り込み
-    elsif fes_year_id != 0 && days_num == 0 && stage_id == 0 && is_sunny == 0
-      @stage_orders = StageOrder.preload(:group).map{ |stage_order| stage_order if stage_order.group.fes_year_id == fes_year_id }.compact
-    # days_numで絞り込み
-    elsif fes_year_id == 0 && days_num != 0 && stage_id == 0 && is_sunny == 0
-      @stage_orders = StageOrder.preload(:group).map{ |stage_order| stage_order if stage_order.fes_date.days_num == days_num }.compact
-    # stage_idで絞り込み
-    elsif fes_year_id == 0 && days_num == 0 && stage_id != 0 && is_sunny == 0
-      @stage_orders = StageOrder.where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id)
-    # is_sunnyで絞り込み
-    elsif fes_year_id == 0 && days_num == 0 && stage_id == 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny])
-    # fes_year_idとdays_numで絞り込み
-    elsif fes_year_id != 0 && days_num != 0 && stage_id == 0 && is_sunny == 0
-      @stage_orders = StageOrder.preload(:group, :fes_date).map{ |stage_order| stage_order if stage_order.group.fes_year_id == fes_year_id && stage_order.fes_date.days_num == days_num }.compact
-    # fes_year_idとstage_idで絞り込み
-    elsif fes_year_id != 0 && days_num == 0 && stage_id != 0 && is_sunny == 0
-      @stage_orders = StageOrder.where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id).preload(:group).map{ |stage_order| stage_order if stage_order.group.fes_year_id == fes_year_id }.compact
-    # fes_year_idとis_sunnyで絞り込み
-    elsif fes_year_id != 0 && days_num == 0 && stage_id == 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).preload(:group).map{ |stage_order| stage_order if stage_order.group.fes_year_id = fes_year_id }.compact
-    # days_numとstage_idで絞り込み
-    elsif fes_year_id == 0 && days_num != 0 && stage_id != 0 && is_sunny == 0
-      @stage_orders = StageOrder.where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id).preload(:group).map{ |stage_order| stage_order if stage_order.fes_date.days_num == days_num }.compact
-    # days_numとis_sunnyで絞り込み
-    elsif fes_year_id == 0 && days_num != 0 && stage_id == 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).preload(:group).map{ |stage_order| stage_order if stage_order.fes_date.days_num }.compact
-    # stage_idとis_sunnyで絞り込み
-    elsif fes_year_id == 0 && days_num == 0 && stage_id != 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id)
+    @stage_orders = StageOrder.all
 
-    # fes_year_idとdays_numとstage_idで絞り込み
-    elsif fes_year_id != 0 && days_num != 0 && stage_id != 0 && is_sunny == 0
-      @stage_orders = StageOrder.where(stage_first: stage_id).where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id).preload(:group).map{ |stage_order| stage_order if stage_order.fes_date.days_num == days_num }.compact
-    # fes_year_idとdays_numとis_sunnyで絞り込み
-    elsif fes_year_id != 0 && days_num != 0 && stage_id == 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).preload(:group).map{ |stage_order| stage_order if stage_order.fes_date.days_num == days_num }.compact
-    # days_numとstage_idとis_sunnyで絞り込み
-    elsif fes_year_id == 0 && days_num != 0 && stage_id != 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id).preload(:group).map{ |stage_order| stage_order if stage_order.fes_date.days_num == days_num }.compact
-    # fes_year_idとstage_idとis_sunnyで絞り込み
-    elsif fes_year_id != 0 && days_num == 0 && stage_id != 0 && is_sunny != 0
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id).preload(:group).map{ |stage_order| stage_order if stage_order.group.fes_year_id == fes_year_id }.compact
-    else
-      @stage_orders = StageOrder.where(is_sunny: is_sunny_list[is_sunny]).where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id).preload(:group).map{ |stage_order| stage_order if stage_order.group.fes_year_id == fes_year_id && stage_order.fes_date.days_num == days_num }.compact
+    # fes_year_idで絞り込み
+    if fes_year_id != 0
+      @stage_orders = @stage_orders.joins(:group).where(groups: { fes_year_id: fes_year_id })
     end
 
-    if @stage_orders.count == 0
+    # days_numで絞り込み
+    if days_num != 0
+      @stage_orders = @stage_orders.joins(:fes_date).where(fes_dates: { days_num: days_num })
+    end
+
+    # stage_idで絞り込み
+    if stage_id != 0
+      @stage_orders = @stage_orders.where("(stage_first = ?) OR (stage_second = ?)", stage_id, stage_id)
+    end
+
+    # is_sunnyで絞り込み
+    if is_sunny != 0
+      @stage_orders = @stage_orders.where(is_sunny: is_sunny_list[is_sunny])
+    end
+
+    if @stage_orders.empty?
       render json: fmt(not_found, [], "Not found stage_orders")
-    else 
+    else
       render json: fmt(ok, fit_stage_order_index_for_admin_view(@stage_orders))
     end
   end
+
 
   #あいまい検索
   def get_search_stage_orders
@@ -98,5 +71,5 @@ class Api::V1::StageOrdersApiController < ApplicationController
     end
   end
 
-      
+
 end


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1451

- issueがミスリーディングでした
- 年度切り替えても絞り込んでもデータはちゃんと表示されました
  - データが存在する年度が初期値だった場合、初期リロード時にそのデータが表示されないバグというのが問題の根本な気がします

# 概要
<!-- 開発内容の概要を記載 -->

- 最初読み込んだ時だけデータが表示されないバグが発生していたので修正した
- APIが地獄の様相を呈していたので綺麗にした

# なぜ動かなかったのか

## dataにvenueMapを返していなかった
240行目以降の`data()`内でページに使う変数の一覧か書いてあります
`asyncData()`内のreturnでvenueMapがdataに返していなかったため、87行目でvenueMapを読み込む際に空配列となってしまっていました
そのため`venueMap[index]`を読み込めずエラーが吐かれていました

## venueMapの存在判定
87行目でvenueMapが存在しているか判定していますが、`venueMap`は254行目初期値が空配列(=truethy)と設定しているため、`venueMap != null`や`venueMap != undefined`は通り抜けてしまいます
`venueMap[index]`を判定式とすることで`venueMap[index]`が存在する時のみ値を表示することができます
- 補足として、仮にvenueMapの初期値をnullにした場合、`venueMap != null`とせずとも、`!venueMap`とするだけで`venueMapが存在しない(falthy)な場合は表示する`という判定式になります
- また、比較演算子は厳密等価を使いましょう(`===`, `!==`)

# テスト項目

- `admin_view/nuxt-project/pages/stage_orders/index.vue`の337行目の`currentYearRes.data.fes_year_id`を`0`にする
  - こうすることで、初期リロードに読み込むデータの年度指定を2021からallにして表示させることができます
  - このテストが終わったら戻してください
- http://localhost:8000/stage_orders に移動し、リロードしてもデータがちゃんと表示されるか確認する

# 備考
APIが大変なことになっていたので修正しました。
絞り込みの全てのパターンを全列挙しているためこんなにごちゃごちゃになってます。
あらかじめ`@stage_orders`に値を入れておき、その値を逐次絞り込み内容から修正することで簡略化しました。