### PR TITLE
[gm3] Uploadコンポーネント作成

### DIFF
--- a/user/.scaffdog/templates/template.md
+++ b/user/.scaffdog/templates/template.md
@@ -18,7 +18,7 @@ export { default } from "./{{ inputs.name | pascal }}";
 ```typescript
 import { Meta, StoryObj } from '@storybook/react';
 import {{ inputs.name | pascal }} from './{{ inputs.name | pascal }}';
-import "../../styles/globals.css";
+import "@globals";
 
 export default {
 title: 'Components/{{ inputs.name | pascal }}',

--- a/user/src/components/Upload/Upload.stories.tsx
+++ b/user/src/components/Upload/Upload.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from "@storybook/react";
+import Upload from "./Upload";
+import "@globals";
+
+export default {
+  title: "Components/Upload",
+  tags: ["autodocs"],
+  component: Upload,
+  parameters: {
+    docs: {
+      source: {
+        type: "auto",
+      },
+    },
+  },
+} as Meta<typeof Upload>;
+
+type Story = StoryObj<typeof Upload>;
+
+export const Default: Story = {
+  args: {
+    title: "PR画像",
+    note: [
+      "画像名：参加形式_団体名",
+      "ファイル形式：png、jpeg",
+      "ファイルサイズ：10MB未満",
+      "画像、イラストの形：正方形（できれば料理の写真)",
+    ],
+    onClick: () => alert("クリックされたよ"),
+  },
+};

--- a/user/src/components/Upload/Upload.stories.tsx
+++ b/user/src/components/Upload/Upload.stories.tsx
@@ -26,6 +26,8 @@ export const Default: Story = {
       "ファイルサイズ：10MB未満",
       "画像、イラストの形：正方形（できれば料理の写真)",
     ],
+    error: "画像の送信に失敗しました。",
     onClick: () => alert("クリックされたよ"),
+    idDisable: false,
   },
 };

--- a/user/src/components/Upload/Upload.tsx
+++ b/user/src/components/Upload/Upload.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+import { MdUploadFile } from "react-icons/md";
+
+// NOTE: 箇条書きで列挙できるようにnoteを配列で定義
+type UploadProps = {
+  title: string;
+  note: string[];
+  onClick: () => void;
+};
+
+const Upload: FC<UploadProps> = ({ title, note = [], onClick }) => {
+  return (
+    <div className="w-[402px] flex-col justify-start items-start gap-1 inline-flex">
+      <div className="self-stretch justify-start items-baseline gap-6 inline-flex">
+        <div className="text-font text-base font-medium">{title}</div>
+        <div className="text-center text-alert text-xs font-light">※必須</div>
+      </div>
+      <div className="h-[72px] px-12 py-4 bg-baseColor rounded-[10px] shadow-[2px_2px_4px_0px_rgba(0,0,0,0.25)] border border-main justify-center items-center gap-4 inline-flex overflow-hidden">
+        <div className="flex items-center justify-center">
+          <MdUploadFile className="text-main w-[40px] h-[40px]" />
+        </div>
+        <button
+          className="text-center text-main text-[26px] font-bold"
+          onClick={onClick}
+        >
+          アップロード
+        </button>
+      </div>
+      <ul className="self-stretch text-font text-xs font-light list-disc list-inside">
+        {note.map((line, idx) => (
+          <li key={idx}>{line}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Upload;

--- a/user/src/components/Upload/Upload.tsx
+++ b/user/src/components/Upload/Upload.tsx
@@ -6,32 +6,49 @@ type UploadProps = {
   title: string;
   note: string[];
   onClick: () => void;
+  idDisable: boolean;
+  error?: string;
 };
 
-const Upload: FC<UploadProps> = ({ title, note = [], onClick }) => {
+const Upload: FC<UploadProps> = ({
+  title,
+  note = [],
+  onClick,
+  idDisable,
+  error = "",
+}) => {
   return (
-    <div className="w-[402px] flex-col justify-start items-start gap-1 inline-flex">
+    <button
+      onClick={onClick}
+      disabled={idDisable}
+      className="w-[402px] flex-col justify-start items-start gap-1 inline-flex"
+    >
       <div className="self-stretch justify-start items-baseline gap-6 inline-flex">
         <div className="text-font text-base font-medium">{title}</div>
         <div className="text-center text-alert text-xs font-light">※必須</div>
       </div>
-      <div className="h-[72px] px-12 py-4 bg-baseColor rounded-[10px] shadow-[2px_2px_4px_0px_rgba(0,0,0,0.25)] border border-main justify-center items-center gap-4 inline-flex overflow-hidden">
+      <div
+        className={`h-[72px] px-12 py-4 bg-baseColor rounded-[10px] shadow-[2px_2px_4px_0px_rgba(0,0,0,0.25)] border border-main
+        justify-center items-center gap-4 inline-flex overflow-hidden transition-transform duration-150 ease-in-out
+        ${idDisable ? "bg-gray-300 cursor-not-allowed" : "bg-base hover:bg-gray-200"}
+        active:scale-95`}
+      >
         <div className="flex items-center justify-center">
           <MdUploadFile className="text-main w-[40px] h-[40px]" />
         </div>
-        <button
-          className="text-center text-main text-[26px] font-bold"
-          onClick={onClick}
-        >
+        <div className="text-center text-main text-[26px] font-bold">
           アップロード
-        </button>
+        </div>
       </div>
-      <ul className="self-stretch text-font text-xs font-light list-disc list-inside">
+      <ul className="text-left text-font text-xs font-light list-disc list-inside">
         {note.map((line, idx) => (
           <li key={idx}>{line}</li>
         ))}
       </ul>
-    </div>
+      <div className="text-xs text-alert max-w-[402px] break-words">
+        {error}
+      </div>
+    </button>
   );
 };
 

--- a/user/src/components/Upload/index.ts
+++ b/user/src/components/Upload/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Upload";

--- a/user/tsconfig.json
+++ b/user/tsconfig.json
@@ -15,7 +15,8 @@
     "incremental": true,
     "paths": {
       "@/*": ["./src/*"],
-      "@/components": ["./src/components"]
+      "@/components": ["./src/components"],
+      "@globals": ["./src/styles/globals.css"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1740

# 概要
<!-- 開発内容の概要を記載 -->
- Uploadのコンポーネントを作成

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- propsとして、titile,note,onClickの三つを定義
- それぞれ、title:ボタン上のテキスト(PR画像など)、note:注意書き部分(PNG形式にしてくださいなど)、onClick:クリック時の動作を渡す。
- noteに関しては箇条書きを改行して表示させるために配列で渡せるようにしています

PS.
新たにerror,isDisableのpropsを追加
errorはエラーメッセージのstring
isDisableは処理中にクリックさせないためのboolean
ボタンホバー時、クリック時のアニメーション追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/user-attachments/assets/457a62d9-741c-4060-b96a-6f3552655b95)

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] storybook上でデザインとの差異がないか確認
- [x] propsの要素がこれでよいか
- [x] コードレビュー

# 備考
<!-- 実装していて困った箇所・質問など -->

Upload自体にバックグラウンドカラーを当てる事も可能だけどいらない感じがしたので付けてません。