### PR TITLE
[fix] アナウンス申請ページで全団体表示させる

### DIFF
--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -35,22 +35,22 @@
             <tr>
               <th>会場アナウンス文</th>
               <td>
-                <div v-if='announcement.announcement.message === ""'>未登録</div>
-                <div v-else>{{ announcement.announcement.message }}</div>
+                <div v-if='announcement.message === null'>未登録</div>
+                <div v-else>{{ announcement.message }}</div>
               </td>
             </tr>
             <tr>
               <th>登録日時</th>
               <td>
-                <div v-if='announcement.announcement.message === ""'>未登録</div>
-                <div v-else>{{ announcement.announcement.created_at | formatDate }}</div>
+                <div v-if='announcement.message === null'>未登録</div>
+                <div v-else>{{ announcement.created_at | formatDate }}</div>
               </td>
             </tr>
             <tr>
               <th>編集日時</th>
               <td>
-                <div v-if='announcement.announcement.message === ""'>未登録</div>
-                <div v-else>{{ announcement.announcement.updated_at | formatDate }}</div>
+                <div v-if='announcement.message === null'>未登録</div>
+                <div v-else>{{ announcement.updated_at | formatDate }}</div>
               </td>
             </tr>
           </VerticalTable>
@@ -124,17 +124,17 @@ export default {
   },
   async asyncData({ $axios, route }) {
     const routeId = route.path.replace("/announcement/", "");
-    const url = "/api/v1/get_announcement_show_for_admin_view/" + routeId;
+    const url = "/api/v1/get_announcement_for_admin_view/" + routeId;
     const res = await $axios.$get(url);
     return {
-      announcement: res.data,
+      announcement: res.data[0],
       route: url,
     };
   },
   methods: {
     openEditModal() {
-      this.group_id = this.announcement.announcement.group_id;
-      this.message = this.announcement.announcement.message;
+      this.group_id = this.announcement.group_id;
+      this.message = this.announcement.message;
       this.isOpenEditModal = true;
     },
     closeEditModal() {
@@ -156,19 +156,18 @@ export default {
       this.isOpenSnackBar = false;
     },
     async reload(id) {
-      const url = "/api/v1/get_announcement_show_for_admin_view/" + id;
+      const url = "/api/v1/get_announcement_for_admin_view/" + id;
       const res = await this.$axios.$get(url);
       this.announcement = res.data;
     },
     async edit() {
-      const url = 
-      "/announcements/" + 
-      this.announcement.announcement.id + 
-      "?group_id=" + 
+      const url =
+      "/announcements/" +
+      this.announcement.announcement.id +
+      "?group_id=" +
       this.group_id+
-      "&message=" + 
+      "&message=" +
       this.message;
-      
 
       await this.$axios.$put(url).then((res) => {
         this.openSnackBar("会場アナウンス文を編集しました");

--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -35,22 +35,22 @@
             <tr>
               <th>会場アナウンス文</th>
               <td>
-                <div v-if='announcement.message === null'>未登録</div>
-                <div v-else>{{ announcement.message }}</div>
+                <div v-if='announcement.announcement === null'>未登録</div>
+                <div v-else>{{ announcement.announcement.message }}</div>
               </td>
             </tr>
             <tr>
               <th>登録日時</th>
               <td>
-                <div v-if='announcement.message === null'>未登録</div>
-                <div v-else>{{ announcement.created_at | formatDate }}</div>
+                <div v-if='announcement.announcement === null'>未登録</div>
+                <div v-else>{{ announcement.announcement.created_at | formatDate }}</div>
               </td>
             </tr>
             <tr>
               <th>編集日時</th>
               <td>
-                <div v-if='announcement.message === null'>未登録</div>
-                <div v-else>{{ announcement.updated_at | formatDate }}</div>
+                <div v-if='announcement.announcement === null'>未登録</div>
+                <div v-else>{{ announcement.announcement.updated_at | formatDate }}</div>
               </td>
             </tr>
           </VerticalTable>
@@ -64,14 +64,6 @@
       title="会場アナウンス文の編集"
     >
       <template v-slot:form>
-        <div>
-          <h3>団体名</h3>
-          <select v-model="group_id">
-            <option v-for="group in groups" :key="group.id" :value="group.id">
-              {{ group.name }}
-            </option>
-          </select>
-        </div>
         <div>
           <h3>会場アナウンス文</h3>
           <input v-model="message" placeholder="入力してください" />
@@ -133,9 +125,15 @@ export default {
   },
   methods: {
     openEditModal() {
-      this.group_id = this.announcement.group_id;
-      this.message = this.announcement.message;
-      this.isOpenEditModal = true;
+      if (this.announcement.announcement) {
+        this.group_id = this.announcement.group.id;
+        this.message = this.announcement.announcement.message;
+        this.isOpenEditModal = true;
+      } else {
+        this.group_id = this.announcement.group.id;
+        this.message = null;
+        this.isOpenEditModal = true;
+      }
     },
     closeEditModal() {
       this.isOpenEditModal = false;
@@ -147,8 +145,8 @@ export default {
     closeDeleteModal() {
       this.isOpenDeleteModal = false;
     },
-    openSnackBar(message) {
-      this.snackMessage = message;
+    openSnackBar(snackMessage) {
+      this.snackMessage = snackMessage;
       this.isOpenSnackBar = true;
       setTimeout(this.closeSnackBar, 2000);
     },
@@ -158,24 +156,41 @@ export default {
     async reload(id) {
       const url = "/api/v1/get_announcement_for_admin_view/" + id;
       const res = await this.$axios.$get(url);
-      this.announcement = res.data;
+      this.announcement = res.data[0];
     },
     async edit() {
-      const url =
-      "/announcements/" +
-      this.announcement.announcement.id +
-      "?group_id=" +
-      this.group_id+
-      "&message=" +
-      this.message;
+      if (this.announcement.announcement) {
+        const editUrl =
+          "/announcements/" +
+          this.announcement.announcement.id +
+          "?group_id=" +
+          this.group_id+
+          "&message=" +
+          this.message;
 
-      await this.$axios.$put(url).then((res) => {
-        this.openSnackBar("会場アナウンス文を編集しました");
-        this.message = "";
-        this.group_id = "";
-        this.reload(res.data.id);
-        this.closeEditModal();
-      });
+        await this.$axios.$put(editUrl).then((res) => {
+          this.openSnackBar("会場アナウンス文を編集しました");
+          this.group_id = null;
+          this.message = null;
+          this.reload(res.data.group_id);
+          this.closeEditModal();
+        });
+      } else {
+        const postAnnouncementUrl =
+          "/announcements/" +
+          "?group_id=" +
+          this.group_id +
+          "&message=" +
+          this.message;
+
+        await this.$axios.$post(postAnnouncementUrl).then((res) => {
+          this.openSnackBar("会場アナウンス文を登録しました");
+          this.group_id = null;
+          this.message = null;
+          this.reload(res.data.group_id);
+          this.closeEditModal();
+        });
+      }
     },
     async destroy() {
       const delUrl = "/announcements/" + this.announcement.announcement.id;

--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -159,6 +159,10 @@ export default {
       this.announcement = res.data[0];
     },
     async edit() {
+      if (!this.message) {
+        this.openSnackBar("会場アナウンス文を入力してください");
+        return;
+      }
       if (this.announcement.announcement) {
         const editUrl =
           "/announcements/" +

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -61,8 +61,8 @@
             <td>{{ announcement.group.id }}</td>
             <td>{{ announcement.group.name}}</td>
             <td>
-              <div v-if='announcement.announcement === null'>未登録</div>
-              <div v-else>登録済み</div>
+              <div v-if='announcement.announcement && announcement.announcement.message'>登録済み</div>
+              <div v-else>未登録</div>
             </td>
           </tr>
         </template>

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -61,7 +61,7 @@
             <td>{{ announcement.group.id }}</td>
             <td>{{ announcement.group.name}}</td>
             <td>
-              <div v-if='announcement.message === null'>未登録</div>
+              <div v-if='announcement.announcement === null'>未登録</div>
               <div v-else>登録済み</div>
             </td>
           </tr>

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -54,14 +54,14 @@
             @click="
               () =>
                 $router.push({
-                  path: `/announcement/` + announcement.announcement.id,
+                  path: `/announcement/` + announcement.group.id,
                 })
             "
           >
             <td>{{ announcement.group.id }}</td>
             <td>{{ announcement.group.name}}</td>
             <td>
-              <div v-if='announcement.announcement.message === ""'>未登録</div>
+              <div v-if='announcement.message === null'>未登録</div>
               <div v-else>登録済み</div>
             </td>
           </tr>
@@ -115,7 +115,6 @@ export default {
       dialog: false,
       message: "",
       snackMessage: "",
-      group_id: "",
       refYears: "Years",
       refYearID: 0,
       searchText: ""
@@ -150,7 +149,7 @@ export default {
   methods: {
 
     async openAddModal() {
-      const groupUrl = "/api/v1/get_groups_refinemented_by_current_fes_year";
+      const groupUrl = "/api/v1/get_groups_have_no_announcement";
       const groupRes = await this.$axios.$get(groupUrl);
       this.groups = groupRes.data;
       this.isOpenAddModal = true;
@@ -166,9 +165,9 @@ export default {
     closeSnackBar() {
       this.isOpenSnackBar = false;
     },
-    reload(id) {
-      const reUrl = "/api/v1/get_announcement_show_for_admin_view/" + id;
-      this.$axios.get(reUrl).then((res) => {
+    reload() {
+      const url = "/api/v1/get_refinement_announcements?fes_year_id=" + this.refYearID;
+      this.$axios.get(url).then((res) => {
         this.announcements.push(res.data.data);
       });
     },

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -172,6 +172,11 @@ export default {
       });
     },
     async submit() {
+      if (!this.group_id || !this.message) {
+        this.openSnackBar("参加団体と会場アナウンス文を入力してください");
+        return;
+      }
+
       const postAnnouncementUrl =
         "/announcements/" +
         "?group_id=" +

--- a/api/app/controllers/api/v1/groups_api_controller.rb
+++ b/api/app/controllers/api/v1/groups_api_controller.rb
@@ -17,7 +17,13 @@ class Api::V1::GroupsApiController < ApplicationController
 
   def get_groups_have_no_public_relation
     @current_fes_year = UserPageSetting.first.fes_year
-    @groups = Group.have_no_public_relation(@current_fes_year.id)
+    @groups = Group.f(@current_fes_year.id)
+    render json: fmt(ok, @groups)
+  end
+
+  def get_groups_have_no_announcement
+    @current_fes_year = UserPageSetting.first.fes_year
+    @groups = Group.have_no_announcement(@current_fes_year.id)
     render json: fmt(ok, @groups)
   end
 

--- a/api/app/controllers/api/v1/groups_api_controller.rb
+++ b/api/app/controllers/api/v1/groups_api_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::GroupsApiController < ApplicationController
 
   def get_groups_have_no_public_relation
     @current_fes_year = UserPageSetting.first.fes_year
-    @groups = Group.f(@current_fes_year.id)
+    @groups = Group.have_no_public_relation(@current_fes_year.id)
     render json: fmt(ok, @groups)
   end
 

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -617,9 +617,7 @@ class Group < ApplicationRecord
           |group|
           {
             "group": group,
-            "message": group.announcement.nil? ? nil : group.announcement.message,
-            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
-            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+            "announcement": group.announcement,
           }
         }
     end
@@ -631,9 +629,7 @@ class Group < ApplicationRecord
           |group|
           {
             "group": group,
-            "message": group.announcement.nil? ? nil : group.announcement.message,
-            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
-            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+            "announcement": group.announcement,
           }
         }
     end
@@ -650,9 +646,7 @@ class Group < ApplicationRecord
           |group|
           {
             "group": group,
-            "message": group.announcement.nil? ? nil : group.announcement.message,
-            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
-            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+            "announcement": group.announcement,
           }
         }
     end
@@ -664,9 +658,7 @@ class Group < ApplicationRecord
           |group|
           {
             "group": group,
-            "message": group.announcement.nil? ? nil : group.announcement.message,
-            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
-            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+            "announcement": group.announcement,
           }
         }
     end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -608,6 +608,69 @@ class Group < ApplicationRecord
         }
     end
 
+    ### announcement (アナウンス文)
+
+    # 全てのgroupとそのannouncementを取得する
+    def self.with_announcements
+      @records = Group.preload(:announcement)
+        .map{
+          |group|
+          {
+            "group": group,
+            "message": group.announcement.nil? ? nil : group.announcement.message,
+            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
+            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+          }
+        }
+    end
+
+    # 指定したIDのgroupとそのannouncementを取得する
+    def self.with_announcement(group_id)
+      @record = Group.eager_load(:announcement).where(groups: {id: group_id})
+        .map{
+          |group|
+          {
+            "group": group,
+            "message": group.announcement.nil? ? nil : group.announcement.message,
+            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
+            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+          }
+        }
+    end
+
+    # announcementが存在しないgroupのみ取得する
+    def self.have_no_announcement(fes_year_id)
+      @records = Group.eager_load(:announcement).where(groups: {fes_year_id: fes_year_id}).filter_map { |group| group if group.announcement.nil? }
+    end
+
+    # 指定したfes_yearに対応するgroupとそのannouncementを取得する
+    def self.with_announcement_narrow_down_by_fes_year(fes_year_id)
+      @record = Group.eager_load(:announcement).where(groups: {fes_year_id: fes_year_id})
+        .map{
+          |group|
+          {
+            "group": group,
+            "message": group.announcement.nil? ? nil : group.announcement.message,
+            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
+            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+          }
+        }
+    end
+
+    # 検索ワードに対応するgroupとそのannouncementを取得する
+    def self.with_announcement_narrow_down_by_search_word(word)
+      @record = Group.eager_load(:announcement).where("name like ?","%#{word}%")
+        .map{
+          |group|
+          {
+            "group": group,
+            "message": group.announcement.nil? ? nil : group.announcement.message,
+            "created_at": group.announcement.nil? ? nil : group.announcement.created_at,
+            "updated_at": group.announcement.nil? ? nil : group.announcement.updated_at,
+          }
+        }
+    end
+
     # 割り当てられたステージを取得
     def stage
       return self.group_identification.nil? || self.group_identification.stage_number.nil? ? nil : self.group_identification.stage_number.stage.name

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -154,8 +154,10 @@ Rails.application.routes.draw do
       #---会場アナウンス文申請
       get "get_announcement_index_for_admin_view" => "announcements_api#get_announcement_index_for_admin_view"
       get "get_announcement_show_for_admin_view/:id" => "announcements_api#get_announcement_show_for_admin_view"
+      get "get_announcement_for_admin_view/:id" => "announcements_api#get_announcement_for_admin_view"
       post "get_refinement_announcements" => "announcements_api#get_refinement_announcements"
       post "get_search_announcements" => "announcements_api#get_search_announcements"
+      get "get_groups_have_no_announcement" => "groups_api#get_groups_have_no_announcement"
 
       #---申請情報ページ
       get "get_order_info_for_admin_view/:id" => "order_infos_api#get_order_info_for_admin_view"


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1436

# 概要
<!-- 開発内容の概要を記載 -->
- 今までは申請済みの団体しか表示されていなかったが、全団体表示させるようにする。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 全団体取得するようにAPIを変更
- アナウンス文申請の有無によって申請状況を変更
- 未申請団体を編集してアナウンス文を追加する場合の処理を実装

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 全団体表示されているかどうか
- [x] ユーザー画面で登録したアナウンス文が管理者画面で正しく反映されているかどうか（詳細ページ）
- [x] 申請状況が正しく動いているかどうか（一覧ページ）
- [x] アナウンス文申請の一覧ページからアナウンス文を追加することができるかどうか
- [x] 詳細ページの編集でアナウンス文を編集できるかどうか（申請済み団体の場合は編集されるかどうか）
- [x] 詳細ページの編集でアナウンス文を編集できるかどうか（未申請団体の場合は追加されるかどうか）

# 備考
<!-- 実装していて困った箇所・質問など -->
