### PR TITLE
管理者画面の会場申請一覧のplaceで枠からはみ出す選択肢の修正

### DIFF
--- a/admin_view/nuxt-project/components/SearchDropDown.vue
+++ b/admin_view/nuxt-project/components/SearchDropDown.vue
@@ -84,7 +84,7 @@ export default {
 .drop-down-button {
   border-radius: 0px;
   width: 160px;
-  height: 35px;
+  height: auto;
   padding: 5px 5px 5px 15px;
   backdrop-filter: blur(4px);
   text-align: center;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1675

# 概要
<!-- 開発内容の概要を記載 -->
- drop-down-buttonのheightを35pxからautoに変更

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- admin_view/nuxt-project/components/SearchDropDown.vue

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x]  プルダウンの選択肢がはみ出していないか


# 備考
<!-- 実装していて困った箇所・質問など -->
選択肢の高さが35px未満になってる箇所があります。最低高さが35px以上である必要はあるか確認お願いします。