### PR TITLE
[fix] 副代表登録がある場合のみ副代表を表示するようにする (#1657)

### DIFF
--- a/api/app/views/print_pdf/output_health_office_documents.pdf.erb
+++ b/api/app/views/print_pdf/output_health_office_documents.pdf.erb
@@ -14,12 +14,14 @@
         <td class="Name"><%=group.user.name %></td>
         <td class="Category">生徒</td>
       </tr>
-      <tr>
-        <td class="No">2</td>
-        <td class="Belonging"><%=group.name %></td>
-        <td class="Name"><%=group.sub_rep.name %></td>
-        <td class="Category">生徒</td>
-      </tr>
+      <% if group.sub_rep %>
+        <tr>
+          <td class="No">2</td>
+          <td class="Belonging"><%=group.name %></td>
+          <td class="Name"><%= group.sub_rep.name %></td>
+          <td class="Category">生徒</td>
+        </tr>
+      <% end %>
       <% group.employees.each_with_index do |employee, index| %>
         <tr>
           <td class="No"><%= index +3%></td>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1657 

# 概要
<!-- 開発内容の概要を記載 -->
- subrepがない場合にエラーが起こるバグを修正

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- subrepがある場合だけ保健所提出資料のPDF出力に副代表情報を表示するようにする
  - `<% if group.sub_rep %>` で場合分けした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 副代表を登録していない団体は副代表以外の情報が表示される
- [ ] 副代表を登録している団体は副代表の情報も表示される
- [ ] 副代表を登録している団体と登録していない団体が混ざっている場合も出力される

# 備考
<!-- 実装していて困った箇所・質問など -->
