### PR TITLE
[fix]物品割り当てページにソート機能のみ追加

### DIFF
--- a/admin_view/nuxt-project/pages/assign_items/_id.vue
+++ b/admin_view/nuxt-project/pages/assign_items/_id.vue
@@ -53,7 +53,7 @@
           </SubHeader>
           <Table>
             <template v-slot:table-header>
-              <th v-for="(header, index) in stocker_headers" v-bind:key="index">
+              <th v-for="(header, index) in stocker_headers" v-bind:key="index" @click = "sorted_assignRentalItems(index)">
                 {{ header }}
               </th>
               <th>編集</th>
@@ -400,6 +400,10 @@ export default {
       rules: {
         required: (value) => !!value || "入力してください",
       },
+      clicked_index:-1,
+      sort_key_1:"",
+      sort_key_2:"",
+      sort_asc: true,
     };
   },
 
@@ -452,11 +456,11 @@ export default {
     };
   },
   computed: {
-      ...mapState({
+    ...mapState({
       roleID: (state) => state.users.role,
     }),
   },
-
+ 
   methods: {
     calculateDifference(stockerItem, index) {
         const matchingAssignRentalItems = this.assignRentalItems.filter(
@@ -658,6 +662,47 @@ export default {
     },
     closeAssignDeleteModal() {
       this.isOpenAssignDeleteModal = false;
+    },
+    
+    sorted_assignRentalItems(index) {
+      console.log(index);
+      if(index == 0){
+        this.sort_key_1 = "group";
+        this.sort_key_2 = "name";
+        if(this.clicked_index == index){
+          this.sort_asc = !this.sort_asc;
+        } else{
+          this.sort_asc = true;
+        }
+      } else if(index == 1){
+        this.sort_key_1 = "rental_item";
+        this.sort_key_2 = "name";
+        if(this.clicked_index == index){
+          this.sort_asc = !this.sort_asc;
+        } else{
+          this.sort_asc = true;
+        }
+      } else{
+        this.sort_key = "";
+      }
+      this.clicked_index = index;
+      if (this.sort_key_1 != "") {
+        let set = 1;
+        this.sort_asc ? (set = 1) : (set = -1);
+        this.assignRentalItems.sort((a, b) => {
+          if (a[this.sort_key_1][this.sort_key_2] < b[this.sort_key_1][this.sort_key_2]) {
+            return -1*set;
+          }
+          if (a[this.sort_key_1][this.sort_key_2] > b[this.sort_key_1][this.sort_key_2]) {
+            return 1*set;
+          }
+          return 0;
+        });
+        
+        return this.assignRentalItems;
+      } else {
+        return this.assignRentalItems;
+      }
     },
   },
 };


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue 1464
<!-- 対応したIssue番号を記載 -->
resolve #1464

# 概要
<!-- 開発内容の概要を記載 -->
- 物品割り当てページの表の団体名・物品名の表タイトルをクリックすると五十音順に並び変わる機能を実装
- 同じ表タイトルをクリックする度に昇順→降順→昇順と交互に切り替わる

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- admin_view>nuxt-project>pages>assign_items>_id.vue　に メソッド"sorted_assignRentalItems"を追加
- 同ファイルの56行目の<tr>タグに↑で追加したメソッドを呼び出すクリックイベントを追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
↓動作説明スライド
https://docs.google.com/presentation/d/1xLxmsN24aepdTEFF5kzcQDo7t-Ddg5PU7IiIxEpibeA/edit#slide=id.p

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- 講義棟101のページだけをテストしたので、他の場所でも動作するかの確認


# 備考
<!-- 実装していて困った箇所・質問など -->
ソート機能があることがパッと見てわからないので、アピールするようなデザインが欲しい