### PR TITLE
会場申請一覧で，会場図の読み込みを削除

### DIFF
--- a/admin_view/nuxt-project/pages/place_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/place_orders/_id.vue
@@ -50,20 +50,6 @@
               <th>第三希望</th>
               <td>{{ placeOrder.place_order_name.third }}</td>
             </tr>
-            <!-- <tr>
-              <th>会場配置図</th>
-              <td>
-                <div v-if="placeOrder.venue_map === null">
-                  未登録
-                </div>
-                <div v-else>
-                  <img
-                    :src="placeOrder.venue_map.picture_path"
-                    style="width: 80%; height: 80%"
-                  />
-                </div>
-              </td>
-            </tr> -->
             <tr>
               <th>備考</th>
               <td>{{ placeOrder.place_order.remark }}</td>

--- a/admin_view/nuxt-project/pages/place_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/place_orders/_id.vue
@@ -50,7 +50,7 @@
               <th>第三希望</th>
               <td>{{ placeOrder.place_order_name.third }}</td>
             </tr>
-            <tr>
+            <!-- <tr>
               <th>会場配置図</th>
               <td>
                 <div v-if="placeOrder.venue_map === null">
@@ -63,7 +63,7 @@
                   />
                 </div>
               </td>
-            </tr>
+            </tr> -->
             <tr>
               <th>備考</th>
               <td>{{ placeOrder.place_order.remark }}</td>

--- a/admin_view/nuxt-project/pages/place_orders/index.vue
+++ b/admin_view/nuxt-project/pages/place_orders/index.vue
@@ -70,14 +70,6 @@
             <td>{{ placeOrder.place_order_name.first }}</td>
             <td>{{ placeOrder.place_order_name.second }}</td>
             <td>{{ placeOrder.place_order_name.third }}</td>
-            <td v-if="venueMaps != null">
-              <div v-if="venueMaps[index].venue_map === null">
-                未登録
-              </div>
-              <div v-else>
-                登録済み
-              </div>
-            </td>
           </tr>
         </template>
       </Table>
@@ -170,15 +162,13 @@ export default {
         "委員",
         "第一希望",
         "第二希望",
-        "第三希望",
-        "会場配置図"
+        "第三希望"
       ],
       isOpenAddModal: false,
       isOpenSnackBar: false,
       placeList: [],
       appGroup: "",
       placeOrders: [],
-      venueMaps: [],
       firstPlaceOrder: "",
       secondPlaceOrder: "",
       thirdPlaceOrder: "",
@@ -211,12 +201,14 @@ export default {
       currentYearRes.data.fes_year_id;
     const placeOrderRes = await $axios.$post(placeOrderUrl);
 
-    let venueMaps = [];
-    for (const res of placeOrderRes.data) {
-      const vennuMapUrl = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
-      const venueMapRes = await $axios.$get(vennuMapUrl);
-      venueMaps.push(venueMapRes.data)
-    }
+    // let venueMaps = [];
+    // for (const res of placeOrderRes.data) {
+    //   console.log(res)
+    //   const vennuMapUrl = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
+    //   const venueMapRes = await $axios.$get(vennuMapUrl);
+    //   console.log(venueMapRes)
+    //   venueMaps.push(venueMapRes.data)
+    // }
 
     const placesUrl = "/places";
     const placesRes = await $axios.$get(placesUrl);
@@ -228,10 +220,10 @@ export default {
       return element.id == currentYearRes.data.fes_year_id;
     });
 
-    console.log(venueMaps)
+    // console.log(venueMaps)
     return {
       placeOrders: placeOrderRes.data,
-      venueMaps: venueMaps,
+      // venueMaps: venueMaps,
       placeList: placesRes.data,
       yearList: yearsRes.data,
       refYearID: currentYearRes.data.fes_year_id,
@@ -281,17 +273,17 @@ export default {
         this.refCategoryID;
       const refRes = await this.$axios.$post(refUrl);
       this.placeOrders = [];
-      this.venueMaps = [];
+      // this.venueMaps = [];
       for (const res of refRes.data) {
         const url = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
         const response = await this.$axios.$get(url);
         this.placeOrders.push(res);
-        this.venueMaps.push(response.data);
+        // this.venueMaps.push(response.data);
       };
     },
     async searchPlaceOrders() {
       this.placeOrders = [];
-      this.venueMaps = [];
+      // this.venueMaps = [];
       const searchUrl =
         "/api/v1/get_search_place_orders?word=" + this.searchText;
       const refRes = await this.$axios.$post(searchUrl);
@@ -299,7 +291,7 @@ export default {
         const url = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
         const response = await this.$axios.$get(url);
         this.placeOrders.push(res);
-        this.venueMaps.push(response.data);
+        // this.venueMaps.push(response.data);
       }
     },
     async openAddModal() {

--- a/admin_view/nuxt-project/pages/place_orders/index.vue
+++ b/admin_view/nuxt-project/pages/place_orders/index.vue
@@ -201,15 +201,6 @@ export default {
       currentYearRes.data.fes_year_id;
     const placeOrderRes = await $axios.$post(placeOrderUrl);
 
-    // let venueMaps = [];
-    // for (const res of placeOrderRes.data) {
-    //   console.log(res)
-    //   const vennuMapUrl = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
-    //   const venueMapRes = await $axios.$get(vennuMapUrl);
-    //   console.log(venueMapRes)
-    //   venueMaps.push(venueMapRes.data)
-    // }
-
     const placesUrl = "/places";
     const placesRes = await $axios.$get(placesUrl);
 
@@ -220,10 +211,8 @@ export default {
       return element.id == currentYearRes.data.fes_year_id;
     });
 
-    // console.log(venueMaps)
     return {
       placeOrders: placeOrderRes.data,
-      // venueMaps: venueMaps,
       placeList: placesRes.data,
       yearList: yearsRes.data,
       refYearID: currentYearRes.data.fes_year_id,
@@ -273,17 +262,14 @@ export default {
         this.refCategoryID;
       const refRes = await this.$axios.$post(refUrl);
       this.placeOrders = [];
-      // this.venueMaps = [];
       for (const res of refRes.data) {
         const url = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
         const response = await this.$axios.$get(url);
         this.placeOrders.push(res);
-        // this.venueMaps.push(response.data);
       };
     },
     async searchPlaceOrders() {
       this.placeOrders = [];
-      // this.venueMaps = [];
       const searchUrl =
         "/api/v1/get_search_place_orders?word=" + this.searchText;
       const refRes = await this.$axios.$post(searchUrl);
@@ -291,7 +277,6 @@ export default {
         const url = "/api/v1/get_place_order_show_for_admin_view/" + res.place_order.id;
         const response = await this.$axios.$get(url);
         this.placeOrders.push(res);
-        // this.venueMaps.push(response.data);
       }
     },
     async openAddModal() {

--- a/admin_view/nuxt-project/pages/stage_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/_id.vue
@@ -54,18 +54,6 @@
             <td>{{ stageOrder.stage_order_info.stage_second }}</td>
           </tr>
           <tr>
-            <th>会場配置図</th>
-            <td>
-              <div v-if="stageOrder.venue_map === null">未登録</div>
-              <div v-else>
-                <img
-                  :src="stageOrder.venue_map.picture_path"
-                  style="width: 80%; height: 80%"
-                />
-              </div>
-            </td>
-          </tr>
-          <tr>
             <th>準備時間幅</th>
             <td>{{ stageOrder.stage_order_info.prepare_time_interval }}</td>
           </tr>

--- a/admin_view/nuxt-project/pages/stage_orders/index.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/index.vue
@@ -84,11 +84,6 @@
             <td>{{ stageOrder.stage_order_info.date }}</td>
             <td>{{ stageOrder.stage_order_info.stage_first }}</td>
             <td>{{ stageOrder.stage_order_info.stage_second }}</td>
-            <td v-if="venueMaps[index]">
-              <div v-if="venueMaps[index].venue_map === null">未登録</div>
-              <div v-else>登録済み</div>
-            </td>
-            <td v-else>会場配置図を読み込めません</td>
           </tr>
         </template>
       </Table>
@@ -246,12 +241,10 @@ export default {
         "希望日",
         "第一希望",
         "第二希望",
-        "会場配置図",
       ],
       isOpenAddModal: false,
       isOpenSnackBar: false,
       isIntervalMode: true,
-      venueMaps: [],
       isSunnyList: [
         { id: 1, text: "はい", value: true },
         { id: 2, text: "いいえ", value: false },
@@ -339,14 +332,6 @@ export default {
 
     const stageOrdersRes = await $axios.$post(url);
 
-    let venueMaps = [];
-    for (const res of stageOrdersRes.data) {
-      const vennuMapUrl =
-        "/api/v1/get_stage_order_show_for_admin_view/" + res.stage_order.id;
-      const venueMapRes = await $axios.$get(vennuMapUrl);
-      venueMaps.push(venueMapRes.data);
-    }
-
     const yearsUrl = "/fes_years";
     const yearsRes = await $axios.$get(yearsUrl);
     const stagesUrl = "/stages";
@@ -360,7 +345,6 @@ export default {
       refYearID: currentYearRes.data.fes_year_id,
       refYears: currentYears[0].year_num,
       stageList: stagesRes.data,
-      venueMaps: venueMaps,
     };
   },
   mounted() {
@@ -425,7 +409,6 @@ export default {
         }
       }
       this.stageOrders = [];
-      this.venueMaps = [];
       const refUrl =
         "/api/v1/get_refinement_stage_orders?fes_year_id=" +
         this.refYearID +
@@ -441,12 +424,10 @@ export default {
           "/api/v1/get_stage_order_show_for_admin_view/" + res.stage_order.id;
         const response = await this.$axios.$get(url);
         this.stageOrders.push(res);
-        this.venueMaps.push(response.data);
       }
     },
     async searchStageOrders() {
       this.stageOrders = [];
-      this.venueMaps = [];
       const searchUrl =
         "/api/v1/get_search_stage_orders?word=" + this.searchText;
       const refRes = await this.$axios.$post(searchUrl);
@@ -455,7 +436,6 @@ export default {
           "/api/v1/get_stage_order_show_for_admin_view/" + res.stage_order.id;
         const response = await this.$axios.$get(url);
         this.stageOrders.push(res);
-        this.venueMaps.push(response.data);
       }
     },
     openSnackBar(message) {

--- a/api/app/models/place_order.rb
+++ b/api/app/models/place_order.rb
@@ -20,7 +20,6 @@ class PlaceOrder < ApplicationRecord
         "place_order": place_order,
         "place_order_name": place_order.to_place_name_h,
         "group": place_order.group,
-        "venue_map": place_order.group.venue_map 
       }
     end
 

--- a/api/app/models/stage_order.rb
+++ b/api/app/models/stage_order.rb
@@ -20,8 +20,7 @@ class StageOrder < ApplicationRecord
       return {
         "stage_order": stage_order,
         "stage_order_info": stage_order.to_info_h,
-        "group": stage_order.group,
-        "venue_map": stage_order.group.venue_map 
+        "group": stage_order.group
       }
     end
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolve #1515 

# 概要
<!-- 開発内容の概要を記載 -->
- 会場申請一覧で，会場配置図が `登録済` か `未登録` を表示するために，各団体の詳細情報を読み込んでいたため，一覧ページの表示が遅かった．
- 一覧ページでは，各団体の詳細情報の読み込みを削除した．

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- venueMapの部分を削除

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/NUTFes/group-manager-2/assets/95607264/d076c8ca-9515-476e-8f57-7d513fb47b8d)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 会場申請の表に，会場配置図の登録 / 未登録 の列が削除されているか．
- [x] 読み込みが速くなっているかどうか．

# 備考
<!-- 実装していて困った箇所・質問など -->
