### PR TITLE
[fix]申請一覧状況ページ/保険所提出書類の権限対応とダッシュボードのレイアウト修正

### DIFF
--- a/admin_view/nuxt-project/components/UsersCard.vue
+++ b/admin_view/nuxt-project/components/UsersCard.vue
@@ -6,19 +6,19 @@
     <div class="users-card-content">
       <h1>{{ dashboardData.all_user_num }}</h1>
       <Row>
-        <Tag primaryColor="#FF7070" secondaryColor="#E38AD5"
+        <Tag primaryColor="#FF7070" secondaryColor="#E38AD5" 
           >{{ dashboardData.developer_num }} Developers</Tag
         >
-        <Tag primaryColor="#8FEE8D" secondaryColor="#E3D08A"
+        <Tag primaryColor="#8FEE8D" secondaryColor="#E3D08A" width = auto
           >{{ dashboardData.participant_num }} Participants</Tag
         >
-        <Tag primaryColor="#9C8AE3" secondaryColor="#70FFDD"
+        <Tag primaryColor="#9C8AE3" secondaryColor="#70FFDD" width = auto
           >{{ dashboardData.inventory_management_num }} Inventory_Managers</Tag
         >
-        <Tag primaryColor="#ffce56" secondaryColor="#d6ff33"
+        <Tag primaryColor="#ffce56" secondaryColor="#d6ff33" width = auto
           >{{ dashboardData.venue_power_num }} Venue_Power_Managers</Tag
         >
-        <Tag primaryColor="#ffce56" secondaryColor="#d6ff33"
+        <Tag primaryColor="#ffce56" secondaryColor="#d6ff33" width = auto
           >{{ dashboardData.sanitation_management_num }} Sanitation_Managers</Tag
         >
         <Tag primaryColor="#ffce56" secondaryColor="#d6ff33"

--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="main-content">
+    <div class="main-content" v-if="this.$role(roleID).order_status.read">
       <SubHeader pageTitle="申請状況一覧"></SubHeader>
 
       <SubSubHeader>
@@ -97,6 +97,7 @@
       </Card>
 
     </div>
+    <h1 v-else>閲覧権限がありません</h1>
   </template>
 
   <script>

--- a/admin_view/nuxt-project/pages/print/index.vue
+++ b/admin_view/nuxt-project/pages/print/index.vue
@@ -92,7 +92,7 @@
             </InTableButton>
           </td>
         </tr>
-        <tr>
+        <tr v-if="this.$role(roleID).food_products.read">
           <td>保健所提出書類（調理計画・従事者）</td>
           <td>
             <InTableButton iconName="file_download" :on_click="downloadHealthOfficeDocumentsPDF">PDF</InTableButton>

--- a/admin_view/nuxt-project/plugins/role/developer.js
+++ b/admin_view/nuxt-project/plugins/role/developer.js
@@ -179,4 +179,10 @@ export const developerRole = {
     update: true,
     delete: true,
   },
+  order_status: {
+    read:   true,
+    create: true,
+    update: true,
+    delete: true,
+  },
 };

--- a/admin_view/nuxt-project/plugins/role/inventory_management.js
+++ b/admin_view/nuxt-project/plugins/role/inventory_management.js
@@ -179,5 +179,11 @@ export const inventoryManagementRole = {
         update: false,
         delete: false,
       },
+      order_status: {
+        read:   true,
+        create: true,
+        update: true,
+        delete: true,
+      },
   };
   

--- a/admin_view/nuxt-project/plugins/role/participant.js
+++ b/admin_view/nuxt-project/plugins/role/participant.js
@@ -179,5 +179,11 @@ export const participantRole = {
         update: false,
         delete: false,
       },
+      order_status: {
+        read:   true,
+        create: true,
+        update: true,
+        delete: true,
+      },
   };
   

--- a/admin_view/nuxt-project/plugins/role/sanitation_management.js
+++ b/admin_view/nuxt-project/plugins/role/sanitation_management.js
@@ -179,5 +179,11 @@ export const sanitationManagementRole = {
         update: false,
         delete: false,
       },
+      order_status: {
+        read:   true,
+        create: true,
+        update: true,
+        delete: true,
+      },
   };
   

--- a/admin_view/nuxt-project/plugins/role/staff.js
+++ b/admin_view/nuxt-project/plugins/role/staff.js
@@ -179,5 +179,11 @@ export const staffRole = {
         update: false,
         delete: false,
       },
+      order_status: {
+        read:   true,
+        create: true,
+        update: true,
+        delete: true,
+      },
   };
   

--- a/admin_view/nuxt-project/plugins/role/user.js
+++ b/admin_view/nuxt-project/plugins/role/user.js
@@ -179,4 +179,10 @@ export const userRole = {
     update: false,
     delete: false,
   },
+  order_status: {
+    read:   false,
+    create: false,
+    update: false,
+    delete: false,
+  },
 };

--- a/admin_view/nuxt-project/plugins/role/venue_power.js
+++ b/admin_view/nuxt-project/plugins/role/venue_power.js
@@ -179,5 +179,11 @@ export const venuePowerRole = {
         update: true,
         delete: true,
       },
+      order_status: {
+        read:   true,
+        create: true,
+        update: true,
+        delete: true,
+      },
   };
   


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1565

# 概要
<!-- 開発内容の概要を記載 -->
- 申請一覧状況ページの閲覧権限追加(User以外は見られる)
- 保険所提出書類の印刷権限追加(sanitation_managementとdeveloperのみ可)
- ダッシュボードのユーザー数一覧のレイアウト修正 (プレートの横幅を伸ばしてプレート内改行防止)

# 実装詳細
<!-- 具体的な開発内容を記載 -->


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- User以外のすべての権限で申請一覧状況ページが見られるか
- 書類印刷ページで対応した権限でだけ保健所提出書類の項目が表示されるか
- ダッシュボードのユーザー数のところで、長い名前の分類(Participantなど)でもプレート内で改行されずに表示されているか

# 備考
<!-- 実装していて困った箇所・質問など -->
ユーザーの種類が4から7に増えているので、プレートも7色にしないといけなくなった
