### PR TITLE
管理者画面の参加団体申請ページの表のヘッダーの表示をグループ名→参加団体

### DIFF
--- a/admin_view/nuxt-project/pages/groups/index.vue
+++ b/admin_view/nuxt-project/pages/groups/index.vue
@@ -210,7 +210,7 @@ export default {
       groupCategories: [],
       headers: [
         "ID",
-        "グループ名",
+        "参加団体",
         "委員",
         "国際",
         "学外",


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolve #1673 

# 概要
<!-- 開発内容の概要を記載 -->
- 管理者画面の参加団体申請ページの表のヘッダーの表示を変更した．
グループ名→参加団体

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- pages/group/index.vue
headersの中のグループ名を参加団体に変えた

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![{C8382DC2-E22C-4E8D-8187-5A5E06CF45F4}](https://github.com/user-attachments/assets/47e3e703-3085-47c2-836d-94ffeb8a8d39)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] ヘッダーが参加団体に変更されていることを確認する 
- [ ] 
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
