### PR TITLE
[fix] 従業員申請をする団体のバリデーション変更

### DIFF
--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -373,7 +373,7 @@ const isStageOverlap = computed(() => {
             {{ $t("RegistInfo.item") }}
           </div>
         </li>
-        <li @click="tab = 7">
+        <li v-if="groupCategoryId === 1" @click="tab = 7">
           <div :class="{ select: tab === 7 }" class="title">
             {{ $t("RegistInfo.employees") }}
           </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1519 

# 概要
<!-- 開発内容の概要を記載 -->
- 食品団体のみ従業員申請ができるようにする

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 食品販売のcategoryIDである1の場合のみ従業員申請のタブが表示されるようにした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 食品販売の団体のみ従業員申請が表示されている
- [ ] 
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
