### PR TITLE
feat: add auto-assign workflow for PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Assign PR
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Assign PR
+        uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
# 対応Issue

# 概要
- GitHub Actionsを使用して、PR作成者を自動的にAssigneeに設定するワークフローを追加しました。

# 実装詳細
- `.github/workflows/auto-assign.yml` ファイルを作成し、auto-assignアクションを設定しました。
- PR作成時に作成者がAssigneeとして自動的に設定されるようにしました。

# 画面スクリーンショット等
（該当なし）

# テスト項目
- [ ] PR作成時に作成者がAssigneeとして自動的に設定されることを確認
- [ ] ワークフローがエラーなく実行されることを確認

# 備考
- 必要に応じて設定を変更してください。
