### PR TITLE
Ruby on Railsのpdf出力方法の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ build:
 	docker compose run --rm api rails db:migrate
 	docker compose run --rm api rails db:seed_fu FIXTURE_PATH=db/fixtures/develop
 
+build mac:
+	PLATFORM=arm64-darwin docker compose build
+	docker compose run --rm user_front npm install
+	docker compose run --rm admin_view npm install
+	docker compose run --rm api rails db:create
+	docker compose run --rm api rails db:migrate
+	docker compose run --rm api rails db:seed_fu FIXTURE_PATH=db/fixtures/develop
+
 build db:
 	docker compose run --rm api rails db:create
 	docker compose run --rm api rails db:migrate

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,14 +1,6 @@
 FROM ruby:2.7.1
 
-
-#RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-#      && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-#      && apt-get update \
-#      && apt-get install -y nodejs npm yarn \
-#      && apt-get install -y build-essential libpq-dev libgtk-3.0 libnss3 libatk-bridge2.0-0\
-#      && mkdir /myapp
- 
-# M1 Mac 対策 
+# M1 Mac 対策として必要なパッケージのインストール
 RUN wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
       && apt-get update \
@@ -16,9 +8,17 @@ RUN wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg |
       && apt-get install -y build-essential libpq-dev libgtk-3.0 libnss3 libatk-bridge2.0-0\
       && mkdir /myapp
 
+# wkhtmltopdfとその依存関係のインストール
+RUN apt-get update \
+    && apt-get install -y wget xz-utils fontconfig libxrender1 libxext6 libfreetype6 xfonts-75dpi xfonts-base \
+    && wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_arm64.deb \
+    && dpkg -i wkhtmltox_0.12.6-1.stretch_arm64.deb \
+    && rm wkhtmltox_0.12.6-1.stretch_arm64.deb
+
+# 日本語フォントのインストール
 RUN apt-get install fonts-ipa*
 
-
+# ワーキングディレクトリの設定
 WORKDIR /myapp
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
@@ -27,10 +27,11 @@ RUN mkdir /myapp/tmp/pids
 RUN bundle install
 COPY . /myapp
 
+# エントリーポイントスクリプトのコピーと実行権限の付与
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
+# Railsサーバーの起動コマンド
 CMD ["rails", "server", "-b", "0.0.0.0"]
-

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,12 @@
 FROM ruby:2.7.1
 
+# ビルド時の引数としてPLATFORMを定義
+ARG PLATFORM
+
+# 環境変数PLATFORMを設定
+ENV PLATFORM=${PLATFORM}
+
+
 # M1 Mac 対策として必要なパッケージのインストール
 RUN wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
@@ -8,12 +15,13 @@ RUN wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg |
       && apt-get install -y build-essential libpq-dev libgtk-3.0 libnss3 libatk-bridge2.0-0\
       && mkdir /myapp
 
-# wkhtmltopdfとその依存関係のインストール
-RUN apt-get update \
-    && apt-get install -y wget xz-utils fontconfig libxrender1 libxext6 libfreetype6 xfonts-75dpi xfonts-base \
-    && wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_arm64.deb \
-    && dpkg -i wkhtmltox_0.12.6-1.stretch_arm64.deb \
-    && rm wkhtmltox_0.12.6-1.stretch_arm64.deb
+# PLATFORMが'arm64-darwin'の場合のみ、特定のコマンドを実行
+RUN if [ "$PLATFORM" = "arm64-darwin" ]; then \
+      apt-get install -y wget xz-utils fontconfig libxrender1 libxext6 libfreetype6 xfonts-75dpi xfonts-base && \
+      wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_arm64.deb && \
+      dpkg -i wkhtmltox_0.12.6-1.stretch_arm64.deb && \
+      rm wkhtmltox_0.12.6-1.stretch_arm64.deb; \
+    fi
 
 # 日本語フォントのインストール
 RUN apt-get install fonts-ipa*

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -30,8 +30,8 @@ gem 'devise_token_auth'
 gem 'seed-fu'
 
 gem 'pdfkit'
-gem 'wkhtmltopdf'
-gem 'wkhtmltopdf-binary'
+# gem 'wkhtmltopdf'
+# gem 'wkhtmltopdf-binary'
 
 gem 'slack-notifier'
 gem 'dotenv-rails'

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -30,8 +30,11 @@ gem 'devise_token_auth'
 gem 'seed-fu'
 
 gem 'pdfkit'
-# gem 'wkhtmltopdf'
-# gem 'wkhtmltopdf-binary'
+# 環境変数PLATFORMが'arm64-darwin'でない場合、以下のGemをインクルード
+if ENV['PLATFORM'] != 'arm64-darwin'
+  gem 'wkhtmltopdf'
+  gem 'wkhtmltopdf-binary'
+end
 
 gem 'slack-notifier'
 gem 'dotenv-rails'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,10 @@ services:
     volumes: [mysql-data:/var/lib/mysql]
 
   api:
-    build: ./api
+    build:
+      context: ./api
+      args:
+        PLATFORM: ${PLATFORM:-default}
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     container_name: 'GM2-API'
     volumes: [./api:/myapp]


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1459 

# 概要
<!-- 開発内容の概要を記載 -->
- macOSのm1、m2でも、pdf出力ができる

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- GemfileとDockerfileの変更
- GemでインストールしていたのをオープンソースからARMプロセッサに対応したwkhtmltopdfをインストールした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] macでちゃんとpdfファイルが出力できる
- [x] windowsでもpdfファイルが出力できる
- [x] ちゃんとhtmlどおりのpdfが出てくる（中の情報や、デザインが間違っていない）

# 備考
<!-- 実装していて困った箇所・質問など -->
