### PR TITLE
[feat]保健所提出書類のpdf出力機能のみ

### DIFF
--- a/admin_view/nuxt-project/pages/print/index.vue
+++ b/admin_view/nuxt-project/pages/print/index.vue
@@ -92,6 +92,12 @@
             </InTableButton>
           </td>
         </tr>
+        <tr>
+          <td>保健所提出書類（調理計画・従事者）</td>
+          <td>
+            <InTableButton iconName="file_download" :on_click="downloadHealthOfficeDocumentsPDF">PDF</InTableButton>
+          </td>
+        </tr>
       </VerticalTable>
     </Card>
   </div>
@@ -175,6 +181,15 @@ export default {
           this.currentYearID +
           "/output.pdf",
         "物品貸し出し表まとめ"
+      );
+    },
+    downloadHealthOfficeDocumentsPDF: function () {
+      window.open(
+        this.$config.apiURL +
+          "/print_pdf/health_office_documents/" +
+          this.currentYearID +
+          "/output.pdf",
+        "保健所提出書類（調理計画・従事者）"
       );
     },
     async downloadPowerCSV() {

--- a/api/app/controllers/print_pdf_controller.rb
+++ b/api/app/controllers/print_pdf_controller.rb
@@ -48,6 +48,12 @@ class PrintPdfController < ApplicationController
     output_groups_with_categories("output_contact", "output_contact_pdf", "連絡先リスト", "Not Landscape")
   end
 
+  # 保健所提出書類（調理計画・従事者）の出力
+  def output_health_office_documents_pdf
+    print_pdf("output_health_office_documents", "output_health_office_documents_pdf", "保健所提出書類（調理計画・従事者）", "Not Landscape")
+  end
+
+
   # 全参加団体用
   def output_groups(template_name, style_name, output_file_name, type)
     if Group.exists?(params[:group_id])

--- a/api/app/views/print_pdf/output_health_office_documents.pdf.erb
+++ b/api/app/views/print_pdf/output_health_office_documents.pdf.erb
@@ -1,0 +1,103 @@
+<body>
+  <h1>従　事　者　名　簿　(※)</h1>
+    <!-- 従事者名簿のテーブル -->
+    <table>
+    <tr>
+        <th class="first No">No.</th>
+        <th class="first Belonging">所属（クラス等）</th>
+        <th class="first Name">氏名</th>
+        <th class="first Category">保護者、生徒等の区分</th>
+    </tr>
+    <tr>
+        <td class="No">1</td>
+        <td class="Belonging">焼き鳥くらりん</td>
+        <td class="Name">阿久津英司</td>
+        <td class="Category">生徒</td>
+    </tr>
+    <tr>
+        <td class="No">1</td>
+        <td class="Belonging">焼き鳥くらりん</td>
+        <td class="Name">阿久津英司</td>
+        <td class="Category">生徒</td>
+    </tr>
+    <tr>
+        <td class="No">1</td>
+        <td class="Belonging">焼き鳥くらりん</td>
+        <td class="Name">阿久津英司</td>
+        <td class="Category">生徒</td>
+    </tr>
+    <tr>
+        <td class="No">1</td>
+        <td class="Belonging">焼き鳥くらりん</td>
+        <td class="Name">阿久津英司</td>
+        <td class="Category">生徒</td>
+    </tr>
+    </table>
+    <div class="attention">
+        <p>※  食品を管理する人についてのみ記入すること。</p>
+    </div>
+  <div class="page-break"></div> <!-- ページブレーク -->
+  <h1>調理計画(※1)</h1>
+    <!-- 調理計画のテーブル -->
+    <table>
+        <tr>
+            <th rowspan="2">調理品目</th>
+            <th colspan="2">食品区分(※2)</br>(該当に◯)</th>
+            <th rowspan="2">提供予定</br>数量</th>
+            <th colspan="3">原材料の仕入状況</th>
+            <th rowspan="2">調理開始</br>日時</th>
+        </tr>
+        <tr>
+            <td>加熱調理</br>食品</td>
+            <td>既製食品</td>
+            <td>原材料名</td>
+            <td>仕入先</td>
+            <td>仕入日</td>
+        </tr>
+        <tr>
+            <td>焼き鳥</td>
+            <td>◯</td>
+            <td></td>
+            <td>200</td>
+            <td>焼きとり　加熱済み　ねぎ間串　50本入</td>
+            <td>ひらせい 長岡ニュータウン店</td>
+            <td>9月15,16日</td>
+            <td>9月16.17日</td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+    </table>
+    <div class="attention">
+        <p>※1  バザーが2日以上の場合は1日ごとに記載すること。</p>
+        <p>※2  現地で加熱調理するものは「加熱調理食品」欄に◯を記入</p>
+        <span>営業許可施設で調理された既製食品を現地で盛り付けるものは、「既製食品」欄に◯を記入</span>
+    </div>
+</body>

--- a/api/app/views/print_pdf/output_health_office_documents_pdf.css
+++ b/api/app/views/print_pdf/output_health_office_documents_pdf.css
@@ -1,0 +1,52 @@
+h1 {
+    text-align: center;
+  }
+  
+  .attention, p, span {
+    margin-left: 5%;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+  
+  body {
+    width: 100%;
+  }
+  
+  table {
+    border-collapse: collapse;
+    margin: auto; /* テーブルを中央に配置 */
+    width: 80%; /* テーブルの全体幅を調整 */
+    table-layout: fixed; /* 各セルの横幅を均等にする */
+  }
+  
+  th, td {
+    border: 1px solid black;
+    padding: 8px;
+    text-align: center;
+    vertical-align: bottom; /* Aligns text to bottom */
+    height: 50px; /* Minimum cell height, adjust as needed */
+  }
+  
+  th.first, td.No {
+    text-align: center; 
+  }
+  
+  th.No, td.No { width: 10%; }
+  th.Belonging, td.Belonging { width: 20%; }
+  th.Name, td.Name { width: 40%; }
+  th.Category, td.Category { width: 30%; }
+  
+  /* 調理計画の表に特有のスタイル */
+  th[rowspan], th[colspan], td[rowspan], td[colspan] {
+    text-align: center;
+  }
+  
+  /* ページブレークのスタイル */
+  .page-break { 
+    page-break-after: always; /* 次の要素を新しいページに配置 */
+  }
+  
+  h1, th {
+    font-weight: normal; /* 太字を解除 */
+  }
+  

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -232,6 +232,7 @@ Rails.application.routes.draw do
   get "print_pdf/food_products/:fes_year_id/output" => "print_pdf#output_food_products_pdf"
   get "print_pdf/group_info/:group_id/output" => "print_pdf#output_group_info_pdf"
   get "print_pdf/all_groups_info/:fes_year_id/output" => "print_pdf#output_all_groups_info_pdf"
+  get "print_pdf/health_office_documents/:fes_year_id/output" => "print_pdf#output_health_office_documents_pdf"
 
   namespace :api do
     mount_devise_token_auth_for 'User', at: 'auth', controllers: {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue1488
<!-- 対応したIssue番号を記載 -->
- resolve #1488 

# 概要
<!-- 開発内容の概要を記載 -->
- 保健所提出書類のフォーマットのみが印刷できる機能をつける

# 実装詳細
<!-- 具体的な開発内容を記載 -->
作成
- api/app/views/print_pdf/output_health_office_documents.pdf.erb
- api/app/views/print_pdf/output_health_office_documents_pdf.css
編集
- api/app/controllers/print_pdf_controller.rb
- admin_view/nuxt-project/pages/print/index.vue
- api/config/routes.rb

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8000/print
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/dc8c921c-02e9-40e6-8dec-afb5925625f2)
- 保健所提出書類（調理計画・従事者）.pdf
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/18fb41b5-b2ee-4170-9b28-3201e4f3e6e8)
![image](https://github.com/NUTFes/group-manager-2/assets/131850959/efd0f897-25ee-4649-bdf3-d7c52a90dc9f)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] printページでpdfボタンを押すとフォーマットのpdfがダウンロードできる

# 備考
<!-- 実装していて困った箇所・質問など -->
- フォーマットのみなので、情報などは入れれません
- 追加で情報を入れるAPIを作成する必要がある