### PR TITLE
アナウンス文のバリデーションを追加

### DIFF
--- a/admin_view/nuxt-project/pages/announcement/_id.vue
+++ b/admin_view/nuxt-project/pages/announcement/_id.vue
@@ -70,7 +70,8 @@
         </div>
       </template>
       <template v-slot:method>
-        <CommonButton iconName="edit" :on_click="edit">登録</CommonButton>
+        <div v-if="isMessageOver" style="color: red;">アナウンス文は300字以内で入力してください。</div>
+        <CommonButton iconName="edit" :on_click="edit" :disabled="isMessageOver">登録</CommonButton>
       </template>
     </EditModal>
 
@@ -113,6 +114,9 @@ export default {
     ...mapState({
       roleID: (state) => state.users.role,
     }),
+    isMessageOver() {
+      return this.message.length > 300;
+    },
   },
   async asyncData({ $axios, route }) {
     const routeId = route.path.replace("/announcement/", "");

--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -89,7 +89,8 @@
         </div>
       </template>
       <template v-slot:method>
-        <CommonButton iconName="add_circle" :on_click="submit"
+        <div v-if="isMessageOver" style="color: red;">アナウンス文は300字以内で入力してください。</div>
+        <CommonButton iconName="add_circle" :on_click="submit" :disabled="isMessageOver"
           >登録</CommonButton
         >
       </template>
@@ -145,6 +146,9 @@ export default {
     ...mapState({
       roleID: (state) => state.users.role,
     }),
+    isMessageOver() {
+      return this.message.length > 300;
+    },
   },
   mounted() {
     window.addEventListener('scroll', this.saveScrollPosition);

--- a/user_front/locales/en.json
+++ b/user_front/locales/en.json
@@ -84,7 +84,8 @@
     "editAnnouncement": "Editing of venue announcement text",
     "text": "Announcement text at the venue",
     "edit": "editing",
-    "regist": "registing"
+    "regist": "registing",
+    "over": "This announcement text is over 125 words."
   },
 
   "VenueMap": {

--- a/user_front/locales/ja.json
+++ b/user_front/locales/ja.json
@@ -83,7 +83,8 @@
     "editAnnouncement": "会場アナウンス文の編集",
     "text": "会場アナウンス文",
     "edit": "編集",
-    "regist": "登録"
+    "regist": "登録",
+    "over": "300文字を超えています"
   },
 
   "VenueMap": {

--- a/user_front/pages/mypage/edit_announcement/index.vue
+++ b/user_front/pages/mypage/edit_announcement/index.vue
@@ -10,6 +10,11 @@ interface Announcement {
 }
 
 const router = useRouter();
+const state = reactive({
+  groupId: 0,
+  language: "",
+});
+
 
 const currentAnnouncement = ref<Announcement>();
 const config = useRuntimeConfig();
@@ -20,6 +25,7 @@ const isEditAnnouncement = ref<boolean>();
 onMounted(async () => {
   // ログインしていない場合は/welcomeに遷移させる
   loginCheck();
+  state.language = localStorage.getItem("local") || "";
   groupId.value = Number(localStorage.getItem("group_id"));
 
   const getAnnouncementUrl = "/announcements";
@@ -47,6 +53,16 @@ onMounted(async () => {
     .then((response) => {
       isEditAnnouncement.value = response.data.data[0].is_edit_announcement;
     });
+});
+
+// アナウンス文のバリデーションチェック300字より多いか
+const isMessageOver = computed(() => {
+  if (state.language == "en") {
+    const messageEng = message.value.split(" ");
+    return messageEng.length > 125;
+  } else {
+    return message.value.length > 300;
+  }
 });
 
 const postAnnouncement = () => {
@@ -95,12 +111,14 @@ const postAnnouncement = () => {
     <Card>
       <div class="text-left">
         <span class="text-3xl mr-4">{{ $t("Announcement.text") }}</span>
+        <p v-if="isMessageOver" class="text-red-500 text-sm">{{ $t("Announcement.over") }}</p>
       </div>
       <textarea class="border-2 w-[60%]" v-model="message"></textarea>
       <RegistPageButton
         v-if="isEditAnnouncement"
         :text="$t('Announcement.edit')"
         @click="postAnnouncement"
+        :disabled="isMessageOver"
       ></RegistPageButton>
     </Card>
   </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1546

# 概要
<!-- 開発内容の概要を記載 -->
- バリデーションがなくて非常に危険で危ないものでジャックされる可能性があるのでつけた。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- user_frontは言語切り替えがあるため、localsにAnnouncement.overを追加した。
- user_frontに英語なら125words、日本語なら300文字のバリデーションを追加した
- admin_viewはpageと_idの画面に追加と編集があったのでそれぞれにバリデーションを追加した

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 会場アナウンス文申請の追加のアナウンス文にバリデーションがついているか
- [x] 会場アナウンス文申請の編集のアナウンス文にバリデーションがついているか
- [x] アナウンス文編集にバリデーションがかかっているか(日本語、英語)

# 備考
<!-- 実装していて困った箇所・質問など -->
