### PR TITLE
[fix]管理者画面で絞り込みをAllから個別名に変える(#1708)

### DIFF
--- a/admin_view/nuxt-project/pages/announcement/index.vue
+++ b/admin_view/nuxt-project/pages/announcement/index.vue
@@ -222,7 +222,7 @@ export default {
       this.refYearID = item_id;
       // ALLの時
       if (item_id == 0) {
-        this.refYears = "ALL";
+        this.refYears = "ALL Years";
       } else {
         this.refYears = name_list[item_id - 1].year_num;
       }

--- a/admin_view/nuxt-project/pages/cooking_process_order/index.vue
+++ b/admin_view/nuxt-project/pages/cooking_process_order/index.vue
@@ -252,7 +252,7 @@ export default {
       this.refYearID = item_id;
       // ALLの時
       if (item_id == 0) {
-        this.refYears = "ALL";
+        this.refYears = "ALL Years";
       } else {
         this.refYears = name_list[item_id - 1].year_num;
       }

--- a/admin_view/nuxt-project/pages/employees/index.vue
+++ b/admin_view/nuxt-project/pages/employees/index.vue
@@ -187,7 +187,7 @@ export default {
       this.refYearID = item_id;
       // ALLの時
       if (item_id == 0) {
-        this.refYears = "ALL";
+        this.refYears = "ALL Years";
       } else {
         this.refYears = name_list[item_id - 1].year_num;
       }

--- a/admin_view/nuxt-project/pages/food_products/index.vue
+++ b/admin_view/nuxt-project/pages/food_products/index.vue
@@ -279,7 +279,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Yeras";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -290,7 +290,7 @@ export default {
         this.refIsCookingID = item_id;
         // ALLの時
         if (item_id === 0) {
-          this.refIsCooking = "ALL";
+          this.refIsCooking = "ALL Cooking states";
         } else {
           this.refIsCooking = name_list[item_id - 1].text;
         }
@@ -300,7 +300,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id === 0) {
-          this.refCategory = "ALL";
+          this.refCategory = "ALL Categorys";
         } else {
           this.refCategory = name_list[item_id - 1].text;
         }

--- a/admin_view/nuxt-project/pages/food_products/index.vue
+++ b/admin_view/nuxt-project/pages/food_products/index.vue
@@ -290,7 +290,7 @@ export default {
         this.refIsCookingID = item_id;
         // ALLの時
         if (item_id === 0) {
-          this.refIsCooking = "ALL Cooking states";
+          this.refIsCooking = "ALL Cooking States";
         } else {
           this.refIsCooking = name_list[item_id - 1].text;
         }

--- a/admin_view/nuxt-project/pages/groups/index.vue
+++ b/admin_view/nuxt-project/pages/groups/index.vue
@@ -346,7 +346,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -355,7 +355,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refGroupCategories = "ALL";
+          this.refGroupCategories = "ALL Categories";
         } else {
           this.refGroupCategories = name_list[item_id - 1].name;
         }
@@ -364,7 +364,7 @@ export default {
         this.refCommitteeID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refCommittee = "ALL";
+          this.refCommittee = "ALL Applicants";
         } else {
           this.refCommittee = name_list[item_id - 1].value;
         }
@@ -373,7 +373,7 @@ export default {
         this.refInternationalID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refInternational = "ALL";
+          this.refInternational = "ALL Nationalities";
         } else {
           this.refInternational = name_list[item_id - 1].value;
         }
@@ -382,7 +382,7 @@ export default {
         this.refExternalID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refExternal = "ALL";
+          this.refExternal = "ALL Groups";
         } else {
           this.refExternal = name_list[item_id - 1].value;
         }

--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -281,7 +281,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -289,7 +289,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refGroupCategories = "ALL";
+          this.refGroupCategories = "ALL Categories";
         } else {
           this.refGroupCategories = name_list[item_id - 1].name;
         }
@@ -298,7 +298,7 @@ export default {
         this.refInternationalID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refInternational = "ALL";
+          this.refInternational = "ALL Nationalities";
         } else {
           this.refInternational = name_list[item_id - 1].value;
         }
@@ -307,7 +307,7 @@ export default {
         this.refExternalID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refExternal = "ALL";
+          this.refExternal = "ALL Gloups";
         } else {
           this.refExternal = name_list[item_id - 1].value;
         }

--- a/admin_view/nuxt-project/pages/place_orders/index.vue
+++ b/admin_view/nuxt-project/pages/place_orders/index.vue
@@ -267,7 +267,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -275,7 +275,7 @@ export default {
         this.refPlaceID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refPlaces = "ALL";
+          this.refPlaces = "ALL Places";
         } else {
           this.refPlaces = name_list[item_id - 1].name;
         }
@@ -284,7 +284,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refGroupCategories = "ALL";
+          this.refGroupCategories = "ALL Categories";
         } else {
           this.refGroupCategories = name_list[item_id - 1].name;
         }

--- a/admin_view/nuxt-project/pages/power_orders/index.vue
+++ b/admin_view/nuxt-project/pages/power_orders/index.vue
@@ -252,7 +252,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -269,7 +269,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refGroupCategories = "ALL";
+          this.refGroupCategories = "ALL Categories";
         } else {
           this.refGroupCategories = name_list[item_id - 1].name;
         }

--- a/admin_view/nuxt-project/pages/public_relations/index.vue
+++ b/admin_view/nuxt-project/pages/public_relations/index.vue
@@ -279,7 +279,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }

--- a/admin_view/nuxt-project/pages/purchase_lists/index.vue
+++ b/admin_view/nuxt-project/pages/purchase_lists/index.vue
@@ -274,7 +274,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -283,7 +283,7 @@ export default {
         this.refIsFreshID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsFresh = "ALL";
+          this.refIsFresh = "ALL Food";
         } else {
           this.refIsFresh = name_list[item_id - 1].value;
         }

--- a/admin_view/nuxt-project/pages/rental_orders/index.vue
+++ b/admin_view/nuxt-project/pages/rental_orders/index.vue
@@ -227,7 +227,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -236,7 +236,7 @@ export default {
         this.refRentalItemID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refRentalItems = "ALL";
+          this.refRentalItems = "ALL Iteams";
         } else {
           this.refRentalItems = name_list[item_id - 1].name;
         }
@@ -245,7 +245,7 @@ export default {
         this.refCategoryID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refGroupCategories = "ALL";
+          this.refGroupCategories = "ALL Categories";
         } else {
           this.refGroupCategories = name_list[item_id - 1].name;
         }

--- a/admin_view/nuxt-project/pages/representatives/index.vue
+++ b/admin_view/nuxt-project/pages/representatives/index.vue
@@ -244,7 +244,7 @@ export default {
       this.refYearID = item_id;
       // ALLの時
       if (item_id == 0) {
-        this.refYears = "ALL";
+        this.refYears = "ALL Years";
       } else {
         this.refYears = name_list[item_id - 1].year_num;
       }

--- a/admin_view/nuxt-project/pages/stage_common_options/index.vue
+++ b/admin_view/nuxt-project/pages/stage_common_options/index.vue
@@ -328,7 +328,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -337,7 +337,7 @@ export default {
         this.refIsOwnEquipmentID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsOwnEquipment = "ALL";
+          this.refIsOwnEquipment = "All Devices: Owned or Not";
         } else {
           this.refIsOwnEquipment = name_list[item_id - 1].value;
         }
@@ -346,7 +346,7 @@ export default {
         this.refIsBgmID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsBgm = "ALL";
+          this.refIsBgm = "All Music Options";
         } else {
           this.refIsBgm = name_list[item_id - 1].value;
         }
@@ -355,7 +355,7 @@ export default {
         this.refIsCameraPermissionID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsCameraPermission = "ALL";
+          this.refIsCameraPermission = "ALL Shooting Permissions";
         } else {
           this.refIsCameraPermission = name_list[item_id - 1].value;
         }
@@ -364,7 +364,7 @@ export default {
         this.refIsLoudSoundID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsLoudSound = "ALL";
+          this.refIsLoudSound = "ALL Sound Levels";
         } else {
           this.refIsLoudSound = name_list[item_id - 1].value;
         }

--- a/admin_view/nuxt-project/pages/stage_orders/index.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/index.vue
@@ -430,7 +430,7 @@ export default {
         this.refIsSunnyID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsSunny = "ALL Weather";
+          this.refIsSunny = "ALL Weather: Sunny or Not";
         } else {
           this.refIsSunny = name_list[item_id - 1].text;
         }
@@ -444,7 +444,7 @@ export default {
           this.refDaysNum = name_list[item_id - 1].days_num;
         }
         // stage_idで絞り込むとき
-      } else if (name_list.toString() == this.stageList.toString()) {
+      } else if (JSON.stringify(name_list) === JSON.stringify(this.stageList)) {
         this.refStageID = item_id;
         // ALLの時
         if (item_id == 0) {

--- a/admin_view/nuxt-project/pages/stage_orders/index.vue
+++ b/admin_view/nuxt-project/pages/stage_orders/index.vue
@@ -421,7 +421,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }
@@ -430,7 +430,7 @@ export default {
         this.refIsSunnyID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refIsSunny = "ALL";
+          this.refIsSunny = "ALL Weather";
         } else {
           this.refIsSunny = name_list[item_id - 1].text;
         }
@@ -439,7 +439,7 @@ export default {
         this.refDaysNumID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refDaysNum = "ALL";
+          this.refDaysNum = "ALL Days";
         } else {
           this.refDaysNum = name_list[item_id - 1].days_num;
         }
@@ -448,7 +448,7 @@ export default {
         this.refStageID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refStage = "ALL";
+          this.refStage = "ALL Stages";
         } else {
           this.refStage = name_list[item_id - 1].name;
         }

--- a/admin_view/nuxt-project/pages/venue_maps/index.vue
+++ b/admin_view/nuxt-project/pages/venue_maps/index.vue
@@ -292,7 +292,7 @@ export default {
         this.refYearID = item_id;
         // ALLの時
         if (item_id == 0) {
-          this.refYears = "ALL";
+          this.refYears = "ALL Years";
         } else {
           this.refYears = name_list[item_id - 1].year_num;
         }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1708 

# 概要
<!-- 開発内容の概要を記載 -->
- 管理者画面で絞り込みを「All」ではなく名前を付ける

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 管理者画面の申請情報の全15ページの絞込の”ALL”を個別の名前に変更する

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![{F104AE94-DE75-4325-8BB1-27F91D9D276A}](https://github.com/user-attachments/assets/16cd385b-2660-4f4c-8794-8e5ea4c633b3)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 全てのALLが個別の名前に変わっているか
- [x] 英語の意味が伝わるか
- [x] 英語が正しいか

# 備考
<!-- 実装していて困った箇所・質問など -->
pushするとdevelopに直接mergeしてしまう．pushしたブランチのheadがoriginになっていたことが原因だった

ステージ申請の「Stage」の部分も変えたが，変更が適用されない．
これは何等かのバグがありそうだが解決できなかったので，バグは放置している