### PR TITLE
[feat]販売品申請ページの食販と物販のフィルター追加

### DIFF
--- a/admin_view/nuxt-project/pages/food_products/_id.vue
+++ b/admin_view/nuxt-project/pages/food_products/_id.vue
@@ -4,10 +4,18 @@
       v-bind:pageTitle="foodProduct.food_product.name"
       pageSubTitle="販売品申請一覧"
     >
-      <CommonButton v-if="this.$role(this.roleID).food_products.update" iconName="edit" :on_click="openEditModal">
+      <CommonButton
+        v-if="this.$role(this.roleID).food_products.update"
+        iconName="edit"
+        :on_click="openEditModal"
+      >
         編集
       </CommonButton>
-      <CommonButton v-if="this.$role(this.roleID).food_products.delete" iconName="delete" :on_click="openDeleteModal">
+      <CommonButton
+        v-if="this.$role(this.roleID).food_products.delete"
+        iconName="delete"
+        :on_click="openDeleteModal"
+      >
         削除
       </CommonButton>
     </SubHeader>
@@ -39,7 +47,10 @@
           </tr>
           <tr>
             <th>調理の有無</th>
-            <td>{{ foodProduct.food_product.is_cooking }}</td>
+            <td>
+              <div v-if="foodProduct.food_product.is_cooking">○</div>
+              <div v-else-if="!foodProduct.food_product.is_cooking">✖</div>
+            </td>
           </tr>
           <tr>
             <th>登録日時</th>

--- a/admin_view/nuxt-project/pages/food_products/index.vue
+++ b/admin_view/nuxt-project/pages/food_products/index.vue
@@ -171,9 +171,9 @@ export default {
       foodProducts: [],
       refYears: "Year",
       refYearID: 0,
-      refIsCooking: "調理あり/なし",
+      refIsCooking: "ALL",
       refIsCookingID: 0,
-      refCategory: "食品/物品販売",
+      refCategory: "ALL",
       refCategoryID: 0,
       searchText: "",
       groupID: null,
@@ -229,7 +229,7 @@ export default {
       this.refIsCookingID = Number(storedIsCookingID);
       this.updateFilters(this.refIsCookingID, this.isCookingList);
     } else {
-      this.refIsCooking = "調理あり/なし";
+      this.refIsCooking = "ALL";
     }
 
     const storedCategoryID = localStorage.getItem(
@@ -239,7 +239,7 @@ export default {
       this.refCategoryID = Number(storedCategoryID);
       this.updateFilters(this.refCategoryID, this.CategoryList);
     } else {
-      this.refCategory = "食品/物品販売";
+      this.refCategory = "ALL";
     }
 
     const storedSearchText = localStorage.getItem(
@@ -290,7 +290,7 @@ export default {
         this.refIsCookingID = item_id;
         // ALLの時
         if (item_id === 0) {
-          this.refIsCooking = "調理あり/なし";
+          this.refIsCooking = "ALL";
         } else {
           this.refIsCooking = name_list[item_id - 1].text;
         }
@@ -300,7 +300,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id === 0) {
-          this.refCategory = "食品/物品販売";
+          this.refCategory = "ALL";
         } else {
           this.refCategory = name_list[item_id - 1].text;
         }


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #1545 

# 概要
<!-- 開発内容の概要を記載 -->
- 管理者サイトの販売品申請ページでグループカテゴリ(食品販売・物品販売)のフィルターを追加した
- 検索とフィルターを組み合わせて絞り込めるように修正した

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 食品/物品販売のドロップダウンの追加
- APIの修正 `/api/v1/get_refinement_food_products` 
  - 食品販売・物品販売の絞り込み
  - 検索文字列の絞り込みの追加

# 画面スクリーンショット等
絞り込み追加
<img width="1179" alt="スクリーンショット 2024-05-13 13 09 03" src="https://github.com/NUTFes/group-manager-2/assets/115447919/3ce9ac21-4ceb-43e9-bb64-ba1f0fe0931f">
食品販売の絞り込み
<img width="1179" alt="スクリーンショット 2024-05-13 13 09 11" src="https://github.com/NUTFes/group-manager-2/assets/115447919/7b60e076-4061-4fef-811d-13facde98f68">
物品販売の絞り込み
<img width="1179" alt="スクリーンショット 2024-05-13 13 09 18" src="https://github.com/NUTFes/group-manager-2/assets/115447919/92fe5fb8-fdac-45c2-ab3e-a850cf9a20e0">
検索文字列とフィルタの絞り込み
<img width="1179" alt="スクリーンショット 2024-05-13 13 18 06" src="https://github.com/NUTFes/group-manager-2/assets/115447919/e35cace4-184f-4c08-8d8b-c2a2c671021b">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 管理者サイトの販売品申請ページ`/food_products`で食品/物品販売のフィルタが追加されているか
- [x] 食品/物品販売の絞り込みが正しく機能するか(グループのカテゴリは参加団体申請ページで確認してください)
- [x] 検索文字列とフィルタを組み合わせて絞り込みが機能するか
- [x] ページを移動しても、絞り込みが残るか
- [x] フィルタを複数組み合わせても結果が正しいか

# 備考
<!-- 実装していて困った箇所・質問など -->
