### PR TITLE
申請状況一覧の年度、カテゴリ、学外、国際のフィルタのバグ修正

### DIFF
--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="main-content" v-if="this.$role(roleID).order_status.read">
-      <SubHeader pageTitle="申請状況一覧"></SubHeader>
+  <div class="main-content" v-if="this.$role(roleID).order_status.read">
+    <SubHeader pageTitle="申請状況一覧"></SubHeader>
 
     <SubSubHeader>
       <template v-slot:refinement>
@@ -46,80 +46,90 @@
       </template>
     </SubSubHeader>
 
-      <Card width="100%" >
-        <Table>
-          <template v-slot:table-header>
-            <th v-for="(header, index) in headers" :key="index">
-              {{ header }}
-            </th>
-          </template>
-          <template v-slot:table-body>
-            <tr
-              v-for="(group, index) in groups"
-              :key="index"
+    <Card width="100%">
+      <Table>
+        <template v-slot:table-header>
+          <th v-for="(header, index) in headers" :key="index">
+            {{ header }}
+          </th>
+        </template>
+        <template v-slot:table-body>
+          <tr v-for="(group, index) in groups" :key="index">
+            <td>{{ group.group.id }}</td>
+            <td>{{ group.group.name }}</td>
+            <td :class="{ unregistered: !group.sub_rep }">
+              <div v-if="group.sub_rep">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.place_order }">
+              <div v-if="group.place_order">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.power_orders }">
+              <div v-if="group.power_orders">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.rental_orders }">
+              <div v-if="group.rental_orders">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.stage_orders }">
+              <div v-if="group.stage_orders">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.stage_common_option }">
+              <div v-if="group.stage_common_option">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.employees }">
+              <div v-if="group.employees">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.food_products }">
+              <div
+                v-if="group.food_products && group.food_products.food_product"
+              >
+                ◯
+              </div>
+              <div v-else>✖️</div>
+            </td>
+            <td
+              :class="{
+                unregistered: !(
+                  group.food_products && group.food_products.purchase_lists
+                ),
+              }"
             >
-              <td>{{ group.group.id }}</td>
-              <td>{{ group.group.name}}</td>
-              <td :class="{unregistered: !group.sub_rep}">
-                <div v-if='group.sub_rep'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.place_order}">
-                <div v-if='group.place_order'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.power_orders}">
-                <div v-if='group.power_orders'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.rental_orders}">
-                <div v-if='group.rental_orders'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.stage_orders}">
-                <div v-if='group.stage_orders'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.stage_common_option}">
-                <div v-if='group.stage_common_option'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.employees}">
-                <div v-if='group.employees'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.food_products}">
-                <div v-if='group.food_products && group.food_products.food_product'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !(group.food_products && group.food_products.purchase_lists)}">
-                <div v-if='group.food_products && group.food_products.purchase_lists'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.public_relation}">
-                <div v-if='group.public_relation'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.announucement}">
-                <div v-if='group.announucement'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.venue_map}">
-                <div v-if='group.venue_map'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-              <td :class="{unregistered: !group.cooking_process_order}">
-                <div v-if='group.cooking_process_order'>◯</div>
-                <div v-else>✖️</div>
-              </td>
-            </tr>
-          </template>
-        </Table>
-      </Card>
-
-    </div>
-    <h1 v-else>閲覧権限がありません</h1>
-  </template>
+              <div
+                v-if="group.food_products && group.food_products.purchase_lists"
+              >
+                ◯
+              </div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.public_relation }">
+              <div v-if="group.public_relation">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.announucement }">
+              <div v-if="group.announucement">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.venue_map }">
+              <div v-if="group.venue_map">◯</div>
+              <div v-else>✖️</div>
+            </td>
+            <td :class="{ unregistered: !group.cooking_process_order }">
+              <div v-if="group.cooking_process_order">◯</div>
+              <div v-else>✖️</div>
+            </td>
+          </tr>
+        </template>
+      </Table>
+    </Card>
+  </div>
+  <h1 v-else>閲覧権限がありません</h1>
+</template>
 
 <script>
 import { mapState } from "vuex";
@@ -153,11 +163,11 @@ export default {
       external: false,
       refYears: "Years",
       refYearID: 0,
-      refGroupCategories: "Categories",
+      refGroupCategories: "ALL",
       refCategoryID: 0,
-      refInternational: "国際",
+      refInternational: "ALL",
       refInternationalID: 0,
-      refExternal: "学外",
+      refExternal: "ALL",
       refExternalID: 0,
       groupCategories: [],
       searchText: "",
@@ -185,26 +195,94 @@ export default {
       return element.id == currentYearRes.data.fes_year_id;
     });
 
-      return {
-        groups: groupsRes.data,
-        yearList: yearsRes.data,
-        refYearID: currentYearRes.data.fes_year_id,
-        refYears: currentYears[0].year_num,
-      };
-    },
-    computed: {
-      ...mapState({
-        roleID: (state) => state.users.role,
-      }),
-    },
-    mounted() {
-      this.refinementgroups(this.refYearID, this.yearList);
+    return {
+      groups: groupsRes.data,
+      groupCategories: groupCategoryRes.data,
+      yearList: yearsRes.data,
+      refYearID: currentYearRes.data.fes_year_id,
+      refYears: currentYears[0].year_num,
+    };
+  },
+  computed: {
+    ...mapState({
+      roleID: (state) => state.users.role,
+    }),
+  },
+  mounted() {
+    const storedYearID = localStorage.getItem(this.$route.path + "RefYear");
 
-      window.addEventListener('scroll', this.saveScrollPosition);
+    if (storedYearID) {
+      this.refYearID = Number(storedYearID);
+      this.updateFilters(this.refYearID, this.yearList);
+    } else {
+      this.refYears = "Year";
+    }
+
+    const storedCategoryID = localStorage.getItem(
+      this.$route.path + "RefCategory"
+    );
+
+    if (storedCategoryID) {
+      this.refCategoryID = Number(storedCategoryID);
+      this.updateFilters(this.refCategoryID, this.groupCategories);
+    } else {
+      this.refGroupCategories = "Categories";
+    }
+
+    const storedInternationalID = localStorage.getItem(
+      this.$route.path + "RefInternational"
+    );
+
+    if (storedInternationalID) {
+      this.refInternationalID = Number(storedInternationalID);
+      this.updateFilters(this.refInternationalID, this.internationalList);
+    } else {
+      this.refInternational = "International";
+    }
+
+    const storedExternalID = localStorage.getItem(
+      this.$route.path + "RefExternal"
+    );
+
+    if (storedExternalID) {
+      this.refExternalID = Number(storedExternalID);
+      this.updateFilters(this.refExternalID, this.externalList);
+    } else {
+      this.refExternal = "External";
+    }
+
+    this.fetchFilteredData();
+
+    window.addEventListener("scroll", this.saveScrollPosition);
+  },
+  methods: {
+    saveScrollPosition() {
+      localStorage.setItem(
+        "scrollPosition-" + this.$route.path,
+        window.scrollY
+      );
     },
-    methods: {
-      async refinementgroups(item_id, name_list) {
-       // fes_yearで絞り込むとき
+    async refinementGroups(item_id, name_list) {
+      this.updateFilters(item_id, name_list);
+      localStorage.setItem(this.$route.path + "RefYear", this.refYearID);
+      localStorage.setItem(
+        this.$route.path + "RefCategory",
+        this.refCategoryID
+      );
+      localStorage.setItem(
+        this.$route.path + "RefInternational",
+        this.refInternationalID
+      );
+      localStorage.setItem(
+        this.$route.path + "RefExternal",
+        this.refExternalID
+      );
+      this.fetchFilteredData();
+    },
+    updateFilters(item_id, name_list) {
+      console.log(item_id, name_list[0]);
+      // fes_yearで絞り込むとき
+      if (name_list.toString() == this.yearList.toString()) {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
@@ -212,44 +290,78 @@ export default {
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
-        this.groups = [];
-        const refUrl =
-          "/api/v1/get_refinement_order_infos?fes_year_id=" +
-          this.refYearID;
-        const refRes = await this.$axios.$post(refUrl);
-        for (const res of refRes.data) {
-          this.groups.push(res);
+      } else if (name_list.toString() == this.groupCategories.toString()) {
+        this.refCategoryID = item_id;
+        // ALLの時
+        if (item_id == 0) {
+          this.refGroupCategories = "ALL";
+        } else {
+          this.refGroupCategories = name_list[item_id - 1].name;
         }
-        const storedSearchText = localStorage.getItem(
-          this.$route.path + "SearchText"
-        );
-        if (storedSearchText) {
-          this.searchText = storedSearchText;
-          this.searchGroups();
+        // internationalで絞り込むとき
+      } else if (Object.is(name_list, this.internationalList)) {
+        this.refInternationalID = item_id;
+        // ALLの時
+        if (item_id == 0) {
+          this.refInternational = "ALL";
+        } else {
+          this.refInternational = name_list[item_id - 1].value;
         }
-      },
-      async searchGroups() {
-        localStorage.setItem(this.$route.path + "SearchText", this.searchText);
-        this.groups = [];
-        const searchUrl = "/api/v1/get_search_order_infos?word=" + this.searchText;
-        const refRes = await this.$axios.$post(searchUrl);
-        for (const res of refRes.data) {
-            this.groups.push(res);
+        // externalで絞り込む時
+      } else if (Object.is(name_list, this.externalList)) {
+        this.refExternalID = item_id;
+        // ALLの時
+        if (item_id == 0) {
+          this.refExternal = "ALL";
+        } else {
+          this.refExternal = name_list[item_id - 1].value;
         }
-      },
+      }
     },
-  };
-  </script>
-  <style scoped>
-  .unregistered {
-    background-color: red;
-    color: white;
-  }
-  .normal-table td.unregistered:hover {
-    background-color: red !important;
-    color: white;
-    background: none;  /* 線形グラデーションを上書きして無効にします */
-    -webkit-background-clip: initial !important;  /* デフォルトの状態に戻します */
-    -webkit-text-fill-color: black !important;
-  }
-  </style>
+    async fetchFilteredData() {
+      this.groups = [];
+      const refUrl =
+        "/api/v1/get_refinement_order_status_check?fes_year_id=" +
+        this.refYearID +
+        "&group_category_id=" +
+        this.refCategoryID +
+        "&is_international=" +
+        this.refInternationalID +
+        "&is_external=" +
+        this.refExternalID;
+      const refRes = await this.$axios.$post(refUrl);
+      for (const res of refRes.data) {
+        this.groups.push(res);
+      }
+      this.$nextTick(() => {
+        window.scrollTo(
+          0,
+          parseInt(localStorage.getItem("scrollPosition-" + this.$route.path))
+        );
+      });
+    },
+    async searchGroups() {
+      this.groups = [];
+      const searchUrl =
+        "/api/v1/get_search_order_status_check?word=" + this.searchText;
+      const refRes = await this.$axios.$post(searchUrl);
+      for (const res of refRes.data) {
+        this.groups.push(res);
+      }
+    },
+  },
+};
+</script>
+<style scoped>
+.unregistered {
+  background-color: red;
+  color: white;
+}
+.normal-table td.unregistered:hover {
+  background-color: red !important;
+  color: white;
+  background: none; /* 線形グラデーションを上書きして無効にします */
+  -webkit-background-clip: initial !important; /* デフォルトの状態に戻します */
+  -webkit-text-fill-color: black !important;
+}
+</style>


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #1609

# 概要
<!-- 開発内容の概要を記載 -->
- コンフリクト修正に伴い、バグが発生していたため、 [申請状況の絞り込みとスクロール保持](https://github.com/NUTFes/group-manager-2/pull/1584)を参考に修正した。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- スクロール保持実装
- フロントの絞り込みの関数の修正
- ALLが選択されていた際、ドロップダウンの表示をALLにした

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] それぞれの絞り込みの機能が正しいか確認する
- [x] 絞り込みのドロップダウンの表示が選択した値になっている確認する
- [x] ページを移動しても、絞り込みがそのままか確認する
- [x] スクロールして移動してもスクロール位置がそのままか確認する

# 備考
<!-- 実装していて困った箇所・質問など -->
