### PR TITLE
管理者ページの確認欄に「-」を表示する条件を追加

### DIFF
--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -57,8 +57,9 @@
           <tr v-for="(group, index) in groups" :key="index">
             <td>{{ group.group.id }}</td>
             <td>{{ group.group.name }}</td>
-            <td :class="{ unregistered: !group.sub_rep }">
+            <td :class="{ unregistered: !group.sub_rep && !isUnregistered(group.group.id, 'sub_rep') }">
               <div v-if="group.sub_rep">◯</div>
+              <div v-else-if="isUnregistered(group.group.id, 'sub_rep')">ー</div>
               <div v-else>✖️</div>
             </td>
             <td :class="{ unregistered: !group.place_order && !group.group.is_international && group.group_category !== 3 }">
@@ -66,12 +67,14 @@
               <div v-else-if="group.group.is_international || group.group_category === 3">ー</div>
               <div v-else>✖️</div>
             </td>
-            <td :class="{ unregistered: !group.power_orders }">
+            <td :class="{ unregistered: !group.power_orders && !isUnregistered(group.group.id, 'power_order') }">
               <div v-if="group.power_orders">◯</div>
+              <div v-else-if="isUnregistered(group.group.id, 'power_order')">ー</div>
               <div v-else>✖️</div>
             </td>
-            <td :class="{ unregistered: !group.rental_orders }">
+            <td :class="{ unregistered: !group.rental_orders && !isUnregistered(group.group.id, 'rental_item_order') }">
               <div v-if="group.rental_orders">◯</div>
+              <div v-else-if="isUnregistered(group.group.id, 'rental_item_order')">ー</div>
               <div v-else>✖️</div>
             </td>
             <td :class="{ unregistered: !group.stage_orders && group.group_category === 3 }">
@@ -150,6 +153,7 @@ export default {
         "調理工程",
       ],
       groups: [],
+      unregisteredGroups: [],
       group_categories: [],
       group_id: "",
       dialog: false,
@@ -190,8 +194,12 @@ export default {
       return element.id == currentYearRes.data.fes_year_id;
     });
 
+    // 申請しないデータを取得
+    const unregisteredGroupsRes = await $axios.$get("/un_registered_groups");
+
     return {
       groups: groupsRes.data,
+      unregisteredGroups: unregisteredGroupsRes.data,
       groupCategories: groupCategoryRes.data,
       yearList: yearsRes.data,
       refYearID: currentYearRes.data.fes_year_id,
@@ -328,6 +336,11 @@ export default {
       for (const res of refRes.data) {
         this.groups.push(res);
       }
+
+      // 申請しないデータも再取得
+      const unregisteredRes = await this.$axios.$get("/un_registered_groups");
+      this.unregisteredGroups = unregisteredRes.data;
+
       const storedSearchText = localStorage.getItem(
         this.$route.path + "SearchText"
       );
@@ -351,6 +364,16 @@ export default {
       for (const res of refRes.data) {
         this.groups.push(res);
       }
+
+      // 検索時も申請しないデータを再取得
+      const unregisteredRes = await this.$axios.$get("/un_registered_groups");
+      this.unregisteredGroups = unregisteredRes.data;
+    },
+    // 申請しないデータかどうかを判定するメソッド
+    isUnregistered(groupId, orderType) {
+      return this.unregisteredGroups.some(item => 
+        item.group_id === groupId && item.order_type === orderType
+      );
     },
   },
 };


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1837 

# 概要
<!-- 開発内容の概要を記載 -->
- 「申請しない」を登録した申請項目が、管理者ページの申請状況一覧に「-」で表示されるように修正

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `/un_registered_groups` から申請しないデータを取得
- 副代表申請・物品申請・電力申請について、申請しないデータがある場合は「-」と表示
- 絞り込みや検索時にも「申請しない」データを再取得するよう処理を追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![6128a68d-6117-44ce-9f1f-abdd05446cb1](https://github.com/user-attachments/assets/f5882876-375c-4bd3-9907-371c31f4e6ae)
![4a11f3ed-6685-4a4d-8f3a-fc3a799b25f6](https://github.com/user-attachments/assets/adaf59d4-257e-429e-8823-1bc510c339b2)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] DBや管理者ページから該当するgroup_idの既存の申請を削除（`sub_reps`, `power_orders`, `rental_orders`）
- [ ] order_typeが0(物品), 1(電力), 2(副代表)で`/un_registered_groups`にPOST
- [x] 申請状況一覧ページ（`http://localhost:8000/order_status_check`）で該当グループの申請が「-」で表示されることを確認
- [x] 絞り込みや検索後も「-」表示が正しく表示されることを確認
