### PR TITLE
[fix] pdf出力の文言修正と借用チェックの追加 (#1448)

### DIFF
--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -43,13 +43,13 @@
   <h2>貸出物品一覧</h2>
   <table class="items">
     <tr>
-      <th>物品名</th>
-      <th>借りる場所</th>
-      <th>数量</th>
-      <th>貸出日</th>
-      <th>返却日</th>
-      <th>借用チェック</th>
-      <th>返却チェック</th>
+      <th class = "large-box">物品名</th>
+      <th class = "large-box">借りる場所</th>
+      <th class = "small-box">数量</th>
+      <th class = "large-box">貸出日</th>
+      <th class = "large-box">返却日</th>
+      <th class = "small-box">借用チェック</th>
+      <th class = "small-box">返却チェック</th>
     </tr>
     <% group.assign_rental_items.each do |assign_rental_item| %>
     <tr>

--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -1,6 +1,6 @@
 <% @groups.each do |group| %>
 <div class="page-break">
-<h1>参加団体情報管理表</h1>
+<h1>物品貸出表</h1>
 
 <div class="padding-top">
   <h2>参加団体情報</h2>
@@ -48,6 +48,7 @@
       <th>数量</th>
       <th>貸出日</th>
       <th>返却日</th>
+      <th>借用チェック</th>
       <th>返却チェック</th>
     </tr>
     <% group.assign_rental_items.each do |assign_rental_item| %>
@@ -58,6 +59,7 @@
       <td><%= group.fes_year.fes_dates.find_by(days_num: 0)&.date %>(準備日)</td>
       <td><%= group.fes_year.fes_dates.find_by(days_num: 3)&.date %>(片付け日)</td>
       <td></td>
+      <td></td>
     </tr>
     <% end %>
   </table>
@@ -66,7 +68,7 @@
   <p>
   《注意事項》<br><br>
   ● 物品は借用・返却場所を間違えないようにしてください。<br>
-  ● 返却時は本部でチェックを受けてください。<br>
+  ● 借用および返却時は貸出場所にいる実行委員のチェックを受けてください。<br>
   ● 備品等は絶対に汚さないように使用し、綺麗にしてから返却してください。 
   </p>
 </div>

--- a/api/app/views/print_pdf/output_rental_items_pdf.css
+++ b/api/app/views/print_pdf/output_rental_items_pdf.css
@@ -28,11 +28,11 @@ table {
 }
 
 
-.small-box{
+.small-box {
   width:5%
 }
 
-.large-box{
+.large-box {
   width:10%
 }
 

--- a/api/app/views/print_pdf/output_rental_items_pdf.css
+++ b/api/app/views/print_pdf/output_rental_items_pdf.css
@@ -27,8 +27,13 @@ table {
   width: 40%;
 }
 
-.items th {
-  width: 20%;
+
+.small-box{
+  width:5%
+}
+
+.large-box{
+  width:10%
 }
 
 .items tr {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1448

# 概要
<!-- 開発内容の概要を記載 -->
- pdfで出力される物品貸出表の文言修正
- 物品貸出表に借用チェック欄追加
- 貸出物品一覧のセルのサイズを修正
# 実装詳細
<!-- 具体的な開発内容を記載 -->
- api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb　の文章を修正
- 同ファイルの貸出物品一覧に「借用チェック」の欄を追加
- api/app/views/print_pdf/output_rental_items_pdf.css　に小さいセルと大きいセルの新しいクラスを定義して、output_all_groups_rental_items.pdf.erbで使用
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="323" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/133647331/de7ace79-64e3-4ee3-b091-bd6a67ed82ad">

<img width="590" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/133647331/7f57c6ee-3519-4b7e-b76c-af8e1b6fc9d9">


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 書類印刷ページの物品貸出表まとめのpdfを出力したときに、注意事項の2行目の文章が「借用および返却時は貸出場所にいる実行委員のチェックを受けてください。」になっているか
- [x] 借用チェック欄が追加されているか
- [x] 「借用チェック」と「返却チェック」が2行で収まっているか
# 備考
<!-- 実装していて困った箇所・質問など -->
「チェック」の文字が途中で改行されているが、このままで良いのか ← 修正したがこれで問題ないか