### PR TITLE
[feat] 物品申請数調整ページの表示 (#1496)

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -168,6 +168,7 @@ export default {
           icon: "assignment_return",
           click: "/assign_items",
         },
+        { title: "物品申請数調整", icon: "stadium", click: "/adjustment_order_items" },
         { title: "識別番号", icon: "format_list_numbered", click: "/group_identify" },
         { title: "会場割り当て", icon: "event_seat", click: "/assign_places" },
         { title: "ステージ割り当て", icon: "stadium", click: "/assign_stages" },

--- a/admin_view/nuxt-project/pages/adjustment_order_items/index.vue
+++ b/admin_view/nuxt-project/pages/adjustment_order_items/index.vue
@@ -25,44 +25,47 @@
       </template>
     </SubSubHeader>
 
-    <div style="display: flex; justify-content: space-between;">
-      <Card width="45%">
-        <Table>
-          <template v-slot:table-header>
-            <th v-for="(header, index) in itemHeaders" v-bind:key="index">
-              {{ header }}
-            </th>
-          </template>
-          <template v-slot:table-body>
-            <tr v-for="(stocker_place, index) in stockerPlaces">
-              <td>{{ stocker_place.id }}</td>
-              <td>{{  }}</td>
-              <td>{{  }}</td>
-              <td>{{  }}</td>
-              <td>{{  }}</td>
-            </tr>
-          </template>
-        </Table>
-      </Card>
-      <Card width="45%">
-        <Table>
-          <template v-slot:table-header>
-            <th v-for="(header, index) in groupHeaders" v-bind:key="index">
-              {{ header }}
-            </th>
-          </template>
-          <template v-slot:table-body>
-            <tr v-for="(stocker_place, index) in stockerPlaces">
-              <td>{{ stocker_place.id }}</td>
-              <td>{{  }}</td>
-              <td>{{  }}</td>
-              <td>{{  }}</td>
-              <td>{{  }}</td>
-            </tr>
-          </template>
-        </Table>
-      </Card>
-    </div>
+    <Row wrap="nowrap" align="start">
+      <Column width="50%" height="800px">
+        <Card width="100%" style="overflow: scroll">
+          <Table>
+            <template v-slot:table-header>
+              <th v-for="(header, index) in itemHeaders" v-bind:key="index">
+                {{ header }}
+              </th>
+            </template>
+            <template v-slot:table-body>
+              <tr v-for="(stocker_place, index) in stockerPlaces">
+                <td>{{ stocker_place.id }}</td>
+                <td>{{  }}</td>
+                <td>{{  }}</td>
+                <td>{{  }}</td>
+              </tr>
+            </template>
+          </Table>
+        </Card>
+      </Column>
+      <Column width="50%" height="800px">
+        <Card width="100%" style="overflow: scroll">
+          <Table>
+            <template v-slot:table-header>
+              <th v-for="(header, index) in groupHeaders" v-bind:key="index">
+                {{ header }}
+              </th>
+            </template>
+            <template v-slot:table-body>
+              <tr v-for="(stocker_place, index) in stockerPlaces">
+                <td>{{ stocker_place.id }}</td>
+                <td>{{  }}</td>
+                <td>{{  }}</td>
+                <td>{{  }}</td>
+                <td>{{  }}</td>
+              </tr>
+            </template>
+          </Table>
+        </Card>
+      </Column>
+    </Row>
 
     <AddModal
       @close="closeAddModal"

--- a/admin_view/nuxt-project/pages/adjustment_order_items/index.vue
+++ b/admin_view/nuxt-project/pages/adjustment_order_items/index.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="main-content">
+    <SubHeader pageTitle="物品申請数調整">
+      <CommonButton v-if="this.$role(roleID).stocker_places.create" iconName="add_circle" :on_click="openAddModal">
+        追加
+      </CommonButton>
+    </SubHeader>
+
+    <SubSubHeader>
+      <template v-slot:refinement>
+        <SearchDropDown
+          :nameList="yearList"
+          :on_click="refinementGroups"
+          value="year_num"
+        >
+          {{ refYears }}
+        </SearchDropDown>
+        <SearchDropDown
+          :nameList="groupCategories"
+          :on_click="refinementGroups"
+          value="name"
+        >
+          {{ refGroupCategories }}
+        </SearchDropDown>
+      </template>
+    </SubSubHeader>
+
+    <div style="display: flex; justify-content: space-between;">
+      <Card width="45%">
+        <Table>
+          <template v-slot:table-header>
+            <th v-for="(header, index) in itemHeaders" v-bind:key="index">
+              {{ header }}
+            </th>
+          </template>
+          <template v-slot:table-body>
+            <tr v-for="(stocker_place, index) in stockerPlaces">
+              <td>{{ stocker_place.id }}</td>
+              <td>{{  }}</td>
+              <td>{{  }}</td>
+              <td>{{  }}</td>
+              <td>{{  }}</td>
+            </tr>
+          </template>
+        </Table>
+      </Card>
+      <Card width="45%">
+        <Table>
+          <template v-slot:table-header>
+            <th v-for="(header, index) in groupHeaders" v-bind:key="index">
+              {{ header }}
+            </th>
+          </template>
+          <template v-slot:table-body>
+            <tr v-for="(stocker_place, index) in stockerPlaces">
+              <td>{{ stocker_place.id }}</td>
+              <td>{{  }}</td>
+              <td>{{  }}</td>
+              <td>{{  }}</td>
+              <td>{{  }}</td>
+            </tr>
+          </template>
+        </Table>
+      </Card>
+    </div>
+
+    <AddModal
+      @close="closeAddModal"
+      v-if="isOpenAddModal"
+      title="在庫場所の追加"
+    >
+      <template v-slot:form>
+        <div>
+          <h3>部屋名</h3>
+          <input v-model="roomName" placeholder="入力してください" />
+        </div>
+      </template>
+      <template v-slot:method>
+        <CommonButton iconName="add_circle" :on_click="submit"
+          >登録</CommonButton
+        >
+      </template>
+    </AddModal>
+  </div>
+</template>
+
+<script>
+import { mapState } from "vuex";
+export default {
+  watchQuery: ["page"],
+  data() {
+      return {
+          itemHeaders: [
+              "ID",
+              "物品",
+              "申請数",
+              "在庫数",
+              "差分",
+          ],
+          groupHeaders: [
+              "ID",
+              "団体名",
+              "物品",
+              "個数",
+              "",
+          ],
+          isOpenAddModal: false,
+          stocker_place: [],
+          roomName: [],
+          roomNameList: [],
+          stockItemStatus: [],
+          assignItemStatus: [],
+      };
+  },
+
+	async asyncData({ $axios }) {
+		const stockerPlacesUrl = "/stocker_places";
+		const stockerPlacesRes = await $axios.$get(stockerPlacesUrl);
+		return {
+			stockerPlaces: stockerPlacesRes.data
+		}
+	},
+  computed: {
+    ...mapState({
+      roleID: (state) => state.users.role,
+    }),
+  },
+  methods: {
+    openAddModal() {
+      this.isOpenAddModal = false;
+      this.isOpenAddModal = true;
+    },
+    closeAddModal() {
+      this.isOpenAddModal = false;
+    },
+    reload(id) {
+      const url = "/stocker_places/" + id;
+      this.$axios.$get(url).then((response) => {
+        this.stocker_place.data.push(response.data);
+        console.log(response)
+      })
+      .catch(error =>
+      {
+        console.log(error)
+      })
+      ;
+      console.log(this.stocker_place)
+    },
+    async submit() {
+      const url =
+        "/stocker_places/" +
+        "?name=" +
+        this.roomName +
+        "&stock_item_status=1&assign_item_status=1";
+
+      this.$axios.$post(url).then((response) => {
+        this.roomName = "";
+        this.stockItemStatus = "";
+        this.assignItemStatus = "";
+        this.reload(response.data.id);
+        this.closeAddModal();
+      });
+    },
+  },
+};
+</script>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1496 

# 概要
<!-- 開発内容の概要を記載 -->
- 物品申請数調整ページの表示

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- タブに「物品申請数調整」を追加する
- 物品申請数調整ページの作成

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1440" alt="スクリーンショット 2024-03-08 14 58 57" src="https://github.com/NUTFes/group-manager-2/assets/107479066/e449aef9-fca3-4e77-ae11-6b22bcf8bc26">


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 物品申請数調整ボタンを押したらページが遷移する
- [x] 物品申請数調整ページが正しく表示されている

# 備考
<!-- 実装していて困った箇所・質問など -->
