### PR TITLE
[fix] 申請状況一覧ページの購入品申請のバグ修正

### DIFF
--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -89,13 +89,13 @@
               <div v-else-if="group.group_category !== 1">ー</div>
               <div v-else>✖️</div>
             </td>
-            <td :class="{ unregistered: !group.food_products && (group.group_category === 1 || group.group_category === 2) }">
-              <div v-if="group.food_products && group.food_products.food_product">◯</div>
+            <td :class="{ unregistered: !group.food_product && (group.group_category === 1 || group.group_category === 2) }">
+              <div v-if="group.food_product">◯</div>
               <div v-else-if="group.group_category !== 1 && group.group_category !== 2">ー</div>
               <div v-else>✖️</div>
             </td>
-            <td :class="{ unregistered: !(group.food_products && group.food_products.purchase_lists) && group.group_category === 1 }">
-              <div v-if="group.food_products && group.food_products.purchase_lists">◯</div>
+            <td :class="{ unregistered: !group.purchase_list && group.group_category === 1 }">
+              <div v-if="group.purchase_list">◯</div>
               <div v-else-if="group.group_category !== 1">ー</div>
               <div v-else>✖️</div>
             </td>
@@ -204,6 +204,7 @@ export default {
     }),
   },
   mounted() {
+    console.log(this.groups)
     const storedYearID = localStorage.getItem(this.$route.path + "RefYear");
 
     if (storedYearID) {
@@ -275,7 +276,6 @@ export default {
       this.fetchFilteredData();
     },
     updateFilters(item_id, name_list) {
-      console.log(item_id, name_list[0]);
       // fes_yearで絞り込むとき
       if (name_list.toString() == this.yearList.toString()) {
         this.refYearID = item_id;

--- a/api/app/controllers/api/v1/order_status_check_api_controller.rb
+++ b/api/app/controllers/api/v1/order_status_check_api_controller.rb
@@ -21,11 +21,8 @@ class Api::V1::OrderStatusCheckApiController < ApplicationController
           "power_orders": group.power_orders.count == 0 ? nil : group.power_orders[0].id,
           "rental_orders": group.rental_orders.count == 0 ? nil : group.rental_orders[0].id,
           "employees": group.employees.count == 0 ? nil : group.employees[0].id,
-          "food_products": group.food_products.empty? ? nil :
-            {
-              "food_product": group.food_products.first.nil? ? nil : group.food_products.first.id,
-              "purchase_lists": group.food_products.first.nil? || group.food_products.first.purchase_lists.empty? ? nil : group.food_products.first.purchase_lists[0].id
-            },
+          "food_product": group.food_products.empty? ? nil : true,
+          "purchase_list": group.food_products.empty? ? nil : group.food_products.any? { |food_product| !food_product.purchase_lists.empty? } ? true : nil,
           "public_relation": group.public_relation.nil? ? nil : group.public_relation.id,
           "venue_map": group.venue_map.nil? ? nil : group.venue_map.id,
           "announcement": group.announcement.nil? ? nil : group.announcement.status,


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1663 

# 概要
<!-- 開発内容の概要を記載 -->
- 最初の販売品に紐づく購入品で判断していたので、二つ目以降の販売品に紐づく購入品があっても×になっていた。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 購入品申請があったらtrueを返すようにした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 一つ目の販売品は `加工しない` にして、二つ目の販売品を `加工する` にして購入品を追加する時に◯になるか
- [x] 販売品がない場合に×になるか
- [x] 購入品がない場合に×になるか

# 備考
<!-- 実装していて困った箇所・質問など -->
