### PR TITLE
会場申請一覧で，各団体の詳細情報の読み込みを削除

### DIFF
--- a/admin_view/nuxt-project/pages/place_orders/index.vue
+++ b/admin_view/nuxt-project/pages/place_orders/index.vue
@@ -70,14 +70,6 @@
             <td>{{ placeOrder.place_order_name.first }}</td>
             <td>{{ placeOrder.place_order_name.second }}</td>
             <td>{{ placeOrder.place_order_name.third }}</td>
-            <td v-if="venueMaps != null">
-              <div v-if="venueMaps[index].venue_map === null">
-                未登録
-              </div>
-              <div v-else>
-                登録済み
-              </div>
-            </td>
           </tr>
         </template>
       </Table>
@@ -170,15 +162,13 @@ export default {
         "委員",
         "第一希望",
         "第二希望",
-        "第三希望",
-        "会場配置図"
+        "第三希望"
       ],
       isOpenAddModal: false,
       isOpenSnackBar: false,
       placeList: [],
       appGroup: "",
       placeOrders: [],
-      venueMaps: [],
       firstPlaceOrder: "",
       secondPlaceOrder: "",
       thirdPlaceOrder: "",
@@ -211,12 +201,14 @@ export default {
       currentYearRes.data.fes_year_id;
     const placeOrderRes = await $axios.$post(placeOrderUrl);
 
-    let venueMaps = [];
-    for (const res of placeOrderRes.data) {
-      const vennuMapUrl = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
-      const venueMapRes = await $axios.$get(vennuMapUrl);
-      venueMaps.push(venueMapRes.data)
-    }
+    // let venueMaps = [];
+    // for (const res of placeOrderRes.data) {
+    //   console.log(res)
+    //   const vennuMapUrl = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
+    //   const venueMapRes = await $axios.$get(vennuMapUrl);
+    //   console.log(venueMapRes)
+    //   venueMaps.push(venueMapRes.data)
+    // }
 
     const placesUrl = "/places";
     const placesRes = await $axios.$get(placesUrl);
@@ -228,10 +220,10 @@ export default {
       return element.id == currentYearRes.data.fes_year_id;
     });
 
-    console.log(venueMaps)
+    // console.log(venueMaps)
     return {
       placeOrders: placeOrderRes.data,
-      venueMaps: venueMaps,
+      // venueMaps: venueMaps,
       placeList: placesRes.data,
       yearList: yearsRes.data,
       refYearID: currentYearRes.data.fes_year_id,
@@ -281,17 +273,17 @@ export default {
         this.refCategoryID;
       const refRes = await this.$axios.$post(refUrl);
       this.placeOrders = [];
-      this.venueMaps = [];
+      // this.venueMaps = [];
       for (const res of refRes.data) {
         const url = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
         const response = await this.$axios.$get(url);
         this.placeOrders.push(res);
-        this.venueMaps.push(response.data);
+        // this.venueMaps.push(response.data);
       };
     },
     async searchPlaceOrders() {
       this.placeOrders = [];
-      this.venueMaps = [];
+      // this.venueMaps = [];
       const searchUrl =
         "/api/v1/get_search_place_orders?word=" + this.searchText;
       const refRes = await this.$axios.$post(searchUrl);
@@ -299,7 +291,7 @@ export default {
         const url = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
         const response = await this.$axios.$get(url);
         this.placeOrders.push(res);
-        this.venueMaps.push(response.data);
+        // this.venueMaps.push(response.data);
       }
     },
     async openAddModal() {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolve #1515 

# 概要
<!-- 開発内容の概要を記載 -->
- 会場申請一覧で，会場配置図が `登録済` か `未登録` を表示するために，各団体の詳細情報を読み込んでいたため，一覧ページの表示が遅かった．
- 一覧ページでは，各団体の詳細情報の読み込みを削除した．

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- venueMapの部分を削除

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/NUTFes/group-manager-2/assets/95607264/d076c8ca-9515-476e-8f57-7d513fb47b8d)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 会場申請の表に，会場配置図の登録 / 未登録 の列が削除されているか．
- [ ] 読み込みが速くなっているかどうか．

# 備考
<!-- 実装していて困った箇所・質問など -->
