### PR TITLE
[fix] 調理工程申請の仕様変更とユーザー画面のバリデーション統一

### DIFF
--- a/admin_view/nuxt-project/components/AddModal.vue
+++ b/admin_view/nuxt-project/components/AddModal.vue
@@ -49,6 +49,22 @@ export default {
     display: none;
 }
 
+.add-modal input[type="radio"] {
+  color: initial;
+  border: initial;
+  padding: initial;
+  width: initial;
+  transition: initial;
+}
+
+.add-modal input[type="radio"] + label {
+  color: initial;
+  border: initial;
+  padding: initial;
+  width: initial;
+  transition: initial;
+}
+
 .add-modal_content input:focus,
 .add-modal_content textarea:focus {
   border: 1px solid var(--accent-7);

--- a/admin_view/nuxt-project/components/EditModal.vue
+++ b/admin_view/nuxt-project/components/EditModal.vue
@@ -59,6 +59,22 @@ export default {
   outline: 0;
 }
 
+.edit-modal input[type="radio"] {
+  color: initial;
+  border: initial;
+  padding: initial;
+  width: initial;
+  transition: initial;
+}
+
+.edit-modal input[type="radio"] + label {
+  color: initial;
+  border: initial;
+  padding: initial;
+  width: initial;
+  transition: initial;
+}
+
 .edit-modal__box h2 {
   color: var(--accent-5);
 }

--- a/admin_view/nuxt-project/pages/cooking_process_order/_id.vue
+++ b/admin_view/nuxt-project/pages/cooking_process_order/_id.vue
@@ -33,97 +33,58 @@
               <td>{{ cooking_process_order.group.name }}</td>
             </tr>
             <tr>
-              <th rowspan="2">営業前</th>
-              <th>調理場</th>
+              <th rowspan="2">調理場</th>
+              <th>営業前</th>
               <td>
-                <div
-                  v-if="cooking_process_order.cooking_process_order === null"
-                >
+                <div v-if="cooking_process_order.cooking_process_order === null">
                   未登録
                 </div>
                 <div v-else>
-                  {{
-                    cooking_process_order.cooking_process_order.pre_open_kitchen
-                  }}
+                  {{ cooking_process_order.cooking_process_order.pre_open_kitchen ? '使用する' : '使用しない' }}
                 </div>
               </td>
             </tr>
             <tr>
-              <th>テント内</th>
+              <th>営業中</th>
               <td>
-                <div
-                  v-if="cooking_process_order.cooking_process_order === null"
-                >
+                <div v-if="cooking_process_order.cooking_process_order === null">
                   未登録
                 </div>
                 <div v-else>
-                  {{
-                    cooking_process_order.cooking_process_order.pre_open_tent
-                  }}
+                  {{ cooking_process_order.cooking_process_order.during_open_kitchen ? '使用する' : '使用しない' }}
                 </div>
               </td>
             </tr>
             <tr>
-              <th rowspan="2">営業中</th>
-              <th>調理場</th>
+              <th colspan="2">テント内</th>
               <td>
-                <div
-                  v-if="cooking_process_order.cooking_process_order === null"
-                >
+                <div v-if="cooking_process_order.cooking_process_order === null">
                   未登録
                 </div>
                 <div v-else>
-                  {{
-                    cooking_process_order.cooking_process_order
-                      .during_open_kitchen
-                  }}
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <th>テント内</th>
-              <td>
-                <div
-                  v-if="cooking_process_order.cooking_process_order === null"
-                >
-                  未登録
-                </div>
-                <div v-else>
-                  {{
-                    cooking_process_order.cooking_process_order.during_open_tent
-                  }}
+                  {{ cooking_process_order.cooking_process_order.tent }}
                 </div>
               </td>
             </tr>
             <tr>
               <th colspan="2">登録日時</th>
               <td>
-                <div
-                  v-if="cooking_process_order.cooking_process_order === null"
-                >
+                <div v-if="cooking_process_order.cooking_process_order === null">
                   未登録
                 </div>
                 <div v-else>
-                  {{
-                    cooking_process_order.cooking_process_order.created_at
-                      | formatDate
-                  }}
+                  {{ cooking_process_order.cooking_process_order.created_at | formatDate }}
                 </div>
               </td>
             </tr>
             <tr>
               <th colspan="2">編集日時</th>
               <td>
-                <div
-                  v-if="cooking_process_order.cooking_process_order === null"
-                >
+                <div v-if="cooking_process_order.cooking_process_order === null">
                   未登録
                 </div>
                 <div v-else>
-                  {{
-                    cooking_process_order.cooking_process_order.updated_at
-                      | formatDate
-                  }}
+                  {{ cooking_process_order.cooking_process_order.updated_at | formatDate }}
                 </div>
               </td>
             </tr>
@@ -139,20 +100,31 @@
     >
       <template v-slot:form>
         <div>
-          <h3>営業前：調理場</h3>
-          <input v-model="pre_open_kitchen" placeholder="入力してください" />
+          <h3>調理場：営業前</h3>
+          <div class="radio-group">
+            <input type="radio" id="preOpenKitchenYes" value="true" v-model="pre_open_kitchen" />
+            <label for="preOpenKitchenYes">使用する</label>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="preOpenKitchenNo" value="false" v-model="pre_open_kitchen" />
+            <label for="preOpenKitchenNo">使用しない</label>
+          </div>
+        </div>
+
+        <div>
+          <h3>調理場：営業中</h3>
+          <div class="radio-group">
+            <input type="radio" id="duringOpenKitchenYes" value="true" v-model="during_open_kitchen" />
+            <label for="duringOpenKitchenYes">使用する</label>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="duringOpenKitchenNo" value="false" v-model="during_open_kitchen" />
+            <label for="duringOpenKitchenNo">使用しない</label>
+          </div>
         </div>
         <div>
-          <h3>営業前：テント内</h3>
-          <input v-model="pre_open_tent" placeholder="入力してください" />
-        </div>
-        <div>
-          <h3>営業中：調理場</h3>
-          <input v-model="during_open_kitchen" placeholder="入力してください" />
-        </div>
-        <div>
-          <h3>営業中：テント内</h3>
-          <input v-model="during_open_tent" placeholder="入力してください" />
+          <h3>テント内での作業内容</h3>
+          <input v-model="tent" placeholder="入力してください" />
         </div>
       </template>
       <template v-slot:method>
@@ -192,6 +164,9 @@ export default {
       snackMessage: null,
       group_id: null,
       routeId: null,
+      pre_open_kitchen: null,
+      during_open_kitchen: null,
+      tent: "",
     };
   },
   computed: {
@@ -214,19 +189,16 @@ export default {
         this.group_id = this.cooking_process_order.group.id;
         this.pre_open_kitchen =
           this.cooking_process_order.cooking_process_order.pre_open_kitchen;
-        this.pre_open_tent =
-          this.cooking_process_order.cooking_process_order.pre_open_tent;
         this.during_open_kitchen =
           this.cooking_process_order.cooking_process_order.during_open_kitchen;
-        this.during_open_tent =
-          this.cooking_process_order.cooking_process_order.during_open_tent;
+        this.tent =
+          this.cooking_process_order.cooking_process_order.tent;
         this.isOpenEditModal = true;
       } else {
         this.group_id = this.cooking_process_order.group.id;
         this.pre_open_kitchen = null;
-        this.pre_open_tent = null;
         this.during_open_kitchen = null;
-        this.during_open_tent = null;
+        this.tent = null;
         this.isOpenEditModal = true;
       }
     },
@@ -256,18 +228,16 @@ export default {
     async edit() {
       if (
         !this.pre_open_kitchen ||
-        !this.pre_open_tent ||
         !this.during_open_kitchen ||
-        !this.during_open_tent
+        !this.tent
       ) {
         this.openSnackBar("調理工程申請を全て入力してください");
         return;
       }
       const cookingProcessOrderData = {
         pre_open_kitchen: this.pre_open_kitchen,
-        pre_open_tent: this.pre_open_tent,
         during_open_kitchen: this.during_open_kitchen,
-        during_open_tent: this.during_open_tent,
+        tent: this.tent,
       };
       if (this.cooking_process_order.cooking_process_order) {
         // 既存の調理工程を編集
@@ -319,5 +289,13 @@ td {
 }
 th {
   width: 15%;
+}
+
+.radio-group {
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  flex-flow: row nowrap;
+  width: 500px;
 }
 </style>

--- a/admin_view/nuxt-project/pages/cooking_process_order/_id.vue
+++ b/admin_view/nuxt-project/pages/cooking_process_order/_id.vue
@@ -102,11 +102,11 @@
         <div>
           <h3>調理場：営業前</h3>
           <div class="radio-group">
-            <input type="radio" id="preOpenKitchenYes" value="true" v-model="pre_open_kitchen" />
+            <input type="radio" id="preOpenKitchenYes" :value="true" v-model="pre_open_kitchen" />
             <label for="preOpenKitchenYes">使用する</label>
           </div>
           <div class="radio-group">
-            <input type="radio" id="preOpenKitchenNo" value="false" v-model="pre_open_kitchen" />
+            <input type="radio" id="preOpenKitchenNo" :value="false" v-model="pre_open_kitchen" />
             <label for="preOpenKitchenNo">使用しない</label>
           </div>
         </div>
@@ -114,11 +114,11 @@
         <div>
           <h3>調理場：営業中</h3>
           <div class="radio-group">
-            <input type="radio" id="duringOpenKitchenYes" value="true" v-model="during_open_kitchen" />
+            <input type="radio" id="duringOpenKitchenYes" :value="true" v-model="during_open_kitchen" />
             <label for="duringOpenKitchenYes">使用する</label>
           </div>
           <div class="radio-group">
-            <input type="radio" id="duringOpenKitchenNo" value="false" v-model="during_open_kitchen" />
+            <input type="radio" id="duringOpenKitchenNo" :value="false" v-model="during_open_kitchen" />
             <label for="duringOpenKitchenNo">使用しない</label>
           </div>
         </div>
@@ -227,9 +227,9 @@ export default {
     },
     async edit() {
       if (
-        !this.pre_open_kitchen ||
-        !this.during_open_kitchen ||
-        !this.tent
+        this.pre_open_kitchen === null ||
+        this.during_open_kitchen === null ||
+        this.tent === ""
       ) {
         this.openSnackBar("調理工程申請を全て入力してください");
         return;

--- a/admin_view/nuxt-project/pages/cooking_process_order/index.vue
+++ b/admin_view/nuxt-project/pages/cooking_process_order/index.vue
@@ -87,20 +87,32 @@
           </select>
         </div>
         <div>
-          <h3>営業前：調理場</h3>
-          <input v-model="pre_open_kitchen" placeholder="入力してください" />
+          <h3>調理場：営業前</h3>
+          <div class="radio-group">
+            <input type="radio" id="preOpenKitchenYes" value="true" v-model="pre_open_kitchen" />
+            <label for="preOpenKitchenYes">使用する</label>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="preOpenKitchenNo" value="false" v-model="pre_open_kitchen" />
+            <label for="preOpenKitchenNo">使用しない</label>
+          </div>
         </div>
+
         <div>
-          <h3>営業前：テント内</h3>
-          <input v-model="pre_open_tent" placeholder="入力してください" />
+          <h3>調理場：営業中</h3>
+          <div class="radio-group">
+            <input type="radio" id="duringOpenKitchenYes" value="true" v-model="during_open_kitchen" />
+            <label for="duringOpenKitchenYes">使用する</label>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="duringOpenKitchenNo" value="false" v-model="during_open_kitchen" />
+            <label for="duringOpenKitchenNo">使用しない</label>
+          </div>
         </div>
+
         <div>
-          <h3>営業中：調理場</h3>
-          <input v-model="during_open_kitchen" placeholder="入力してください" />
-        </div>
-        <div>
-          <h3>営業中：テント内</h3>
-          <input v-model="during_open_tent" placeholder="入力してください" />
+          <h3>テント内での作業内容</h3>
+          <input v-model="tent" placeholder="入力してください" />
         </div>
       </template>
       <template v-slot:method>
@@ -132,6 +144,9 @@ export default {
       refYears: "Years",
       refYearID: 0,
       searchText: "",
+      pre_open_kitchen: null,
+      during_open_kitchen: null,
+      tent: "",
     };
   },
   async asyncData({ $axios }) {
@@ -195,18 +210,16 @@ export default {
       if (
         !this.group_id ||
         !this.pre_open_kitchen ||
-        !this.pre_open_tent ||
         !this.during_open_kitchen ||
-        !this.during_open_tent
+        !this.tent
       ) {
         this.openSnackBar("参加団体と全ての調理工程申請を入力してください");
         return;
       }
       const cookingProcessOrderData = {
         pre_open_kitchen: this.pre_open_kitchen,
-        pre_open_tent: this.pre_open_tent,
         during_open_kitchen: this.during_open_kitchen,
-        during_open_tent: this.during_open_tent,
+        tent: this.tent,
       };
 
       // POSTリクエストのURL
@@ -230,9 +243,8 @@ export default {
     clearForm() {
       this.group_id = null;
       this.pre_open_kitchen = "";
-      this.pre_open_tent = "";
       this.during_open_kitchen = "";
-      this.during_open_tent = "";
+      this.tent = "";
     },
 
     async refinementCookingProcessOrders(item_id, name_list) {
@@ -277,3 +289,13 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.radio-group {
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  flex-flow: row nowrap;
+  width: 500px;
+}
+</style>

--- a/api/app/controllers/api/v1/cooking_process_orders_api_controller.rb
+++ b/api/app/controllers/api/v1/cooking_process_orders_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::CookingProcessOrdersApiController < ApplicationController
-  
+
   def get_cooking_process_order_for_admin_view
     @groups = Group.with_cooking_process_order(params[:id])
     render json: fmt(ok, @groups)

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -454,15 +454,14 @@ class Api::V1::OutputCsvController < ApplicationController
     @cooking_process_orders = CookingProcessOrder.all
     bom = "\uFEFF"
     csv_data = CSV.generate(bom) do |csv|
-      column_name = %w(参加団体名 営業前:調理場 営業前:テント内 営業中:調理場 営業中:テント内)
+      column_name = %w(参加団体名 営業前:調理場 営業中:調理場 テント内)
       csv << column_name
       @cooking_process_orders.each do |cooking_process_order|
         column_values = [
           cooking_process_order.group.name,
           cooking_process_order.pre_open_kitchen,
-          cooking_process_order.pre_open_tent,
           cooking_process_order.during_open_kitchen,
-          cooking_process_order.during_open_tent
+          cooking_process_order.tent
         ]
         csv << column_values
       end

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -459,8 +459,8 @@ class Api::V1::OutputCsvController < ApplicationController
       @cooking_process_orders.each do |cooking_process_order|
         column_values = [
           cooking_process_order.group.name,
-          cooking_process_order.pre_open_kitchen,
-          cooking_process_order.during_open_kitchen,
+          cooking_process_order.pre_open_kitchen ? "申請する" : "申請しない",  
+          cooking_process_order.during_open_kitchen ? "申請する" : "申請しない",  
           cooking_process_order.tent
         ]
         csv << column_values

--- a/api/app/controllers/cooking_process_orders_controller.rb
+++ b/api/app/controllers/cooking_process_orders_controller.rb
@@ -45,6 +45,6 @@ class CookingProcessOrdersController < ApplicationController
 
     # Only allow a list of trusted parameters through
     def cooking_process_order_params
-      params.require(:cooking_process_order).permit(:pre_open_kitchen, :pre_open_tent, :during_open_kitchen, :during_open_tent)
+      params.require(:cooking_process_order).permit(:pre_open_kitchen, :during_open_kitchen, :tent)
     end
 end

--- a/api/app/models/cooking_process_order.rb
+++ b/api/app/models/cooking_process_order.rb
@@ -28,9 +28,8 @@ class CookingProcessOrder < ApplicationRecord
       "id": self.id,
       "group_id": self.group_id,
       "pre_open_kitchen": self.pre_open_kitchen,
-      "pre_open_tent": self.pre_open_tent,
       "during_open_kitchen": self.during_open_kitchen,
-      "during_open_tent": self.during_open_tent
+      "tent": self.tent
     }
   end
 end

--- a/api/db/migrate/20240418122445_create_cooking_process_orders.rb
+++ b/api/db/migrate/20240418122445_create_cooking_process_orders.rb
@@ -5,7 +5,7 @@ class CreateCookingProcessOrders < ActiveRecord::Migration[6.1]
       t.text :pre_open_kitchen
       t.text :pre_open_tent
       t.text :during_open_kitchen
-      t.text :during_open_tent
+      t.text :tent
       t.timestamps
     end
   end

--- a/api/db/migrate/20240522012844_modify_cooking_process_orders.rb
+++ b/api/db/migrate/20240522012844_modify_cooking_process_orders.rb
@@ -1,0 +1,14 @@
+class ModifyCookingProcessOrders < ActiveRecord::Migration[6.1]
+  def change
+    change_table :cooking_process_orders do |t|
+      t.remove :pre_open_kitchen
+      t.remove :pre_open_tent
+      t.remove :during_open_kitchen
+      t.remove :tent
+
+      t.boolean :pre_open_kitchen, null: false, default: false
+      t.boolean :during_open_kitchen, null: false, default: false
+      t.text :tent
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_13_081443) do
+ActiveRecord::Schema.define(version: 2024_05_22_012844) do
 
   create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "group_id"
@@ -55,12 +55,11 @@ ActiveRecord::Schema.define(version: 2024_05_13_081443) do
 
   create_table "cooking_process_orders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "group_id", null: false
-    t.text "pre_open_kitchen"
-    t.text "pre_open_tent"
-    t.text "during_open_kitchen"
-    t.text "during_open_tent"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "pre_open_kitchen", default: false, null: false
+    t.boolean "during_open_kitchen", default: false, null: false
+    t.text "tent"
     t.index ["group_id"], name: "index_cooking_process_orders_on_group_id"
   end
 

--- a/user_front/components/RegistPageButton.vue
+++ b/user_front/components/RegistPageButton.vue
@@ -6,20 +6,18 @@ const props = defineProps<{
 }>();
 </script>
 <template>
-  <div>
-    <button
-      :disabled="disabled"
-      :class="{
-        none: disabled,
-        primary: variant === 'primary' || variant === undefined,
-        danger: variant === 'danger',
-        secondary: variant === 'secondary',
-        success: variant === 'success',
-      }"
-    >
-      {{ props.text }}
-    </button>
-  </div>
+  <button
+    :disabled="disabled"
+    :class="{
+      none: disabled,
+      primary: variant === 'primary' || variant === undefined,
+      danger: variant === 'danger',
+      secondary: variant === 'secondary',
+      success: variant === 'success',
+    }"
+  >
+    {{ props.text }}
+  </button>
 </template>
 
 <style scoped>

--- a/user_front/locales/en.json
+++ b/user_front/locales/en.json
@@ -367,8 +367,7 @@
   "Cook": {
     "cookTitle":"Cooking Process Order",
     "preOpenKitchen":"Pre-Open Kitchen",
-    "preOpenTent":"Pre-Open Tent",
     "duringOpenKitchen":"During Open Kitchen",
-    "duringOpenTent":"During Open Tent"
+    "tent":"Activities Inside the Tent"
   }
 }

--- a/user_front/locales/ja.json
+++ b/user_front/locales/ja.json
@@ -364,8 +364,7 @@
   "Cook": {
     "cookTitle":"調理工程申請",
     "preOpenKitchen":"営業前調理場",
-    "preOpenTent":"営業前テント内",
     "duringOpenKitchen":"営業中調理場",
-    "duringOpenTent":"営業中テント内"
+    "tent":"テント内での作業内容"
   }
 }

--- a/user_front/pages/mypage/edit_contact_person/index.vue
+++ b/user_front/pages/mypage/edit_contact_person/index.vue
@@ -1,9 +1,7 @@
 <script lang="ts" setup>
 import axios from "axios";
-import { ContactPerson } from '@/types/regist/contactPerson';
 import { useForm, useField } from "vee-validate";
-import { contactPersonSchema } from "~~/utils/validate";
-import { loginCheck } from "@/utils/methods";
+import { ContactPerson } from '@/types/regist/contactPerson';
 
 const router = useRouter();
 const config = useRuntimeConfig();
@@ -11,10 +9,9 @@ const config = useRuntimeConfig();
 const contactPersonName = ref<string>("");
 const contactPersonEmail = ref<string>("");
 const groupId = Number(localStorage.getItem("group_id"));
-const isSubmitting = ref<boolean>(false);
 const currentContactPerson = ref<ContactPerson>();
 
-const { meta } = useForm({
+const { meta, isSubmitting } = useForm({
   validationSchema: contactPersonSchema,
 });
 
@@ -29,6 +26,8 @@ onMounted(() => {
     currentContactPerson.value = contactPersons.find((cp) => cp.group_id === groupId);
     contactPersonName.value = currentContactPerson.value?.name || "";
     contactPersonEmail.value = currentContactPerson.value?.email || "";
+    handleChangeContactPersonName(currentContactPerson.value?.name);
+    handleChangeContactPersonEmail(currentContactPerson.value?.email);
   });
 });
 
@@ -70,8 +69,8 @@ const register = () => {
 
 const buttonDisabled = computed(() => {
   return !!(
-    ContactPersonNameError.value ||
-    ContactPersonEmailError.value
+    !contactPersonName.value ||
+    !contactPersonEmail.value
   );
 });
 </script>
@@ -116,7 +115,7 @@ const buttonDisabled = computed(() => {
     <div class="regist-button">
       <RegistPageButton
         @click="register"
-        :disabled="buttonDisabled || isSubmitting"
+        :disabled="buttonDisabled || !meta.valid || isSubmitting"
         :text="$t('Button.register')"
       ></RegistPageButton>
     </div>

--- a/user_front/pages/mypage/edit_cooking_process/index.vue
+++ b/user_front/pages/mypage/edit_cooking_process/index.vue
@@ -9,10 +9,9 @@ const router = useRouter();
 const config = useRuntimeConfig();
 
 const currentCookingProcessOrder = ref<CookingProcessOrder>();
-const preOpenKitchen = ref<Text>();
-const preOpenTent = ref<Text>();
-const duringOpenKitchen = ref<Text>();
-const duringOpenTent = ref<Text>();
+const preOpenKitchen = ref<boolean>();
+const duringOpenKitchen = ref<boolean>();
+const tent = ref<Text>();
 const groupId = Number(localStorage.getItem("group_id"));
 const setting = ref("");
 const isEditGroup = ref<boolean>();
@@ -23,9 +22,8 @@ const { meta } = useForm({
 });
 
 const { handleChange: handleChangepreOpenKitchen, errorMessage: preOpenKitchenError } = useField("preOpenKitchen");
-const { handleChange: handleChangepreOpenTent, errorMessage: preOpenTentError } = useField("preOpenKitchen");
 const { handleChange: handleChangeduringOpenKitchen, errorMessage: duringOpenKitchenError } = useField("duringOpenKitchen");
-const { handleChange: handleChangeduringOpenTent, errorMessage: duringOpenTentError } = useField("duringOpenTent");
+const { handleChange: handleChangetent, errorMessage: tentError } = useField("tent");
 
 onMounted(() => {
   loginCheck();
@@ -34,9 +32,8 @@ onMounted(() => {
     const cookingProcessOrders: CookingProcessOrder[] = response.data;
     currentCookingProcessOrder.value = cookingProcessOrders.find((cpo) => cpo.group_id === groupId);
     preOpenKitchen.value = currentCookingProcessOrder.value?.pre_open_kitchen;
-    preOpenTent.value = currentCookingProcessOrder.value?.pre_open_tent;
     duringOpenKitchen.value = currentCookingProcessOrder.value?.during_open_kitchen;
-    duringOpenTent.value = currentCookingProcessOrder.value?.during_open_tent;
+    tent.value = currentCookingProcessOrder.value?.tent;
   });
 
   const settingUrl = config.APIURL + "/user_page_settings";
@@ -64,9 +61,8 @@ const register = () => {
       .put(cookingProcessOrderUrl, {
         group_id: groupId,
         pre_open_kitchen: preOpenKitchen.value,
-        pre_open_tent: preOpenTent.value,
         during_open_kitchen: duringOpenKitchen.value,
-        during_open_tent: duringOpenTent.value
+        tent: tent.value
       })
       .then(() => {
         alert("登録できました\nRegistration Success");
@@ -81,9 +77,8 @@ const register = () => {
       .post(cookingProcessOrderUrl, {
         group_id: groupId,
         pre_open_kitchen: preOpenKitchen.value,
-        pre_open_tent: preOpenTent.value,
         during_open_kitchen: duringOpenKitchen.value,
-        during_open_tent: duringOpenTent.value
+        tent: tent.value
       })
       .then(() => {
         alert("登録できました\nRegistration Success");
@@ -97,10 +92,9 @@ const register = () => {
 
 const buttonDisabled = computed(() => {
   return !!(
-    preOpenKitchenError.value||
-    preOpenTentError.value||
-    duringOpenKitchenError.value||
-    duringOpenTentError.value
+    preOpenKitchen.value &&
+    duringOpenKitchen.value &&
+    tent.value
   );
 });
 </script>
@@ -118,43 +112,59 @@ const buttonDisabled = computed(() => {
         <div class="text-lg">
           {{ $t("Cook.preOpenKitchen") }}
         </div>
-        <input
-          class="rounded-md border border-black p-2 text-xl"
-          id="group"
-          type="text"
-          v-model="preOpenKitchen"
-          @change="handleChangepreOpenKitchen"
-        />
+        <div class="flex items-center">
+          <input
+            type="radio"
+            id="preOpenKitchenYes"
+            value="true"
+            v-model="preOpenKitchen"
+            @change="handleChangepreOpenKitchen"
+            class="form-radio h-4 w-4 text-blue-600"
+          />
+          <label for="preOpenKitchenYes" class="ml-2 text-xl">使用する</label>
+        </div>
+        <div class="flex items-center">
+          <input
+            type="radio"
+            id="preOpenKitchenNo"
+            value="false"
+            v-model="preOpenKitchen"
+            @change="handleChangepreOpenKitchen"
+            class="form-radio h-4 w-4 text-blue-600"
+          />
+          <label for="preOpenKitchenNo" class="ml-2 text-xl">使用しない</label>
+        </div>
         <p class="text-red-500 text-sm" v-if="preOpenKitchenError">
           {{ preOpenKitchenError }}
         </p>
       </div>
-      <div class="flex flex-col gap-2">
-        <div class="text-lg">
-          {{ $t("Cook.preOpenTent") }}
-        </div>
-        <input
-          class="rounded-md border border-black p-2 text-xl"
-          id="project"
-          type="text"
-          v-model="preOpenTent"
-          @change="handleChangepreOpenTent"
-        />
-        <p class="text-red-500 text-sm" v-if="preOpenTentError">
-          {{ preOpenTentError }}
-        </p>
-      </div>
+
       <div class="flex flex-col gap-2">
         <div class="text-lg">
           {{ $t("Cook.duringOpenKitchen") }}
         </div>
-        <input
-          class="rounded-md border border-black p-2 text-xl"
-          id="group"
-          type="text"
-          v-model="duringOpenKitchen"
-          @change="handleChangeduringOpenKitchen"
-        />
+        <div class="flex items-center">
+          <input
+            type="radio"
+            id="duringOpenKitchenYes"
+            value="true"
+            v-model="duringOpenKitchen"
+            @change="handleChangeduringOpenKitchen"
+            class="form-radio h-4 w-4 text-blue-600"
+          />
+          <label for="duringOpenKitchenYes" class="ml-2 text-xl">使用する</label>
+        </div>
+        <div class="flex items-center">
+          <input
+            type="radio"
+            id="duringOpenKitchenNo"
+            value="false"
+            v-model="duringOpenKitchen"
+            @change="handleChangeduringOpenKitchen"
+            class="form-radio h-4 w-4 text-blue-600"
+          />
+          <label for="duringOpenKitchenNo" class="ml-2 text-xl">使用しない</label>
+        </div>
         <p class="text-red-500 text-sm" v-if="duringOpenKitchenError">
           {{ duringOpenKitchenError }}
         </p>
@@ -162,17 +172,17 @@ const buttonDisabled = computed(() => {
 
       <div class="flex flex-col gap-2">
         <div class="text-lg">
-          {{ $t("Cook.duringOpenTent") }}
+          {{ $t("Cook.tent") }}
         </div>
         <input
           class="rounded-md border border-black p-2 text-xl"
           id="activity"
           type="text"
-          v-model="duringOpenTent"
-          @change="handleChangeduringOpenTent"
+          v-model="tent"
+          @change="handleChangetent"
         />
-        <p class="text-red-500 text-sm" v-if="duringOpenTentError">
-          {{ duringOpenTentError }}
+        <p class="text-red-500 text-sm" v-if="tentError">
+          {{ tentError }}
         </p>
       </div>
     </div>
@@ -181,7 +191,7 @@ const buttonDisabled = computed(() => {
         v-if="isEditGroup"
         @click="register"
         class="regist-button"
-        :disabled="buttonDisabled || isSubmitting"
+        :disabled="!buttonDisabled || isSubmitting"
         :text="$t('Button.register')"
       ></RegistPageButton>
     </div>

--- a/user_front/pages/mypage/edit_cooking_process/index.vue
+++ b/user_front/pages/mypage/edit_cooking_process/index.vue
@@ -170,13 +170,12 @@ const buttonDisabled = computed(() => {
         <div class="text-lg">
           {{ $t("Cook.tent") }}
         </div>
-        <input
+        <textarea
           class="rounded-md border border-black p-2 text-xl"
           id="activity"
-          type="text"
           v-model="tent"
           @change="handleChangetent"
-        />
+        ></textarea>
         <p class="text-red-500 text-sm" v-if="tentError">
           {{ tentError }}
         </p>
@@ -186,14 +185,12 @@ const buttonDisabled = computed(() => {
       <RegistPageButton
         v-if="isEditGroup"
         @click="register"
-        class="regist-button"
         :disabled="buttonDisabled || !meta.valid || isSubmitting"
         :text="$t('Button.register')"
       ></RegistPageButton>
     </div>
   </div>
 </template>
-
 <style scoped>
 .regist-button {
   @apply text-right

--- a/user_front/pages/mypage/edit_cooking_process/index.vue
+++ b/user_front/pages/mypage/edit_cooking_process/index.vue
@@ -90,8 +90,6 @@ const register = () => {
 
 const buttonDisabled = computed(() => {
   return !!(
-    !preOpenKitchen.value ||
-    !duringOpenKitchen.value ||
     !tent.value
   );
 });

--- a/user_front/pages/mypage/edit_cooking_process/index.vue
+++ b/user_front/pages/mypage/edit_cooking_process/index.vue
@@ -1,9 +1,7 @@
 <script lang="ts" setup>
 import axios from "axios";
-import { CookingProcessOrder } from "@/types/regist/cookingProcessOrder";
 import { useForm, useField } from "vee-validate";
-import { cookingProcessOrderSchema } from "~~/utils/validate";
-import { loginCheck } from "@/utils/methods";
+import { CookingProcessOrder } from "@/types/regist/cookingProcessOrder";
 
 const router = useRouter();
 const config = useRuntimeConfig();
@@ -13,11 +11,9 @@ const preOpenKitchen = ref<boolean>();
 const duringOpenKitchen = ref<boolean>();
 const tent = ref<Text>();
 const groupId = Number(localStorage.getItem("group_id"));
-const setting = ref("");
 const isEditGroup = ref<boolean>();
-const isSubmitting = ref<boolean>(false);
 
-const { meta } = useForm({
+const { meta, isSubmitting } = useForm({
   validationSchema: cookingProcessOrderSchema,
 });
 
@@ -34,6 +30,9 @@ onMounted(() => {
     preOpenKitchen.value = currentCookingProcessOrder.value?.pre_open_kitchen;
     duringOpenKitchen.value = currentCookingProcessOrder.value?.during_open_kitchen;
     tent.value = currentCookingProcessOrder.value?.tent;
+    handleChangepreOpenKitchen(currentCookingProcessOrder.value?.pre_open_kitchen);
+    handleChangeduringOpenKitchen(currentCookingProcessOrder.value?.during_open_kitchen);
+    handleChangetent(currentCookingProcessOrder.value?.tent);
   });
 
   const settingUrl = config.APIURL + "/user_page_settings";
@@ -47,7 +46,6 @@ onMounted(() => {
       },
     })
     .then((response) => {
-      setting.value = response.data.data[0];
       isEditGroup.value = response.data.data[0].is_edit_group;
     });
 });
@@ -92,9 +90,9 @@ const register = () => {
 
 const buttonDisabled = computed(() => {
   return !!(
-    preOpenKitchen.value &&
-    duringOpenKitchen.value &&
-    tent.value
+    !preOpenKitchen.value ||
+    !duringOpenKitchen.value ||
+    !tent.value
   );
 });
 </script>
@@ -191,7 +189,7 @@ const buttonDisabled = computed(() => {
         v-if="isEditGroup"
         @click="register"
         class="regist-button"
-        :disabled="!buttonDisabled || isSubmitting"
+        :disabled="buttonDisabled || !meta.valid || isSubmitting"
         :text="$t('Button.register')"
       ></RegistPageButton>
     </div>

--- a/user_front/pages/mypage/edit_user_info/index.vue
+++ b/user_front/pages/mypage/edit_user_info/index.vue
@@ -1,10 +1,6 @@
 <script lang="ts" setup>
-import { loginCheck } from "@/utils/methods";
 import { useForm, useField } from "vee-validate";
-import { userDetailSchema } from "~~/utils/validate";
-import { User, UserDetail, EditUser, CurrentUser } from "~~/types/currentUser";
-import { gradeList, GradeWithDepartmentList } from "~/utils/list";
-import { NoScript } from '../../../.nuxt/components';
+import { User, UserDetail, CurrentUser } from "~~/types/currentUser";
 import { Setting } from "~~/types";
 
 const config = useRuntimeConfig();

--- a/user_front/pages/mypage/password_reset/index.vue
+++ b/user_front/pages/mypage/password_reset/index.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
 import axios from "axios";
-import { loginCheck } from "@/utils/methods";
 import { useForm, useField } from "vee-validate";
-import { PasswordResetParams } from "~~/types/Mypage/passwordReset";
+import { PasswordResetParams } from "~~/types/mypage/passwordReset";
 
 definePageMeta({
   layout: false,

--- a/user_front/types/regist/announcement.ts
+++ b/user_front/types/regist/announcement.ts
@@ -1,0 +1,8 @@
+export interface Announcement {
+    id: number;
+    group_id: number;
+    message: string;
+    status: string;
+    created_at: string;
+    updated_at: string;
+}

--- a/user_front/types/regist/cookingProcessOrder.ts
+++ b/user_front/types/regist/cookingProcessOrder.ts
@@ -1,10 +1,9 @@
 export interface CookingProcessOrder {
     id: number;
     group_id: number;
-    pre_open_kitchen: Text;
-    pre_open_tent: Text;
-    during_open_kitchen: Text;
-    during_open_tent: Text;
+    pre_open_kitchen: boolean;
+    during_open_kitchen: boolean;
+    tent: Text;
     created_at: string;
     updated_at: string;
 }

--- a/user_front/utils/validate.ts
+++ b/user_front/utils/validate.ts
@@ -292,5 +292,5 @@ export const announcementSchema = object({
         return wordCount <= 125;
       }
     }),
-  status: string().required("選択してください\nPlease enter"),
+  status: string().required("選択してください\nPlease select"),
 });

--- a/user_front/utils/validate.ts
+++ b/user_front/utils/validate.ts
@@ -273,8 +273,7 @@ export const contactPersonSchema = object({
 });
 
 export const cookingProcessOrderSchema = object({
-  preOpenKitchen: string().required("入力してください\nPlease enter"),
-  preOpenTent: string().required("入力してください\nPlease enter"),
-  duringOpenKitchen: string().required("入力してください\nPlease enter"),
-  duringOpenTent: string().required("入力してください\nPlease enter"),
+  preOpenKitchen: boolean().required("入力してください\nPlease enter"),
+  duringOpenKitchen: boolean().required("入力してください\nPlease enter"),
+  tent: string().required("入力してください\nPlease enter"),
 });

--- a/user_front/utils/validate.ts
+++ b/user_front/utils/validate.ts
@@ -272,8 +272,25 @@ export const contactPersonSchema = object({
   email: string().email('メールアドレスをご確認ください\nPlease check your e-mail address').required("入力してください\nPlease enter")
 });
 
+// cookingProcess登録のバリデーション
 export const cookingProcessOrderSchema = object({
   preOpenKitchen: boolean().required("入力してください\nPlease enter"),
   duringOpenKitchen: boolean().required("入力してください\nPlease enter"),
   tent: string().required("入力してください\nPlease enter"),
+});
+
+// announcement登録のバリデーション
+export const announcementSchema = object({
+  message: string().required("入力してください\nPlease enter")
+    .test('is-valid-length', '日本語の場合は300字未満、英語の場合は125words未満で入力してください\nPlease enter less than 300 characters for Japanese and less than 125 words for English', (value) => {
+      if (!value) return true;
+      const isJapanese = /[\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}ーa-zA-Z0-9ａ-ｚＡ-Ｚ０-９々〆〤]/u.test(value);
+      if (isJapanese) {
+        return value.length <= 300;
+      } else {
+        const wordCount = value.split(' ').length;
+        return wordCount <= 125;
+      }
+    }),
+  status: string().required("選択してください\nPlease enter"),
 });


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1623 
resolve #1621 

# 概要
<!-- 開発内容の概要を記載 -->
- ユーザー画面の空値申請をできないようにする
  - ユーザー画面のバリデーションの掛け方を統一する
- 調理工程申請を申請情報を修正する

変更前
- テキスト
    - 営業前調理場
    - 営業前テント内
    - 営業中調理場
    - 営業中テント内

変更後
- 使用する or 使用しない
    - 営業前調理場
    - 営業中調理場
- テキスト
    - テント内


# 実装詳細
<!-- 具体的な開発内容を記載 -->
- cooking_process_orderテーブルのカラム変更

変更前
```
（text）pre_open_kitchen
（text）pre_open_tent
（text）during_open_kitchen
（text）during_open_tent
```
変更後
```
（boolean）pre_open_kitchen
（boolean）during_open_kitchen
（text）tent
```
- ユーザー画面の調理工程申請ページの変更
- 管理者画面の調理工程申請の一覧ページの追加モーダルの変更
- 管理者画面の調理工程申請の詳細ページの変更
  - 表示される表のレイアウト変更
  - 編集モーダルの変更

- 空値の時にバリデーションをかけるようにする
  - バリデーションを`VeeValidate`と`Yup`で統一する
    - 団体団体情報の編集ページ
    - 実行委員担当者登録＆編集
    - アナウンス文編集ページ
    - 調理工程申請ページ

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- ユーザー画面の調理工程申請ページの変更
  <img width="998" alt="スクリーンショット 2024-05-22 23 01 46" src="https://github.com/NUTFes/group-manager-2/assets/107479066/2295cf95-0db4-4667-84b3-0576246b1cf0">

- 管理者画面の調理工程申請の一覧ページの追加モーダルの変更
  <img width="1140" alt="スクリーンショット 2024-05-22 22 22 27" src="https://github.com/NUTFes/group-manager-2/assets/107479066/27f7583e-e918-459f-9ac1-252644df0945">

- 管理者画面の調理工程申請の詳細ページの変更
  - 表示される表のレイアウト変更
    <img width="1171" alt="スクリーンショット 2024-05-22 22 23 24" src="https://github.com/NUTFes/group-manager-2/assets/107479066/b48c1f92-2013-4313-ae9b-6c9afbff9dbc">

  - 編集モーダルの変更
    <img width="1145" alt="スクリーンショット 2024-05-22 22 23 49" src="https://github.com/NUTFes/group-manager-2/assets/107479066/21d8eecf-e785-46b0-86ed-1a9479cc2b68">

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
はじめに`docker compose down -v` → `make build` or `make build mac`をする
- [x] ユーザー画面の調理工程申請で正しく申請できる
  - [x] バリデーションが正しくかかっている
  - [x] 申請済みの場合初期値が正しく入っている
- [x] 管理者画面の調理工程申請の一覧ページ
  - [x] 申請状況が正しく表示されている
  - [x] 追加モーダルで正しく追加できる
  - [x] 正しくcsv出力ができる
- [x] 管理者画面の調理工程申請の詳細ページ
  - [x] 申請情報が正しく表示されている
  - [x] 編集モーダルで正しく編集できる
  - [x] 削除ボタンで削除できる
- [x] ユーザー画面のバリデーションが正しくかかっている
  - [x] 団体団体情報の編集ページ
  - [x] 実行委員担当者登録＆編集
  - [x] アナウンス文編集ページ
  - [x] 調理工程申請ページ

# 備考
<!-- 実装していて困った箇所・質問など -->
- バリデーションの統一を残りの申請ページにも実装する
    - ユーザー情報確認&編集ページ
    - パスワード変更ページ
    - PR文編集
    - 模擬店平面図