### PR TITLE
食品販売の場合のみ調理工程へのリンクを表示する

### DIFF
--- a/user_front/pages/mypage/index.vue
+++ b/user_front/pages/mypage/index.vue
@@ -58,7 +58,6 @@ const links: { to: string; text: string }[] = [
 const linksGroupCategoryId_1 = [...links,  { to: "/mypage/edit_cooking_process", text: "Mypage.editCookingProcess"}]
 
 
-console.log("registGroupCategoryId",registGroupCategoryId)
 
 const shouldDisplayLink = (link: { to: string; text: string }) => {
   return link.text !== "Mypage.editContactPerson" || is_external.value;

--- a/user_front/pages/mypage/index.vue
+++ b/user_front/pages/mypage/index.vue
@@ -11,8 +11,11 @@ const registGroupId = ref<number>(0);
 const registGroupCategoryId = ref<number>(0);
 const config = useRuntimeConfig();
 const is_external = ref<boolean>(false);
+const isLoading = ref(true); // ローディング状態を管理するフラグ
+
 
 onMounted(async () => {
+  isLoading.value = true; // データ取得開始時にローディングを true に設定
   loginCheck();
   await $fetch<RegistInfo>(
     config.APIURL + "/api/v1/current_user/current_regist_info",
@@ -34,11 +37,13 @@ onMounted(async () => {
       registGroupCategoryId.value.toString()
     );
   });
+  isLoading.value = false; // データ取得終了時にローディングを false に設定
   await loginCheck();
   const currentUser = await getCurrentUser();
   state.currentUserName = currentUser?.data.user.name || "";
 });
 
+// 食品販売を行う団体のみが、mypage/edit_cooking_processにいけるようにする
 const links: { to: string; text: string }[] = [
   { to: "/mypage/edit_group", text: "Mypage.editGroup" },
   { to: "/mypage/publicRelations", text: "Mypage.editPR" },
@@ -47,12 +52,20 @@ const links: { to: string; text: string }[] = [
   { to: "/mypage/password_reset", text: "Mypage.editPassword" },
   { to: "/mypage/edit_announcement", text: "Mypage.editAnnouncemant" },
   { to: "/mypage/edit_contact_person", text: "Mypage.editContactPerson" },
-  { to: "/mypage/edit_cooking_process", text: "Mypage.editCookingProcess"},
 ];
+
+// 食品販売用のリストを作る
+const linksGroupCategoryId_1 = [...links,  { to: "/mypage/edit_cooking_process", text: "Mypage.editCookingProcess"}]
+
+
+console.log("registGroupCategoryId",registGroupCategoryId)
 
 const shouldDisplayLink = (link: { to: string; text: string }) => {
   return link.text !== "Mypage.editContactPerson" || is_external.value;
 }
+
+
+
 </script>
 
 <template>
@@ -76,9 +89,19 @@ const shouldDisplayLink = (link: { to: string; text: string }) => {
               {{ $t("Mypage.operations") }}
             </p>
           </div>
-          <div class="flex flex-col gap-4 items-center">
+          <!-- データを取り出してからリンクを表示する -->
+          <div v-if="isLoading===false" class="flex flex-col gap-4 items-center">
             <MypageButton :text="$t('Mypage.check')" link="/regist_info" />
-            <div class="grid md:grid-cols-2 justify-items-center my-2 gap-2 text-pink-400">
+              <!-- 食品販売団体の場合 -->
+            <div v-if="registGroupCategoryId === 1" class="grid md:grid-cols-2 justify-items-center my-2 gap-2 text-pink-400">
+              <ui v-for="linkCook in linksGroupCategoryId_1" :key="linkCook.text">
+                <nuxt-link v-if="shouldDisplayLink(linkCook)" :to="linkCook.to" class="text-lg">{{
+                  $t(linkCook.text)
+                }}</nuxt-link>
+              </ui>
+            </div>
+            <!-- それ以外の場合 -->
+            <div v-else class="grid md:grid-cols-2 justify-items-center my-2 gap-2 text-pink-400">
               <ui v-for="link in links" :key="link.text">
                 <nuxt-link v-if="shouldDisplayLink(link)" :to="link.to" class="text-lg">{{
                   $t(link.text)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1602 

# 概要
<!-- 開発内容の概要を記載 -->
- 食品販売の団体のみ、調理工程申請へのリンクを表示させた

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- user_front/pages/mypage/index.vueのlinksを修正
- ハイドレーションエラーをついでに解決

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 食品販売の団体のみ、調理工程申請というリンクが表示されるか
- [x] consoleにハイドレーションエラーが出ていないか

# 備考
<!-- 実装していて困った箇所・質問など -->
