### PR TITLE
cssによるwarningの解消

### DIFF
--- a/admin_view/nuxt-project/components/AccountModal.vue
+++ b/admin_view/nuxt-project/components/AccountModal.vue
@@ -187,7 +187,7 @@ export default {
 
 .account-modal_content div {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-flow: column;
   gap: 10px;
@@ -211,14 +211,14 @@ export default {
   width: 100%;
   min-height: 100%;
   display: flex;
-  justify-content: end;
-  align-items: start;
+  justify-content: flex-end;
+  align-items: flex-start;
 }
 
 .account-modal__box {
   width: 400px;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   padding: 30px 15px;

--- a/admin_view/nuxt-project/components/AddModal.vue
+++ b/admin_view/nuxt-project/components/AddModal.vue
@@ -84,7 +84,7 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   gap: 25px;
@@ -92,7 +92,7 @@ export default {
 
 .add-modal_content div {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-flow: column;
   gap: 10px;

--- a/admin_view/nuxt-project/components/Card.vue
+++ b/admin_view/nuxt-project/components/Card.vue
@@ -64,7 +64,7 @@ export default {
   min-height: var(--card-height);
   display: flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   flex-flow: var(--card-flex-flow);
   flex-grow: var(--card-flex-grow);
   background-color: #fff;

--- a/admin_view/nuxt-project/components/DeleteModal.vue
+++ b/admin_view/nuxt-project/components/DeleteModal.vue
@@ -77,7 +77,7 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   gap: 25px;
@@ -85,7 +85,7 @@ export default {
 
 .delete-modal_content div {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-flow: column;
   gap: 10px;

--- a/admin_view/nuxt-project/components/EditModal.vue
+++ b/admin_view/nuxt-project/components/EditModal.vue
@@ -73,7 +73,7 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   gap: 25px;
@@ -81,7 +81,7 @@ export default {
 
 .edit-modal_content div {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-flow: column;
   gap: 10px;

--- a/admin_view/nuxt-project/components/Header.vue
+++ b/admin_view/nuxt-project/components/Header.vue
@@ -170,7 +170,7 @@ img {
 .header-option {
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   flex-grow: 1;
   gap: 15px;
 }

--- a/admin_view/nuxt-project/components/MemoModal.vue
+++ b/admin_view/nuxt-project/components/MemoModal.vue
@@ -111,7 +111,7 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   gap: 25px;
@@ -119,7 +119,7 @@ export default {
 
 .memo-modal_content div {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-flow: column;
   gap: 10px;
@@ -143,15 +143,15 @@ export default {
   width: 100%;
   min-height: 100%;
   display: flex;
-  justify-content: end;
-  align-items: start;
+  justify-content: flex-end;
+  align-items: flex-start;
 }
 
 .memo-modal__box {
   width: 400px;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   padding: 15px;

--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -228,8 +228,8 @@ export default {
 .menu-content {
   width: 100%;
   display: flex;
-  align-items: start;
-  justify-content: start;
+  align-items: flex-start;
+  justify-content: flex-start;
   flex-flow: column;
   gap: 5px;
   margin-bottom: 60px;

--- a/admin_view/nuxt-project/components/NotificationModal.vue
+++ b/admin_view/nuxt-project/components/NotificationModal.vue
@@ -87,7 +87,7 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   gap: 25px;
@@ -95,7 +95,7 @@ export default {
 
 .notification-modal_content div {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-flow: column;
   gap: 10px;
@@ -119,15 +119,15 @@ export default {
   width: 100%;
   min-height: 100%;
   display: flex;
-  justify-content: end;
-  align-items: start;
+  justify-content: flex-end;
+  align-items: flex-start;
 }
 
 .notification-modal__box {
   width: 400px;
   height: 100%;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   flex-flow: column;
   padding: 15px;

--- a/admin_view/nuxt-project/components/SearchDropDown.vue
+++ b/admin_view/nuxt-project/components/SearchDropDown.vue
@@ -150,8 +150,8 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
-  align-items: start;
+  justify-content: flex-start;
+  align-items: flex-start;
 }
 
 .drop-down__box {

--- a/admin_view/nuxt-project/components/SelectBox.vue
+++ b/admin_view/nuxt-project/components/SelectBox.vue
@@ -147,8 +147,8 @@ export default {
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: start;
-  align-items: start;
+  justify-content: flex-start;
+  align-items: flex-start;
 }
 
 .drop-down__box {

--- a/admin_view/nuxt-project/components/SnackBar.vue
+++ b/admin_view/nuxt-project/components/SnackBar.vue
@@ -40,8 +40,8 @@ export default {};
   min-height: 100%;
   padding: 20px;
   display: flex;
-  justify-content: end;
-  align-items: end;
+  justify-content: flex-end;
+  align-items: flex-end;
 }
 
 .snack-modal__box {

--- a/admin_view/nuxt-project/components/SubHeader.vue
+++ b/admin_view/nuxt-project/components/SubHeader.vue
@@ -106,8 +106,8 @@ export default {
   width: 100%;
   height: 100px;
   display: flex;
-  align-items: start;
-  justify-content: start;
+  align-items: flex-start;
+  justify-content: flex-start;
   flex-flow: column;
 }
 
@@ -122,7 +122,7 @@ export default {
 
 .sub-header-title {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   flex-wrap: wrap;
   flex-flow: column;
@@ -131,7 +131,7 @@ export default {
 .sub-header-content {
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   flex-wrap: wrap;
   flex-grow: 1;
   gap: 20px;

--- a/admin_view/nuxt-project/components/SubSubHeader.vue
+++ b/admin_view/nuxt-project/components/SubSubHeader.vue
@@ -71,7 +71,7 @@ p {
 .drop-down-container {
   display: flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   flex-wrap: wrap;
   flex-grow: 1;
   gap: 20px;
@@ -79,7 +79,7 @@ p {
 .search-bar-container {
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   flex-wrap: wrap;
   gap: 20px;
 }

--- a/admin_view/nuxt-project/components/SwitchButton.vue
+++ b/admin_view/nuxt-project/components/SwitchButton.vue
@@ -58,7 +58,7 @@ export default {
   letter-spacing: 2px;
   color: var(--accent-0);
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   border: none;
   transition: all 0.2s 0s ease;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1615

# 概要
<!-- 開発内容の概要を記載 -->
コンテナを立ち上げると`start value has mixed support, consider using flex-start instead`というwarningが大量に発生していたので解消した

# 実装詳細
<!-- 具体的な開発内容を記載 -->
warningが出ているcomponentsで以下の修正をした
- `justify-content: start;`→`justify-content: flex-start;`
- `align-items: start;`→`align-items: flex-start;`
- `justify-content: end;`→`justify-content: flex-end;`
- `align-items: end;`→`align-items: flex-end;`

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 管理者画面でデザインが崩れていないか確認する

# 備考
<!-- 実装していて困った箇所・質問など -->
