### PR TITLE
希望場所申請の備考欄を別の欄にして作成した。

### DIFF
--- a/admin_view/nuxt-project/components/SearchDropDown.vue
+++ b/admin_view/nuxt-project/components/SearchDropDown.vue
@@ -84,7 +84,7 @@ export default {
 .drop-down-button {
   border-radius: 0px;
   width: 160px;
-  height: 35px;
+  height: auto;
   padding: 5px 5px 5px 15px;
   backdrop-filter: blur(4px);
   text-align: center;

--- a/user_front/components/RegistInfo/card/Place.vue
+++ b/user_front/components/RegistInfo/card/Place.vue
@@ -58,6 +58,7 @@ const openEditModal = () => {
         <div class="w-[40%] text-center text-4xl">
           {{ place.place }}
         </div>
+        <!-- 以下備考欄の記述 -->
         <!-- <div class="w-[13%] h-[80%] text-base">{{ $t('Place.free') }}</div>
           <div class="w-[25%] h-[80%] pr-1 break-normal break-words text-ellipsis overflow-hidden">
             {{ place.remark }}

--- a/user_front/components/RegistInfo/card/Place.vue
+++ b/user_front/components/RegistInfo/card/Place.vue
@@ -55,7 +55,7 @@ const openEditModal = () => {
           {{ $t('Place.hope1') }}{{ place.n }}{{ $t('Place.hope2') }}
         </div>
         <RegistInfoDivideBar />
-        <div class="w-[40%] text-center text-4xl">
+        <div class="w-[65%] text-center text-4xl">
           {{ place.place }}
         </div>
         <!-- 以下備考欄の記述 -->

--- a/user_front/components/RegistInfo/card/Place.vue
+++ b/user_front/components/RegistInfo/card/Place.vue
@@ -82,3 +82,6 @@ const openEditModal = () => {
     @reload-place="reloadPlace()"
   />
 </template>
+
+export default remark;
+

--- a/user_front/components/RegistInfo/card/Place.vue
+++ b/user_front/components/RegistInfo/card/Place.vue
@@ -58,10 +58,10 @@ const openEditModal = () => {
         <div class="w-[40%] text-center text-4xl">
           {{ place.place }}
         </div>
-        <div class="w-[13%] h-[80%] text-base">{{ $t('Place.free') }}</div>
+        <!-- <div class="w-[13%] h-[80%] text-base">{{ $t('Place.free') }}</div>
           <div class="w-[25%] h-[80%] pr-1 break-normal break-words text-ellipsis overflow-hidden">
             {{ place.remark }}
-          </div>
+          </div> -->
       </template>
       <template v-if="isEditPlace" #method>
         <div class="mx-4">

--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -470,10 +470,13 @@ const isStageOverlap = computed(() => {
               @reload-place="reload"
             />
           </div>
-          <div class="w-[13%] h-[80%] text-base color=red">{{ $t('Place.free') }}</div>
-          <div class="w-[25%] h-[80%] pr-1 break-normal break-words text-ellipsis overflow-hidden">
-            {{ placeOrder?.remark}}
+          <div class="bg-white w-[55%]">
+            <div class="w-[100%] h-[80%] text-base color=red">{{ $t('Place.free') }}</div>
+            <div class="w-[80%]  pr-1 break-normal break-words text-ellipsis overflow-hidden ">
+              {{ placeOrder?.remark}}
+            </div>
           </div>
+         
         </div>
 
         <!-- ステージ申請 group_category_id === ３ -->

--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -2,6 +2,7 @@
 import { is } from "@vee-validate/rules";
 import axios from "axios";
 import { Group } from "~~/types";
+import Place from "~~/components/RegistInfo/card/Place.vue";
 
 interface RegistInfo {
   sub_rep: SubRep[];
@@ -468,6 +469,10 @@ const isStageOverlap = computed(() => {
               :remark="placeOrder?.remark"
               @reload-place="reload"
             />
+          </div>
+          <div class="w-[13%] h-[80%] text-base color=red">{{ $t('Place.free') }}</div>
+          <div class="w-[25%] h-[80%] pr-1 break-normal break-words text-ellipsis overflow-hidden">
+            {{ Place.Exremark }}
           </div>
         </div>
 

--- a/user_front/pages/regist_info/index.vue
+++ b/user_front/pages/regist_info/index.vue
@@ -472,7 +472,7 @@ const isStageOverlap = computed(() => {
           </div>
           <div class="w-[13%] h-[80%] text-base color=red">{{ $t('Place.free') }}</div>
           <div class="w-[25%] h-[80%] pr-1 break-normal break-words text-ellipsis overflow-hidden">
-            {{ Place.Exremark }}
+            {{ placeOrder?.remark}}
           </div>
         </div>
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1695 

# 概要
<!-- 開発内容の概要を記載 -->
- 希望場所申請画面で第１希望から第３希望までのそれぞれにあった備考欄を統合して別の場所に設置した。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 希望場所単位にあった備考欄を削除
- 備考欄を空いた場所に設置
- 備考さん移動に際してremarkのファイル間での共有が必要だった。（大変だったし、不備があるかもしれない。）
- 新備考欄の最低限のデザインを作成（新しいタスクとしてデザインの作成お願いします。）
- 希望場所のwidthを少し調整した。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
タスク完了後からプルリク書く数分の間にgm2にログインできなくなったため画面スクショはなし。復旧次第編集で貼り付けます。すいません。（おそらくdocker compose down -vがいけなかった）

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 第１希望から第３希望までが適切に表示できているか
- [ ] 備考欄が表示されているか
- [ ] 編集ボタンが機能するか
- [ ] リセットを押すまで備考欄の内容が消えずに保存され続けるかどうか（何度か編集できるかどうか）

# 備考
<!-- 実装していて困った箇所・質問など -->
似たような名前のファイル（パス名もややこしい）ばっかりをいじっていたのも相まって備考欄の記述を探すのに1.2時間かかった。
remarkのファイル間での共有がなかなかできなくてここで4時間くらい戦ってた。
開発時間：6~7時間