### PR TITLE
電力申請コンポーネント：「いいえ」選択時にFormListが表示されるように修正

### DIFF
--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -30,7 +30,8 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
   } = usePowerApplication(groupId);
 
   const { isEditing, applyPower, submitError, isSubmitted } = state;
-  const { fields, addDevice, removeDevice, totalPower, isValid, formMethods } = powerForm;
+  const { fields, addDevice, removeDevice, totalPower, isValid, formMethods } =
+    powerForm;
 
   const { mode, setNegativeEditMode } = usePowerDisplay({
     applyPower,

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -81,7 +81,9 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           radioOptions={RADIO_OPTIONS}
           onEdit={() => setNegativeEditMode(true)}
           isEdit={true}
-          onCancel={() => setNegativeEditMode(false)}
+          onCancel={
+            hasUnregistered ? () => setNegativeEditMode(false) : undefined
+          }
         />
       );
       break;

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -37,6 +37,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
     applyPower,
     hasExisting,
     isEditing,
+    hasUnregistered,
   });
 
   let content;
@@ -47,7 +48,27 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           radioValue={getRadioValue(applyPower)}
           onRadioChange={(v) => {
             handleRadioChange(v);
-            setNegativeEditMode(true);
+          }}
+          onNegativeSubmit={() => {
+            handleApplyNegative();
+            completeSubmission();
+            setNegativeEditMode(false);
+          }}
+          isSubmitted={isSubmitted}
+          submitError={submitError}
+          showRegisterButton={!hasUnregistered}
+          radioOptions={RADIO_OPTIONS}
+          onEdit={() => setNegativeEditMode(true)}
+          isEdit={true}
+        />
+      );
+      break;
+    case 'negativeRegister':
+      content = (
+        <PowerNegativeView
+          radioValue={getRadioValue(applyPower)}
+          onRadioChange={(v) => {
+            handleRadioChange(v);
           }}
           onNegativeSubmit={() => {
             handleApplyNegative();
@@ -82,28 +103,6 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           radioOptions={RADIO_OPTIONS}
           onEdit={() => setNegativeEditMode(true)}
           isEdit={false}
-        />
-      );
-      break;
-    case 'negativeRegister':
-      content = (
-        <PowerNegativeView
-          radioValue={getRadioValue(applyPower)}
-          onRadioChange={(v) => {
-            handleRadioChange(v);
-            setNegativeEditMode(true);
-          }}
-          onNegativeSubmit={() => {
-            handleApplyNegative();
-            completeSubmission();
-            setNegativeEditMode(false);
-          }}
-          isSubmitted={isSubmitted}
-          submitError={submitError}
-          showRegisterButton={!hasUnregistered}
-          radioOptions={RADIO_OPTIONS}
-          onEdit={() => setNegativeEditMode(true)}
-          isEdit={true}
         />
       );
       break;

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -81,6 +81,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           radioOptions={RADIO_OPTIONS}
           onEdit={() => setNegativeEditMode(true)}
           isEdit={true}
+          onCancel={() => setNegativeEditMode(false)}
         />
       );
       break;

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -38,6 +38,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
     hasExisting,
     isEditing,
     hasUnregistered,
+    isDeadline,
   });
 
   let content;
@@ -106,6 +107,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           radioOptions={RADIO_OPTIONS}
           onEdit={() => setNegativeEditMode(true)}
           isEdit={false}
+          isDeadline={isDeadline}
         />
       );
       break;

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -4,6 +4,7 @@ import { PowerNegativeView, PowerSummaryView } from './components';
 import { PowerFormView } from './components/PowerFormView';
 import { RADIO_OPTIONS } from './constants';
 import { usePowerApplication } from './hooks/usePowerApplication';
+import { usePowerDisplay } from './hooks/usePowerDisplay';
 
 type PowerProps = {
   isDeadline?: boolean;
@@ -15,8 +16,6 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
   // 電力申請のカスタムフックから状態とロジックの取得
   const {
     state,
-    isLoading,
-    hasError,
     hasExisting,
     hasUnregistered,
     devices,
@@ -31,75 +30,109 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
   } = usePowerApplication(groupId);
 
   const { isEditing, applyPower, submitError, isSubmitted } = state;
-  const { fields, addDevice, removeDevice, totalPower, isValid, formMethods } =
-    powerForm;
+  const { fields, addDevice, removeDevice, totalPower, isValid, formMethods } = powerForm;
 
-  // ローディング中の表示
-  if (isLoading) {
-    return (
-      <div className="w-[400px] py-4 text-center">
-        <p>データを読み込み中です...</p>
-      </div>
-    );
-  }
-
-  // エラー表示
-  if (hasError) {
-    return (
-      <div className="relative w-[400px] rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
-        <strong className="font-bold">エラー：</strong>
-        <span className="block sm:inline">
-          データの取得に失敗しました。ページを再読込してください。
-        </span>
-      </div>
-    );
-  }
+  const { mode, setNegativeEditMode } = usePowerDisplay({
+    applyPower,
+    hasExisting,
+    isEditing,
+  });
 
   let content;
-
-  // 「いいえ」が選択された場合は最優先で処理
-  if (applyPower === 'no') {
-    content = (
-      <PowerNegativeView
-        radioValue={getRadioValue(applyPower)}
-        onRadioChange={handleRadioChange}
-        onNegativeSubmit={() => {
-          handleApplyNegative();
-          completeSubmission();
-        }}
-        isSubmitted={isSubmitted}
-        submitError={submitError}
-        showRegisterButton={!hasUnregistered}
-        radioOptions={RADIO_OPTIONS}
-      />
-    );
-  } else if (hasExisting && !isEditing) {
-    // 既存データの表示（「いいえ」が選択されていない場合だけ）
-    content = (
-      <PowerSummaryView
-        devices={devices}
-        onEdit={prepareFormForEditing}
-        onDeleteDevice={handleDeleteDevice}
-        isDeadline={!isDeadline}
-      />
-    );
-  } else {
-    // 新規登録・編集モード
-    content = (
-      <PowerFormView
-        radioValue={getRadioValue(applyPower)}
-        onRadioChange={handleRadioChange}
-        formMethods={formMethods}
-        fields={fields}
-        onRemove={removeDevice}
-        onAddDevice={addDevice}
-        totalPower={totalPower}
-        isValid={isValid}
-        radioOptions={RADIO_OPTIONS}
-        showForm={applyPower === 'yes'}
-        onSubmit={handleFormSubmit}
-      />
-    );
+  switch (mode) {
+    case 'negativeUndecided':
+      content = (
+        <PowerNegativeView
+          radioValue={getRadioValue(applyPower)}
+          onRadioChange={(v) => {
+            handleRadioChange(v);
+            setNegativeEditMode(true);
+          }}
+          onNegativeSubmit={() => {
+            handleApplyNegative();
+            completeSubmission();
+            setNegativeEditMode(false);
+          }}
+          isSubmitted={isSubmitted}
+          submitError={submitError}
+          showRegisterButton={!hasUnregistered}
+          radioOptions={RADIO_OPTIONS}
+          onEdit={() => setNegativeEditMode(true)}
+          isEdit={true}
+        />
+      );
+      break;
+    case 'negativeDisplay':
+      content = (
+        <PowerNegativeView
+          radioValue={getRadioValue(applyPower)}
+          onRadioChange={(v) => {
+            handleRadioChange(v);
+            setNegativeEditMode(true);
+          }}
+          onNegativeSubmit={() => {
+            handleApplyNegative();
+            completeSubmission();
+            setNegativeEditMode(false);
+          }}
+          isSubmitted={isSubmitted}
+          submitError={submitError}
+          showRegisterButton={false}
+          radioOptions={RADIO_OPTIONS}
+          onEdit={() => setNegativeEditMode(true)}
+          isEdit={false}
+        />
+      );
+      break;
+    case 'negativeRegister':
+      content = (
+        <PowerNegativeView
+          radioValue={getRadioValue(applyPower)}
+          onRadioChange={(v) => {
+            handleRadioChange(v);
+            setNegativeEditMode(true);
+          }}
+          onNegativeSubmit={() => {
+            handleApplyNegative();
+            completeSubmission();
+            setNegativeEditMode(false);
+          }}
+          isSubmitted={isSubmitted}
+          submitError={submitError}
+          showRegisterButton={!hasUnregistered}
+          radioOptions={RADIO_OPTIONS}
+          onEdit={() => setNegativeEditMode(true)}
+          isEdit={true}
+        />
+      );
+      break;
+    case 'summary':
+      content = (
+        <PowerSummaryView
+          devices={devices}
+          onEdit={prepareFormForEditing}
+          onDeleteDevice={handleDeleteDevice}
+          isDeadline={!isDeadline}
+        />
+      );
+      break;
+    case 'form':
+    default:
+      content = (
+        <PowerFormView
+          radioValue={getRadioValue(applyPower)}
+          onRadioChange={handleRadioChange}
+          formMethods={formMethods}
+          fields={fields}
+          onRemove={removeDevice}
+          onAddDevice={addDevice}
+          totalPower={totalPower}
+          isValid={isValid}
+          radioOptions={RADIO_OPTIONS}
+          showForm={applyPower === 'yes'}
+          onSubmit={handleFormSubmit}
+        />
+      );
   }
 
   return (

--- a/user/src/components/Applications/Power/components/PowerNegativeView.tsx
+++ b/user/src/components/Applications/Power/components/PowerNegativeView.tsx
@@ -17,27 +17,26 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
   isEdit,
 }) => {
   const noApplicationItems: FormItem[] = [
-    { label: '電力申請は不要（登録済み）', content: '電力が必要な機器は使用しません。' }
+    {
+      label: '電力申請は不要（登録済み）',
+      content: '電力が必要な機器は使用しません。',
+    },
   ];
 
   return (
     <div className="flex flex-col gap-6 w-full">
       {isEdit && (
-      <Radio
-        label="電力申請を行いますか？"
-        value={radioValue}
-        onChange={onRadioChange}
-        required
-        options={radioOptions}
-      />
+        <Radio
+          label="電力申請を行いますか？"
+          value={radioValue}
+          onChange={onRadioChange}
+          required
+          options={radioOptions}
+        />
       )}
 
       {!isEdit && (
-      <FormList
-        items={noApplicationItems}
-        onEdit={onEdit}
-        isEdit={true}
-      />
+        <FormList items={noApplicationItems} onEdit={onEdit} isEdit={true} />
       )}
 
       {isEdit && !isSubmitted && showRegisterButton && (

--- a/user/src/components/Applications/Power/components/PowerNegativeView.tsx
+++ b/user/src/components/Applications/Power/components/PowerNegativeView.tsx
@@ -15,6 +15,7 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
   radioOptions,
   onEdit,
   isEdit,
+  onCancel,
 }) => {
   const noApplicationItems: FormItem[] = [
     {
@@ -26,13 +27,28 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
   return (
     <div className="flex w-full flex-col gap-6">
       {isEdit && (
-        <Radio
-          label="電力申請を行いますか？"
-          value={radioValue}
-          onChange={onRadioChange}
-          required
-          options={radioOptions}
-        />
+        <>
+          <Radio
+            label="電力申請を行いますか？"
+            value={radioValue}
+            onChange={onRadioChange}
+            required
+            options={radioOptions}
+          />
+          {onCancel && (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                size="pc"
+                color="main"
+                variant
+                onClick={onCancel}
+              >
+                キャンセル
+              </Button>
+            </div>
+          )}
+        </>
       )}
 
       {!isEdit && (

--- a/user/src/components/Applications/Power/components/PowerNegativeView.tsx
+++ b/user/src/components/Applications/Power/components/PowerNegativeView.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react';
 import Button from '@/components/Button/Button';
 import Radio from '@/components/Form/Radio/Radio';
+import FormList from '@/components/FormList/FormList';
+import { FormItem } from '@/components/FormList/type';
 import { PowerNegativeViewProps } from '../types';
 
 export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
@@ -11,10 +13,16 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
   submitError,
   showRegisterButton,
   radioOptions,
+  onEdit,
+  isEdit,
 }) => {
+  const noApplicationItems: FormItem[] = [
+    { label: '電力申請は不要（登録済み）', content: '電力が必要な機器は使用しません。' }
+  ];
+
   return (
-    <div className="flex flex-col gap-6">
-      {/* ラジオボタン */}
+    <div className="flex flex-col gap-6 w-full">
+      {isEdit && (
       <Radio
         label="電力申請を行いますか？"
         value={radioValue}
@@ -22,9 +30,17 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
         required
         options={radioOptions}
       />
+      )}
 
-      {/* 申請しない場合の表示 */}
-      {!isSubmitted && showRegisterButton ? (
+      {!isEdit && (
+      <FormList
+        items={noApplicationItems}
+        onEdit={onEdit}
+        isEdit={true}
+      />
+      )}
+
+      {isEdit && !isSubmitted && showRegisterButton && (
         <div className="flex flex-col items-center gap-4">
           {submitError && (
             <div className="relative w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
@@ -40,13 +56,6 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
           >
             登録
           </Button>
-        </div>
-      ) : (
-        // 登録済みまたは提出完了の場合は完了メッセージを表示
-        <div className="text-center">
-          <p className="mb-4 text-[#FF6752]">
-            電力申請を行わない登録が完了しました
-          </p>
         </div>
       )}
     </div>

--- a/user/src/components/Applications/Power/components/PowerNegativeView.tsx
+++ b/user/src/components/Applications/Power/components/PowerNegativeView.tsx
@@ -24,7 +24,7 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
   ];
 
   return (
-    <div className="flex flex-col gap-6 w-full">
+    <div className="flex w-full flex-col gap-6">
       {isEdit && (
         <Radio
           label="電力申請を行いますか？"

--- a/user/src/components/Applications/Power/components/PowerNegativeView.tsx
+++ b/user/src/components/Applications/Power/components/PowerNegativeView.tsx
@@ -16,6 +16,7 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
   onEdit,
   isEdit,
   onCancel,
+  isDeadline,
 }) => {
   const noApplicationItems: FormItem[] = [
     {
@@ -52,7 +53,11 @@ export const PowerNegativeView: FC<PowerNegativeViewProps> = ({
       )}
 
       {!isEdit && (
-        <FormList items={noApplicationItems} onEdit={onEdit} isEdit={true} />
+        <FormList
+          items={noApplicationItems}
+          onEdit={isDeadline ? undefined : onEdit}
+          isEdit={!isDeadline}
+        />
       )}
 
       {isEdit && !isSubmitted && showRegisterButton && (

--- a/user/src/components/Applications/Power/components/PowerSummaryView.tsx
+++ b/user/src/components/Applications/Power/components/PowerSummaryView.tsx
@@ -29,7 +29,7 @@ export const PowerSummaryView: FC<PowerSummaryViewProps> = ({
         <div key={`device-${index}`} className="mb-4">
           <FormList
             items={createFormItemsForDevice(device)}
-            onEdit={onEdit}
+            onEdit={isDeadline ? undefined : onEdit}
             isDelete={isDeadline}
             onDelete={device.id ? () => onDeleteDevice(device.id!) : undefined}
           />

--- a/user/src/components/Applications/Power/hooks/usePowerApplication.ts
+++ b/user/src/components/Applications/Power/hooks/usePowerApplication.ts
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify';
 import { mutate } from 'swr';
 import { DEFAULT_DEVICE } from '../constants';
 import { PowerApplicationFormData } from '../schema';
-import { ORDER_TYPES, PowerApplicationOption } from '../types';
+import { Device, ORDER_TYPES, PowerApplicationOption } from '../types';
 import { usePowerForm } from './usePowerForm';
 
 // 電力申請フォームの状態管理型
@@ -27,6 +27,9 @@ export const usePowerApplication = (groupId: number) => {
     submitError: null,
     isSubmitted: false,
   });
+
+  // 「はい」未登録時の入力内容を一時保存するstate
+  const [pendingDevices, setPendingDevices] = useState<Device[] | null>(null);
 
   // 電力申請データの取得
   const {
@@ -295,7 +298,6 @@ export const usePowerApplication = (groupId: number) => {
 
     if (radioValue === 'yes') {
       // 「はい」を選択した場合
-      // 以前のapplyPowerの値を取得して、「いいえ」から「はい」への変更を検出する
       const isChangingFromNo = state.applyPower === 'no';
 
       updateState({
@@ -304,12 +306,10 @@ export const usePowerApplication = (groupId: number) => {
         isSubmitted: false,
       });
 
-      // 「いいえ」から「はい」に変更した場合、フォームリセットが必要な場合はフォームを初期化
-      if (isChangingFromNo) {
+      // 「いいえ」から「はい」に戻す場合、pendingDevicesがあればそれを復元する
+      if (isChangingFromNo && pendingDevices) {
         formMethods.reset(
-          {
-            devices: [{ ...DEFAULT_DEVICE }],
-          },
+          { devices: pendingDevices },
           {
             keepDirty: false,
             keepErrors: false,
@@ -319,6 +319,11 @@ export const usePowerApplication = (groupId: number) => {
         );
       }
     } else if (radioValue === 'no') {
+      // 「はい」から「いいえ」に変えるとき、未登録内容をpendingDevicesに保存する
+      if (state.applyPower === 'yes') {
+        const currentDevices = formMethods.getValues('devices');
+        setPendingDevices(currentDevices);
+      }
       updateState({
         applyPower: 'no',
         isSubmitted: false,

--- a/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
+++ b/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
@@ -14,6 +14,7 @@ type UsePowerDisplayInput = {
   hasExisting: boolean;
   isEditing: boolean;
   hasUnregistered: boolean;
+  isDeadline?: boolean;
 };
 
 export const usePowerDisplay = ({
@@ -21,6 +22,7 @@ export const usePowerDisplay = ({
   hasExisting,
   isEditing,
   hasUnregistered,
+  isDeadline,
 }: UsePowerDisplayInput) => {
   const [negativeEditMode, setNegativeEditMode] = useState(false);
   const prevApplyPower = useRef<ApplyPower | null>(null);
@@ -43,16 +45,29 @@ export const usePowerDisplay = ({
   }, [applyPower, hasUnregistered]);
 
   let mode: PowerDisplayMode;
-  if (applyPower === 'undecided') {
-    mode = 'negativeUndecided';
-  } else if (applyPower === 'no' && !negativeEditMode) {
-    mode = 'negativeDisplay';
-  } else if (applyPower === 'no' && negativeEditMode) {
-    mode = 'negativeRegister';
-  } else if (hasExisting && !isEditing) {
-    mode = 'summary';
+
+  // 締切後は編集不可のFormList表示にする
+  if (isDeadline) {
+    if (applyPower === 'no' && !negativeEditMode) {
+      mode = 'negativeDisplay';
+    } else if (hasExisting && !isEditing) {
+      mode = 'summary';
+    } else {
+      mode = hasExisting ? 'summary' : 'negativeDisplay';
+    }
   } else {
-    mode = 'form';
+    // 締切前の通常処理
+    if (applyPower === 'undecided') {
+      mode = 'negativeUndecided';
+    } else if (applyPower === 'no' && !negativeEditMode) {
+      mode = 'negativeDisplay';
+    } else if (applyPower === 'no' && negativeEditMode) {
+      mode = 'negativeRegister';
+    } else if (hasExisting && !isEditing) {
+      mode = 'summary';
+    } else {
+      mode = 'form';
+    }
   }
 
   return { mode, negativeEditMode, setNegativeEditMode };

--- a/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
+++ b/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
+
+type ApplyPower = 'yes' | 'no' | 'undecided';
+
+export type PowerDisplayMode = 
+  | 'negativeUndecided'  // 未登録の状態：ラジオボタン表示
+  | 'negativeRegister'   // 「はい」→「いいえ」変更後：ラジオボタン+登録ボタン表示
+  | 'negativeDisplay'    // 「なし」で登録済みの場合：FormListを表示
+  | 'summary'            // 「あり」で登録済みの場合：FormListを表示
+  | 'form';              // 「はい」選択時または編集中：Formを表示
+
+type UsePowerDisplayInput = {
+  applyPower: ApplyPower;
+  hasExisting: boolean;
+  isEditing: boolean;
+};
+
+export const usePowerDisplay = ({
+  applyPower,
+  hasExisting,
+  isEditing,
+}: UsePowerDisplayInput) => {
+  const [negativeEditMode, setNegativeEditMode] = useState(false);
+  const prevApplyPower = useRef<ApplyPower | null>(null);
+
+  useEffect(() => {
+    if (applyPower === 'no') {
+      if (prevApplyPower.current === 'yes') {
+        setNegativeEditMode(true);
+      } else {
+        setNegativeEditMode(false);
+      }
+    } else if (applyPower === 'undecided') {
+      setNegativeEditMode(true);
+    } else {
+      setNegativeEditMode(true);
+    }
+    prevApplyPower.current = applyPower;
+  }, [applyPower]);
+
+  let mode: PowerDisplayMode;
+  if (applyPower === 'undecided') {
+    mode = 'negativeUndecided';
+  } else if (applyPower === 'no' && !negativeEditMode) {
+    mode = 'negativeDisplay';
+  } else if (applyPower === 'no' && negativeEditMode) {
+    mode = 'negativeRegister';
+  } else if (hasExisting && !isEditing) {
+    mode = 'summary';
+  } else {
+    mode = 'form';
+  }
+
+  return { mode, negativeEditMode, setNegativeEditMode };
+};

--- a/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
+++ b/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
@@ -2,12 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 
 type ApplyPower = 'yes' | 'no' | 'undecided';
 
-export type PowerDisplayMode = 
-  | 'negativeUndecided'  // 未登録の状態：ラジオボタン表示
-  | 'negativeRegister'   // 「はい」→「いいえ」変更後：ラジオボタン+登録ボタン表示
-  | 'negativeDisplay'    // 「なし」で登録済みの場合：FormListを表示
-  | 'summary'            // 「あり」で登録済みの場合：FormListを表示
-  | 'form';              // 「はい」選択時または編集中：Formを表示
+export type PowerDisplayMode =
+  | 'negativeUndecided' // 未登録の状態：ラジオボタン表示
+  | 'negativeRegister' // 「はい」→「いいえ」変更後：ラジオボタン+登録ボタン表示
+  | 'negativeDisplay' // 「なし」で登録済みの場合：FormListを表示
+  | 'summary' // 「あり」で登録済みの場合：FormListを表示
+  | 'form'; // 「はい」選択時または編集中：Formを表示
 
 type UsePowerDisplayInput = {
   applyPower: ApplyPower;

--- a/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
+++ b/user/src/components/Applications/Power/hooks/usePowerDisplay.ts
@@ -13,12 +13,14 @@ type UsePowerDisplayInput = {
   applyPower: ApplyPower;
   hasExisting: boolean;
   isEditing: boolean;
+  hasUnregistered: boolean;
 };
 
 export const usePowerDisplay = ({
   applyPower,
   hasExisting,
   isEditing,
+  hasUnregistered,
 }: UsePowerDisplayInput) => {
   const [negativeEditMode, setNegativeEditMode] = useState(false);
   const prevApplyPower = useRef<ApplyPower | null>(null);
@@ -26,6 +28,8 @@ export const usePowerDisplay = ({
   useEffect(() => {
     if (applyPower === 'no') {
       if (prevApplyPower.current === 'yes') {
+        setNegativeEditMode(true);
+      } else if (!hasUnregistered) {
         setNegativeEditMode(true);
       } else {
         setNegativeEditMode(false);
@@ -36,7 +40,7 @@ export const usePowerDisplay = ({
       setNegativeEditMode(true);
     }
     prevApplyPower.current = applyPower;
-  }, [applyPower]);
+  }, [applyPower, hasUnregistered]);
 
   let mode: PowerDisplayMode;
   if (applyPower === 'undecided') {

--- a/user/src/components/Applications/Power/types.ts
+++ b/user/src/components/Applications/Power/types.ts
@@ -72,6 +72,8 @@ export interface PowerNegativeViewProps {
   submitError: string | null;
   showRegisterButton: boolean;
   radioOptions: RadioOption[];
+  onEdit?: () => void;
+  isEdit?: boolean;
 }
 
 export interface PowerSummaryViewProps {

--- a/user/src/components/Applications/Power/types.ts
+++ b/user/src/components/Applications/Power/types.ts
@@ -74,6 +74,7 @@ export interface PowerNegativeViewProps {
   radioOptions: RadioOption[];
   onEdit?: () => void;
   isEdit?: boolean;
+  onCancel?: () => void;
 }
 
 export interface PowerSummaryViewProps {

--- a/user/src/components/Applications/Power/types.ts
+++ b/user/src/components/Applications/Power/types.ts
@@ -75,6 +75,7 @@ export interface PowerNegativeViewProps {
   onEdit?: () => void;
   isEdit?: boolean;
   onCancel?: () => void;
+  isDeadline?: boolean;
 }
 
 export interface PowerSummaryViewProps {


### PR DESCRIPTION
# 対応Issue
https://nut-m-e-g.slack.com/archives/C0158CX350Q/p1746162002994059

# 概要

- 「いいえ」選択時にFormListが表示されるようにしました
- Powerコンポーネントの状態管理および表示ロジックをhooksに移譲

# 実装詳細

- usePowerDisplayフックに、状態管理、表示モードの処理を移譲しました。

# 画面スクリーンショット等
<!-- 必要に応じてスクリーンショットのURLなどを記載 -->
![image](https://github.com/user-attachments/assets/d64c4dac-6c56-44f9-9ea3-2d7df7ddb168)


# テスト項目
- [x] Powerコンポーネントが各状態（未登録、登録済み、「はい」選択時、「いいえ」選択時）で正しく表示されること
- [x] 「はい」から「いいえ」へのラジオボタン切替時に、登録ボタンが表示され、登録後にフォームリストに切り替わること
- [x] 各操作（登録、削除、編集）が正しく動作し、データが反映されること