### PR TITLE
[fix]Add role-based permissions to buttons in assign_items/_id page

### DIFF
--- a/admin_view/nuxt-project/pages/assign_items/_id.vue
+++ b/admin_view/nuxt-project/pages/assign_items/_id.vue
@@ -4,10 +4,10 @@
       v-bind:pageTitle="placeName.name"
       pageSubTitle="物品申請"
     >
-      <CommonButton iconName="edit" :on_click="openPlaceEditModal">
+      <CommonButton v-if="this.$role(roleID).stocker_places.update" iconName="edit" :on_click="openPlaceEditModal">
         編集
       </CommonButton>
-      <CommonButton iconName="delete" :on_click="openPlaceDeleteModal">
+      <CommonButton v-if="this.$role(roleID).stocker_places.delete" iconName="delete" :on_click="openPlaceDeleteModal">
         削除
       </CommonButton>
     </SubHeader>
@@ -16,7 +16,7 @@
       <Column width="100%">
         <Card width="100%">
           <SubHeader pageTitle="在庫物品">
-            <CommonButton iconName="add_circle" :on_click="openItemAddModal">
+            <CommonButton v-if="this.$role(this.roleID).rental_items.create" iconName="add_circle" :on_click="openItemAddModal">
               追加
             </CommonButton>
           </SubHeader>
@@ -47,7 +47,7 @@
         </Card>
         <Card width="100%">
           <SubHeader pageTitle="割り当て">
-            <CommonButton iconName="add_circle" :on_click="openAssignAddModal">
+            <CommonButton v-if="this.$role(roleID).assign_items.create" iconName="add_circle" :on_click="openAssignAddModal">
               追加
             </CommonButton>
           </SubHeader>
@@ -228,7 +228,7 @@
 
     <EditModal
       @close="closeItemEditModal"
-      v-if="isOpenItemEditModal"
+      v-if="isOpenItemEditModal && this.$role(this.roleID).rental_items.create"
       title="在庫物品個数の編集"
     >
       <template v-slot:form>
@@ -244,7 +244,7 @@
 
     <EditModal
       @close="closeAssignEditModal"
-      v-if="isOpenAssignEditModal"
+      v-if="isOpenAssignEditModal && this.$role(roleID).assign_items.update"
       title="割当個数の編集"
     >
       <template v-slot:form>
@@ -273,7 +273,7 @@
 
     <DeleteModal
       @close="closeItemDeleteModal"
-      v-if="isOpenItemDeleteModal"
+      v-if="isOpenItemDeleteModal && this.$role(this.roleID).rental_items.delete"
       title="在庫物品の削除"
     >
       <template v-slot:method>
@@ -286,7 +286,7 @@
 
     <DeleteModal
       @close="closeAssignDeleteModal"
-      v-if="isOpenAssignDeleteModal"
+      v-if="isOpenAssignDeleteModal && this.$role(roleID).assign_items.delete"
       title="割当の削除"
     >
       <template v-slot:method>

--- a/admin_view/nuxt-project/plugins/role/member.js
+++ b/admin_view/nuxt-project/plugins/role/member.js
@@ -161,7 +161,7 @@ export const memberRole = {
     update: false,
     delete: false,
   },
-  assgin_items: {
+  assign_items: {
     read: true,
     create: false,
     update: false,

--- a/admin_view/nuxt-project/plugins/role/user.js
+++ b/admin_view/nuxt-project/plugins/role/user.js
@@ -161,7 +161,7 @@ export const userRole = {
     update: false,
     delete: false,
   },
-  assgin_items: {
+  assign_items: {
     read: false,
     create: false,
     update: false,


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1475 

# 概要
<!-- 開発内容の概要を記載 -->
- 管理者画面の物品割り当ての詳細ページでの各追加、編集、削除ボタンをdeveloperにだけ表示させるように権限追加

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- CommonButtonやEditModal、DeleteModalにv-ifでplugin/roleにあるroleを用いて権限を追加。
- memberとuserのroleのassginをassignに変更


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/NUTFes/group-manager-2/assets/97947201/a11fa85e-744c-467b-a412-a89d5f3fd50f)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] developer以外の権限レベルのユーザーにボタン操作が行えないようになっているか
- [ ] developerのユーザーはボタン操作が行えるか
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
