### PR TITLE
[fix]pdf出力時のタイトル修正(#1462)

### DIFF
--- a/admin_view/nuxt-project/pages/print/index.vue
+++ b/admin_view/nuxt-project/pages/print/index.vue
@@ -28,7 +28,7 @@
           </td>
         </tr>
         <tr>
-          <td>貸出物品リスト</td>
+          <td>貸出物品リストまとめ</td>
           <td>
             <InTableButton
               iconName="file_download"
@@ -80,7 +80,7 @@
           </td>
         </tr>
         <tr>
-          <td>物品貸し出し表まとめ</td>
+          <td>物品貸出表</td>
           <td>
             <InTableButton
               iconName="file_download"

--- a/api/app/controllers/print_pdf_controller.rb
+++ b/api/app/controllers/print_pdf_controller.rb
@@ -3,13 +3,13 @@ class PrintPdfController < ApplicationController
 
   # 物品貸し出し書類出力
   def output_rental_items_pdf
-    output_groups("output_rental_items", "output_rental_items_pdf", "物品貸し出し書類_物品持ち出し表(各団体向け)", "Not Landscape")
+    output_groups("output_rental_items", "output_rental_items_pdf", "物品貸出表", "Not Landscape")
   end
   
   # 物品貸し出し書類をまとめて出力
   def output_all_groups_rental_items_pdf
     @groups = Group.where(fes_year_id: params[:fes_year_id])
-    print_pdf("output_all_groups_rental_items", "output_rental_items_pdf", "物品貸し出し書類_物品持ち出し表(各団体向け)", "Not Landscape")
+    print_pdf("output_all_groups_rental_items", "output_rental_items_pdf", "物品貸出表", "Not Landscape")
   end
 
   # 参加団体情報リスト
@@ -20,7 +20,7 @@ class PrintPdfController < ApplicationController
   # 参加団体情報リストをまとめて出力
   def output_all_groups_info_pdf
     @groups = Group.where(fes_year_id: params[:fes_year_id])
-    print_pdf("output_all_groups_info", "output_rental_items_pdf", "参加団体情報", "Not Landscape")
+    print_pdf("output_all_groups_info", "output_rental_items_pdf", "参加団体情報リストまとめ", "Not Landscape")
   end
 
   # 使用電力リスト出力
@@ -35,7 +35,7 @@ class PrintPdfController < ApplicationController
 
   # 貸出物品リスト
   def output_rental_items_list_pdf
-    output_groups_with_categories("output_rental_items_list", "output_rental_items_list_pdf", "貸出物品リスト", "Landscape")
+    output_groups_with_categories("output_rental_items_list", "output_rental_items_list_pdf", "貸出物品リストまとめ", "Landscape")
   end
 
   # 販売食品リスト

--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -1,6 +1,6 @@
 <% @groups.each do |group| %>
 <div class="page-break">
-<h1>参加団体情報管理表</h1>
+<h1>物品貸出表</h1>
 
 <div class="padding-top">
   <h2>参加団体情報</h2>

--- a/api/app/views/print_pdf/output_rental_items_list.pdf.erb
+++ b/api/app/views/print_pdf/output_rental_items_list.pdf.erb
@@ -1,7 +1,7 @@
 <% @catgories.each do |category| %>
   <% if category.exists? %>
   <div class="page-break">
-    <h1>貸し出し物品リスト - <%= category.first.group_category.name %></h1>
+    <h1>貸出物品リストまとめ - <%= category.first.group_category.name %></h1>
     <table>
       <tr>
         <th>参加形式</th>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1462

# 概要
<!-- 開発内容の概要を記載 -->
- 書類印刷のタイトル修正及び，pdfタイトルの修正

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- タグ内の文言の修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="921" alt="image" src="https://github.com/NUTFes/group-manager-2/assets/134277111/2a346327-d912-40c1-a7af-a212f0ce07d6">


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x]　管理者画面の書類印刷ページの各書類印刷タイトルが正しいか 
- [x] 　書類印刷ページと出力されたpdfのタイトルが同様か
- [x] 　pdfのタイトルと出力されたpdfの見出し部のタイトルが同様か

# 備考
<!-- 実装していて困った箇所・質問など -->
githubがよくわからん
