### PR TITLE
[gm3]会場申請コンポーネント作成

### DIFF
--- a/user/src/api/api.ts
+++ b/user/src/api/api.ts
@@ -1,3 +1,5 @@
+import snakecaseKeys from 'snakecase-keys';
+
 /**
  * APIのベースURL
  * 環境変数から読み込む
@@ -24,6 +26,37 @@ export const fetcher = (url: string) => {
       throw error;
     });
 };
+
+/**
+ * POSTリクエスト用のfetcher関数
+ * @param url - リクエスト先のベースURL
+ * @param param1 - SWR Mutationで渡される引数（bodyとqueryを含む）
+ * @returns レスポンスのJSON
+ */
+export async function postFetcher(
+  url: string,
+  { arg }: { arg: { body?: any; query?: { [key: string]: any } } }
+): Promise<any> {
+  // queryパラメータが存在する場合、URLに追加
+  let finalUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
+  if (arg.query) {
+    const queryStr = objectToQueryString(arg.query);
+    finalUrl = `${API_URL}${url}?${queryStr}`;
+  }
+
+  const response = await fetch(finalUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(arg.body),
+  });
+
+  if (!response.ok) {
+    throw new Error('Error posting data');
+  }
+  return response.json();
+}
 
 /**
  * リクエストオプションを生成するヘルパー関数
@@ -92,3 +125,18 @@ export const putData = async (url: string, data: any) => {
 export const deleteData = async (url: string) => {
   return sendRequest(url, createRequestOptions('DELETE'));
 };
+
+/**
+ * オブジェクトをクエリパラメータ文字列に変換するユーティリティ関数
+ * @param params - キーと値の組み合わせが格納されたオブジェクト
+ * @returns クエリパラメータ形式の文字列
+ */
+function objectToQueryString(params: { [key: string]: any }): string {
+  const snakeParams = snakecaseKeys(params, { deep: true });
+  return Object.keys(snakeParams)
+    .map(
+      (key) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(snakeParams[key])}`
+    )
+    .join('&');
+}

--- a/user/src/api/venueApplication.ts
+++ b/user/src/api/venueApplication.ts
@@ -1,0 +1,50 @@
+import useSWRMutation from 'swr/mutation';
+import { useApiGet } from '@/hooks/useApi';
+import { postFetcher } from './api';
+
+export type FesDate = {
+  id: number;
+  date: string;
+};
+
+export type Stage = {
+  id: number;
+  name: string;
+};
+
+const API_ENDPOINTS = {
+  PLACES: '/places',
+  VENUE_MAPS: '/place_orders',
+};
+
+export type Place = {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// APIレスポンス型定義
+type ApiResponse<T> = {
+  data: T[];
+};
+
+// フォームデータの取得用フック
+export const usePlacesData = () => {
+  const {
+    data: fesDateResponse,
+    error: fesDateError,
+    isLoading: fesDateLoading,
+  } = useApiGet<ApiResponse<Place>>(API_ENDPOINTS.PLACES);
+  return {
+    places: fesDateResponse?.data || [],
+    placesError: fesDateError,
+    placesLoading: fesDateLoading,
+  };
+};
+
+// データ送信用フック
+export const usePlacesOrderMutations = () => {
+  const urlPath = API_ENDPOINTS.VENUE_MAPS;
+  return useSWRMutation(urlPath, postFetcher);
+};

--- a/user/src/components/Form/Selector/Selector.tsx
+++ b/user/src/components/Form/Selector/Selector.tsx
@@ -13,6 +13,7 @@ type SelectorProps = {
   note?: string;
   error?: string;
   options: Option[];
+  disableOptions?: number[];
 };
 
 const Selector: FC<SelectorProps> = ({
@@ -23,6 +24,7 @@ const Selector: FC<SelectorProps> = ({
   note,
   error,
   options = [],
+  disableOptions = [],
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     onChange(event.target.value);
@@ -41,7 +43,11 @@ const Selector: FC<SelectorProps> = ({
           className={`w-[400px] h-12 text-font border-2 rounded-[10px] ${error ? 'border-alert' : 'border-main'} mb-[4px]`}
         >
           {options.map((option) => (
-            <option key={option.id} value={option.id}>
+            <option
+              key={option.id}
+              value={option.id}
+              disabled={disableOptions.includes(option.id)}
+            >
               {option.name}
             </option>
           ))}

--- a/user/src/components/Form/Selector/Selector.tsx
+++ b/user/src/components/Form/Selector/Selector.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC } from 'react';
 
 type Option = {
   id: number;
@@ -7,7 +7,7 @@ type Option = {
 
 type SelectorProps = {
   label: string;
-  value: string;
+  value: number | string;
   onChange: (value: string) => void;
   required?: boolean;
   note?: string;
@@ -38,7 +38,7 @@ const Selector: FC<SelectorProps> = ({
         <select
           value={value}
           onChange={handleChange}
-          className={`w-[400px] h-12 text-font border-2 rounded-[10px] ${error ? "border-alert" : "border-main"} mb-[4px]`}
+          className={`w-[400px] h-12 text-font border-2 rounded-[10px] ${error ? 'border-alert' : 'border-main'} mb-[4px]`}
         >
           {options.map((option) => (
             <option key={option.id} value={option.id}>

--- a/user/src/components/VenueApplication/VenueApplication.stories.tsx
+++ b/user/src/components/VenueApplication/VenueApplication.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import VenueApplication from './VenueApplication';
+import "@globals";
+
+export default {
+title: 'Components/VenueApplication',
+tags: ["autodocs"],
+component: VenueApplication,
+parameters: {
+    docs: {
+      source: {
+        type: "auto",
+      },
+    },
+  },
+} as Meta<typeof VenueApplication>;
+
+type Story = StoryObj<typeof VenueApplication>;
+
+export const Default: Story = {
+  args: {
+
+  },
+};

--- a/user/src/components/VenueApplication/VenueApplication.tsx
+++ b/user/src/components/VenueApplication/VenueApplication.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import AccordionMenu from '../AccordionMenu';
+import {
+  getIsOpenAccordionMenuAtom,
+  setIsOpenAccordionMenuAtom,
+} from './store';
+
+type VenueApplicationProps = {};
+
+const VenueApplication: FC<VenueApplicationProps> = () => {
+  const isOpen = useAtomValue(getIsOpenAccordionMenuAtom);
+  const [, toggleIsOpen] = useAtom(setIsOpenAccordionMenuAtom);
+
+  return (
+    <AccordionMenu
+      title="ステージオプション申請"
+      isEdit={false}
+      isExist={false}
+      required
+      isOpen={isOpen}
+      onToggle={toggleIsOpen}
+      onSubmit={() => {}}
+    >
+      aaa
+    </AccordionMenu>
+  );
+};
+
+export default VenueApplication;

--- a/user/src/components/VenueApplication/VenueApplication.tsx
+++ b/user/src/components/VenueApplication/VenueApplication.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import AccordionMenu from '../AccordionMenu';
+import VenueApplicationForm from './VenueApplicationForm';
 import {
   getIsOpenAccordionMenuAtom,
   setIsOpenAccordionMenuAtom,
@@ -14,7 +15,7 @@ const VenueApplication: FC<VenueApplicationProps> = () => {
 
   return (
     <AccordionMenu
-      title="ステージオプション申請"
+      title="会場申請"
       isEdit={false}
       isExist={false}
       required
@@ -22,7 +23,7 @@ const VenueApplication: FC<VenueApplicationProps> = () => {
       onToggle={toggleIsOpen}
       onSubmit={() => {}}
     >
-      aaa
+      <VenueApplicationForm />
     </AccordionMenu>
   );
 };

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.stories.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.stories.tsx
@@ -1,0 +1,22 @@
+import '@globals';
+import { Meta, StoryObj } from '@storybook/react';
+import VenueApplicationForm from './VenueApplicationForm';
+
+export default {
+  title: 'Components/VenueApplicationForm',
+  tags: ['autodocs'],
+  component: VenueApplicationForm,
+  parameters: {
+    docs: {
+      source: {
+        type: 'auto',
+      },
+    },
+  },
+} as Meta<typeof VenueApplicationForm>;
+
+type Story = StoryObj<typeof VenueApplicationForm>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
@@ -1,62 +1,26 @@
 import { FC } from 'react';
-import { usePlacesData, usePlacesOrderMutations } from '@/api/venueApplication';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
 import Button from '@/components/Button';
 import Selector from '@/components/Form/Selector';
 import TextArea from '@/components/Form/TextArea';
 import FormContainer from '@/components/FormContainer';
-import { convertPlacesToOptions } from '../hooks';
-import {
-  DEFAULT_ID,
-  VenueApplicationType,
-  venueApplicationFormSchema,
-} from './schema';
+import { useVenueMapHooks } from './hooks';
 
 type VenueApplicationFormProps = {};
 
 const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
   const {
-    handleSubmit,
-    formState: { errors },
+    placesLoading,
+    isMutating,
+    options,
+    values,
+    errors,
     setValue,
-    watch,
-  } = useForm<VenueApplicationType>({
-    resolver: zodResolver(venueApplicationFormSchema),
-    defaultValues: {
-      // FIX: group_idの取得は団体申請実装時に追加。
-      groupId: 4,
-      first: DEFAULT_ID,
-      second: DEFAULT_ID,
-      third: DEFAULT_ID,
-      remark: '',
-    },
-  });
-  const { trigger, error, isMutating } = usePlacesOrderMutations();
-
-  const { places, placesLoading } = usePlacesData();
+    onSubmit,
+    handleSubmit,
+  } = useVenueMapHooks();
   if (placesLoading || isMutating) {
     return <div>loading...</div>;
   }
-
-  const values = watch();
-  const options = convertPlacesToOptions(places);
-  const onSubmit = async (formData: VenueApplicationType) => {
-    if (errors.first || errors.second || errors.third || errors.remark) {
-      console.error(errors);
-      alert('入力エラーがあります。');
-      return;
-    }
-    try {
-      await trigger({
-        query: formData,
-      });
-      alert('送信しました');
-    } catch {
-      console.error(error);
-      alert('送信に失敗しました。');
-    }
-  };
 
   return (
     <FormContainer>

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
@@ -17,6 +17,7 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
     setValue,
     onSubmit,
     handleSubmit,
+    disableOptions,
   } = useVenueMapHooks();
   if (placesLoading || isMutating) {
     return <div>loading...</div>;
@@ -30,6 +31,7 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
           <Selector
             label="第一希望"
             options={options}
+            disableOptions={disableOptions}
             value={values.first}
             onChange={(value) => setValue('first', Number(value))}
             error={errors.first?.message}
@@ -37,6 +39,7 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
           <Selector
             label="第二希望"
             options={options}
+            disableOptions={disableOptions}
             value={values.second}
             onChange={(value) => setValue('second', Number(value))}
             error={errors.second?.message}
@@ -44,6 +47,7 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
           <Selector
             label="第三希望"
             options={options}
+            disableOptions={disableOptions}
             value={values.third}
             onChange={(value) => setValue('third', Number(value))}
             error={errors.third?.message}

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+import Button from '@/components/Button';
+import Selector from '@/components/Form/Selector';
+import TextArea from '@/components/Form/TextArea';
+import FormContainer from '@/components/FormContainer';
+
+type VenueApplicationFormProps = {};
+
+const options = [
+  { id: 0, name: '選択してください' },
+  { id: 1, name: '講義棟部屋A' },
+  { id: 2, name: '講義棟部屋B' },
+  { id: 3, name: 'A講義室' },
+];
+
+const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
+  return (
+    <FormContainer>
+      <form className="w-full">
+        <div className="flex flex-col space-y-10"></div>
+        <div className="w-full flex flex-col gap-10 justify-center items-center mt-10">
+          <Selector
+            label="第一希望"
+            options={options}
+            value=""
+            onChange={function (value: string): void {
+              throw new Error('Function not implemented.');
+            }}
+            required
+          />
+          <Selector
+            label="第二希望"
+            options={options}
+            value=""
+            onChange={function (value: string): void {
+              throw new Error('Function not implemented.');
+            }}
+            required
+          />
+          <Selector
+            label="第三希望"
+            options={options}
+            value=""
+            onChange={function (value: string): void {
+              throw new Error('Function not implemented.');
+            }}
+            required
+          />
+          <TextArea
+            label="備考"
+            value=""
+            onChange={function (value: string): void {
+              throw new Error('Function not implemented.');
+            }}
+          />
+          <Button size="pc" color="main" type="submit">
+            登録
+          </Button>
+        </div>
+      </form>
+    </FormContainer>
+  );
+};
+
+export default VenueApplicationForm;

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
@@ -27,7 +27,7 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
     <FormContainer>
       <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col space-y-10"></div>
-        <div className="w-full flex flex-col gap-10 justify-center items-center mt-10">
+        <div className="w-full flex flex-col gap-10 justify-center items-center">
           <Selector
             label="第一希望"
             options={options}

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
@@ -1,57 +1,86 @@
 import { FC } from 'react';
+import { usePlacesData, usePlacesOrderMutations } from '@/api/venueApplication';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
 import Button from '@/components/Button';
 import Selector from '@/components/Form/Selector';
 import TextArea from '@/components/Form/TextArea';
 import FormContainer from '@/components/FormContainer';
+import { convertPlacesToOptions } from '../hooks';
+import { VenueApplicationType, venueApplicationFormSchema } from './schema';
 
 type VenueApplicationFormProps = {};
 
-const options = [
-  { id: 0, name: '選択してください' },
-  { id: 1, name: '講義棟部屋A' },
-  { id: 2, name: '講義棟部屋B' },
-  { id: 3, name: 'A講義室' },
-];
-
 const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
+  const {
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useForm<VenueApplicationType>({
+    resolver: zodResolver(venueApplicationFormSchema),
+    defaultValues: {
+      // FIX: group_idの取得は団体申請実装時に追加。
+      groupId: 4,
+      first: 0,
+      second: 0,
+      third: 0,
+      remark: '',
+    },
+  });
+  const { trigger, error, isMutating } = usePlacesOrderMutations();
+
+  const { places, placesLoading } = usePlacesData();
+  if (placesLoading || isMutating) {
+    return <div>loading...</div>;
+  }
+
+  const values = watch();
+  const options = convertPlacesToOptions(places);
+  const onSubmit = async (formData: VenueApplicationType) => {
+    if (errors.first || errors.second || errors.third || errors.remark) {
+      console.error(errors);
+      alert('入力エラーがあります。');
+      return;
+    }
+    try {
+      await trigger({
+        query: formData,
+      });
+      alert('送信しました');
+    } catch {
+      console.error(error);
+      alert('送信に失敗しました。');
+    }
+  };
+
   return (
     <FormContainer>
-      <form className="w-full">
+      <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col space-y-10"></div>
         <div className="w-full flex flex-col gap-10 justify-center items-center mt-10">
           <Selector
             label="第一希望"
             options={options}
-            value=""
-            onChange={function (value: string): void {
-              throw new Error('Function not implemented.');
-            }}
-            required
+            value={values.first}
+            onChange={(value) => setValue('first', Number(value))}
           />
           <Selector
             label="第二希望"
             options={options}
-            value=""
-            onChange={function (value: string): void {
-              throw new Error('Function not implemented.');
-            }}
-            required
+            value={values.second}
+            onChange={(value) => setValue('second', Number(value))}
           />
           <Selector
             label="第三希望"
             options={options}
-            value=""
-            onChange={function (value: string): void {
-              throw new Error('Function not implemented.');
-            }}
-            required
+            value={values.third}
+            onChange={(value) => setValue('third', Number(value))}
           />
           <TextArea
             label="備考"
-            value=""
-            onChange={function (value: string): void {
-              throw new Error('Function not implemented.');
-            }}
+            value={values.remark ?? ''}
+            onChange={(value) => setValue('remark', value)}
           />
           <Button size="pc" color="main" type="submit">
             登録

--- a/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
+++ b/user/src/components/VenueApplication/VenueApplicationForm/VenueApplicationForm.tsx
@@ -7,7 +7,11 @@ import Selector from '@/components/Form/Selector';
 import TextArea from '@/components/Form/TextArea';
 import FormContainer from '@/components/FormContainer';
 import { convertPlacesToOptions } from '../hooks';
-import { VenueApplicationType, venueApplicationFormSchema } from './schema';
+import {
+  DEFAULT_ID,
+  VenueApplicationType,
+  venueApplicationFormSchema,
+} from './schema';
 
 type VenueApplicationFormProps = {};
 
@@ -22,9 +26,9 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
     defaultValues: {
       // FIX: group_idの取得は団体申請実装時に追加。
       groupId: 4,
-      first: 0,
-      second: 0,
-      third: 0,
+      first: DEFAULT_ID,
+      second: DEFAULT_ID,
+      third: DEFAULT_ID,
       remark: '',
     },
   });
@@ -64,23 +68,27 @@ const VenueApplicationForm: FC<VenueApplicationFormProps> = () => {
             options={options}
             value={values.first}
             onChange={(value) => setValue('first', Number(value))}
+            error={errors.first?.message}
           />
           <Selector
             label="第二希望"
             options={options}
             value={values.second}
             onChange={(value) => setValue('second', Number(value))}
+            error={errors.second?.message}
           />
           <Selector
             label="第三希望"
             options={options}
             value={values.third}
             onChange={(value) => setValue('third', Number(value))}
+            error={errors.third?.message}
           />
           <TextArea
             label="備考"
             value={values.remark ?? ''}
             onChange={(value) => setValue('remark', value)}
+            error={errors.remark?.message}
           />
           <Button size="pc" color="main" type="submit">
             登録

--- a/user/src/components/VenueApplication/VenueApplicationForm/hooks.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/hooks.ts
@@ -1,0 +1,70 @@
+import {
+  Place,
+  usePlacesData,
+  usePlacesOrderMutations,
+} from '@/api/venueApplication';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import {
+  DEFAULT_ID,
+  VenueApplicationType,
+  venueApplicationFormSchema,
+} from './schema';
+
+export const useVenueMapHooks = () => {
+  const convertPlacesToOptions = (places: Place[]) => {
+    return places.map((place) => {
+      return { id: place.id, name: place.name };
+    });
+  };
+
+  const {
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useForm<VenueApplicationType>({
+    resolver: zodResolver(venueApplicationFormSchema),
+    defaultValues: {
+      // FIX: group_idの取得は団体申請実装時に追加。
+      groupId: 4,
+      first: DEFAULT_ID,
+      second: DEFAULT_ID,
+      third: DEFAULT_ID,
+      remark: '',
+    },
+  });
+  const { trigger, error, isMutating } = usePlacesOrderMutations();
+
+  const { places, placesLoading } = usePlacesData();
+  const values = watch();
+
+  const options = convertPlacesToOptions(places);
+  const onSubmit = async (formData: VenueApplicationType) => {
+    if (errors.first || errors.second || errors.third || errors.remark) {
+      console.error(errors);
+      alert('入力エラーがあります。');
+      return;
+    }
+    try {
+      await trigger({
+        query: formData,
+      });
+      alert('送信しました');
+    } catch {
+      console.error(error);
+      alert('送信に失敗しました。');
+    }
+  };
+
+  return {
+    placesLoading,
+    isMutating,
+    options,
+    values,
+    errors,
+    setValue,
+    onSubmit,
+    handleSubmit,
+  };
+};

--- a/user/src/components/VenueApplication/VenueApplicationForm/hooks.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/hooks.ts
@@ -12,12 +12,6 @@ import {
 } from './schema';
 
 export const useVenueMapHooks = () => {
-  const convertPlacesToOptions = (places: Place[]) => {
-    return places.map((place) => {
-      return { id: place.id, name: place.name };
-    });
-  };
-
   const {
     handleSubmit,
     formState: { errors },
@@ -40,6 +34,11 @@ export const useVenueMapHooks = () => {
   const values = watch();
 
   const options = convertPlacesToOptions(places);
+  const disableOptions = extractDisableOptions([
+    values.first,
+    values.second,
+    values.third,
+  ]);
   const onSubmit = async (formData: VenueApplicationType) => {
     if (errors.first || errors.second || errors.third || errors.remark) {
       console.error(errors);
@@ -66,5 +65,16 @@ export const useVenueMapHooks = () => {
     setValue,
     onSubmit,
     handleSubmit,
+    disableOptions,
   };
+};
+
+const convertPlacesToOptions = (places: Place[]) => {
+  return places.map((place) => {
+    return { id: place.id, name: place.name };
+  });
+};
+
+const extractDisableOptions = (values: number[]) => {
+  return values.filter((value) => value !== DEFAULT_ID);
 };

--- a/user/src/components/VenueApplication/VenueApplicationForm/index.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from './VenueApplicationForm';

--- a/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
@@ -1,11 +1,35 @@
 import { z } from 'zod';
 
-export const venueApplicationFormSchema = z.object({
-  groupId: z.number({ required_error: '入力してください' }).int().default(1),
-  first: z.number({ required_error: '入力してください' }),
-  second: z.number({ required_error: '入力してください' }),
-  third: z.number({ required_error: '入力してください' }),
-  remark: z.string().optional(),
-});
+export const DEFAULT_ID = 1;
+export const venueApplicationFormSchema = z
+  .object({
+    groupId: z.number({ required_error: '入力してください' }).int().default(1),
+    first: z.number({ required_error: '入力してください' }),
+    second: z.number({ required_error: '入力してください' }),
+    third: z.number({ required_error: '入力してください' }),
+    remark: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const fields = [
+      { field: 'first', value: data.first },
+      { field: 'second', value: data.second },
+      { field: 'third', value: data.third },
+    ];
+    const freq: Record<number, number> = {};
+    fields.forEach(({ value }) => {
+      if (value !== DEFAULT_ID) {
+        freq[value] = (freq[value] || DEFAULT_ID) + 1;
+      }
+    });
+    fields.forEach(({ field, value }) => {
+      if (value !== DEFAULT_ID && freq[value] > 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '希望が重複しています',
+          path: [field],
+        });
+      }
+    });
+  });
 
 export type VenueApplicationType = z.infer<typeof venueApplicationFormSchema>;

--- a/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
@@ -18,7 +18,7 @@ export const venueApplicationFormSchema = z
     const freq: Record<number, number> = {};
     fields.forEach(({ value }) => {
       if (value !== DEFAULT_ID) {
-        freq[value] = (freq[value] || DEFAULT_ID) + 1;
+        freq[value] = (freq[value] || 0) + 1;
       }
     });
     fields.forEach(({ field, value }) => {

--- a/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
 export const DEFAULT_ID = 1;
+// NOTE: その他の選択肢のIDは11としている
+const OTHER_OPTION_ID = 11;
+
 export const venueApplicationFormSchema = z
   .object({
     groupId: z.number({ required_error: '入力してください' }).int().default(1),
@@ -27,6 +30,15 @@ export const venueApplicationFormSchema = z
           code: z.ZodIssueCode.custom,
           message: '希望が重複しています',
           path: [field],
+        });
+      }
+
+      // その他の選択肢が選択された場合、備考に場所が入力されているかチェック
+      if (value === OTHER_OPTION_ID && !data.remark) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '備考に場所を入力してください',
+          path: ['remark'],
         });
       }
     });

--- a/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod';
 
 export const venueApplicationFormSchema = z.object({
-  // groupId: z.number({ required_error: '入力してください' }).int().default(1),
-  // ownEquipment: z.number({ required_error: '入力してください' }),
-  // bgm: z.number({ required_error: '入力してください' }),
-  // cameraPermission: z.number({ required_error: '入力してください' }),
-  // loudSound: z.number({ required_error: '入力してください' }),
-  // remarks: z.string().optional(),
+  groupId: z.number({ required_error: '入力してください' }).int().default(1),
+  first: z.number({ required_error: '入力してください' }),
+  second: z.number({ required_error: '入力してください' }),
+  third: z.number({ required_error: '入力してください' }),
+  remark: z.string().optional(),
 });
 
-export type VenueApplicationForm = z.infer<typeof venueApplicationFormSchema>;
+export type VenueApplicationType = z.infer<typeof venueApplicationFormSchema>;

--- a/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
+++ b/user/src/components/VenueApplication/VenueApplicationForm/schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const venueApplicationFormSchema = z.object({
+  // groupId: z.number({ required_error: '入力してください' }).int().default(1),
+  // ownEquipment: z.number({ required_error: '入力してください' }),
+  // bgm: z.number({ required_error: '入力してください' }),
+  // cameraPermission: z.number({ required_error: '入力してください' }),
+  // loudSound: z.number({ required_error: '入力してください' }),
+  // remarks: z.string().optional(),
+});
+
+export type VenueApplicationForm = z.infer<typeof venueApplicationFormSchema>;

--- a/user/src/components/VenueApplication/hooks/index.ts
+++ b/user/src/components/VenueApplication/hooks/index.ts
@@ -1,0 +1,7 @@
+import { Place } from '@/api/venueApplication';
+
+export const convertPlacesToOptions = (places: Place[]) => {
+  return places.map((place) => {
+    return { id: place.id, name: place.name };
+  });
+};

--- a/user/src/components/VenueApplication/hooks/index.ts
+++ b/user/src/components/VenueApplication/hooks/index.ts
@@ -1,7 +1,0 @@
-import { Place } from '@/api/venueApplication';
-
-export const convertPlacesToOptions = (places: Place[]) => {
-  return places.map((place) => {
-    return { id: place.id, name: place.name };
-  });
-};

--- a/user/src/components/VenueApplication/index.ts
+++ b/user/src/components/VenueApplication/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VenueApplication";

--- a/user/src/components/VenueApplication/store.ts
+++ b/user/src/components/VenueApplication/store.ts
@@ -1,0 +1,12 @@
+import { atom } from 'jotai';
+
+const isOpenAccordionMenuAtom = atom(false);
+
+export const getIsOpenAccordionMenuAtom = atom((get) =>
+  get(isOpenAccordionMenuAtom)
+);
+
+export const setIsOpenAccordionMenuAtom = atom(null, (get, set) => {
+  const toggledIsOpen: boolean = !get(isOpenAccordionMenuAtom);
+  set(isOpenAccordionMenuAtom, toggledIsOpen);
+});

--- a/user/src/pages/index.tsx
+++ b/user/src/pages/index.tsx
@@ -62,7 +62,6 @@ export default function Home() {
             Read our docs
           </a>
         </div>
-        <VenueApplication />
       </main>
       <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
         <a

--- a/user/src/pages/index.tsx
+++ b/user/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import localFont from 'next/font/local';
 import Image from 'next/image';
+import VenueApplication from '@/components/VenueApplication';
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -61,6 +62,7 @@ export default function Home() {
             Read our docs
           </a>
         </div>
+        <VenueApplication />
       </main>
       <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
         <a


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #1776 

# 概要
<!-- 開発内容の概要を記載 -->
- コンポーネントUI作成
  - 選択肢はDBから取得しています、変更する必要がある場合はseedを修正します  
- コンポーネントを開くと、/placesを叩き、選択肢を取得
- セレクトボックスで選択→登録ボタン押下でplace_orderを登録

# 実装詳細
<!-- 具体的な開発内容を記載 -->

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

<img width="592" alt="スクリーンショット 2025-03-22 10 28 24" src="https://github.com/user-attachments/assets/ee36e259-7e0e-432b-957e-49e1494f52ae" />
<img width="562" alt="スクリーンショット 2025-03-22 10 28 59" src="https://github.com/user-attachments/assets/0377cc53-9c75-4ab1-a12f-50559607514d" />

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] storybookで表示されるか（選択肢はapiを叩く必要があるため表示されない） 
- [x] コンポーネントをpages/index.tsxとかに配置して登録ができる確認

# 備考
<!-- 実装していて困った箇所・質問など -->
- group_idは固定してます
- userのenvにapiのURL追加する
- 動作確認どうやってしています？自分はホーム画面に一時的にコンポーネント追加してやりました
