### PR TITLE
お知らせリストに改行を適用

### DIFF
--- a/admin_view/nuxt-project/pages/news/_id.vue
+++ b/admin_view/nuxt-project/pages/news/_id.vue
@@ -23,7 +23,7 @@
             </tr>
             <tr>
               <th>内容</th>
-              <td>{{ news.body }}</td>
+              <td :style="{ whiteSpace: 'pre-line' }">{{ news.body }}</td>
             </tr>
             <tr>
               <th>登録日時</th>

--- a/admin_view/nuxt-project/pages/news/index.vue
+++ b/admin_view/nuxt-project/pages/news/index.vue
@@ -121,12 +121,14 @@ export default {
       });
     },
     async submit() {
+      const encodedBody = encodeURIComponent(this.body.replace(/\r\n?/g, "\n"));
+
       const url =
         "/news/" +
         "?title=" +
         this.title +
         "&body=" +
-        this.body
+        encodedBody
 
       this.$axios.$post(url).then((res) => {
         this.title = "";

--- a/api/app/models/news.rb
+++ b/api/app/models/news.rb
@@ -1,2 +1,9 @@
 class News < ApplicationRecord
-end
+    before_save :normalize_body_newlines
+
+    private
+
+    def normalize_body_newlines
+      self.body = body.gsub(/\r\n?/, "\n") if body.present?
+    end
+  end

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -24,7 +24,7 @@ const NewsList: FC<NewsListProps> = () => {
     return (
       <div key={item.id} className="flex flex-col gap-2">
         <span className="w-24 text-base font-medium text-font">{date}</span>
-        <span className="w-56 text-base font-medium text-font">
+        <span className="w-56 whitespace-pre-line text-base font-medium text-font">
           {item.body}
         </span>
       </div>

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -24,7 +24,7 @@ const NewsList: FC<NewsListProps> = () => {
     return (
       <div key={item.id} className="flex flex-col gap-2">
         <span className="w-24 text-base font-medium text-font">{date}</span>
-        <span className="w-56 whitespace-pre-line text-base font-medium text-font">
+        <span className="w-full whitespace-pre-line text-base font-medium text-font">
           {item.body}
         </span>
       </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #0

# 概要
<!-- 開発内容の概要を記載 -->
- お知らせそ作成する時、改行が認識されていなかったので/nのコードを認識させるようにしました。
- 表示側も治ってるはず

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
こんな感じ～
![image](https://github.com/user-attachments/assets/19ac32a5-b242-4b51-b60d-1031960a49fe)
![image](https://github.com/user-attachments/assets/2db30604-1ef8-46e0-8b83-dfcba460a72e)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 
- [ ] 
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
