### PR TITLE
[fix] アナウンス分が登録されている時，ラジオボタンを選択した状態にする

### DIFF
--- a/user_front/pages/mypage/edit_announcement/index.vue
+++ b/user_front/pages/mypage/edit_announcement/index.vue
@@ -36,10 +36,11 @@ onMounted(async () => {
     currentAnnouncement.value = announcements.find(
       (announcement: Announcement) => announcement.group_id === groupId.value
     );
+    console.log("announcements", currentAnnouncement.value?.message);
 
     if (currentAnnouncement.value) {
       message.value = currentAnnouncement.value.message;
-      status.value = currentAnnouncement.value.status || "未申請";
+      status.value = currentAnnouncement.value.message ? "申請済み" : "申請しない";
     }
   });
   const settingUrl = config.APIURL + "/user_page_settings";

--- a/user_front/pages/mypage/edit_announcement/index.vue
+++ b/user_front/pages/mypage/edit_announcement/index.vue
@@ -36,7 +36,6 @@ onMounted(async () => {
     currentAnnouncement.value = announcements.find(
       (announcement: Announcement) => announcement.group_id === groupId.value
     );
-    console.log("announcements", currentAnnouncement.value?.message);
 
     if (currentAnnouncement.value) {
       message.value = currentAnnouncement.value.message;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolve #1621

# 概要
<!-- 開発内容の概要を記載 -->
- ユーザーフロントで，アナウンス文編集の 申請する / 申請しないのラジオボタンに初期値を追加

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- アナウンス文編集ページで， アナウンスのテキストが登録されているかどうかで，申請する / 申請しない のラジオボタンの初期値を設定する．

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] ユーザーページでアナウンス文を新規登録した時には，ラジオボタンは選択されていない
- [ ] 申請しないで登録した時，初期値は申請しないになっているか
- [ ] 申請をするで，テキストを入力して登録した時，初期値は申請するになっているか

# 備考
<!-- 実装していて困った箇所・質問など -->
