### PR TITLE
[fix] PR文ファイル名バリデーションを削除

### DIFF
--- a/user/src/components/Applications/PublicRelations/PublicRelationsForm/hooks.ts
+++ b/user/src/components/Applications/PublicRelations/PublicRelationsForm/hooks.ts
@@ -146,17 +146,6 @@ export const usePublicRelationsFormHooks = (
           return resolve(false);
         }
 
-        const fileNamePattern =
-          /^[^\\/:*?"<>|\r\n]+_[^\\/:*?"<>|\r\n]+\.(png|jpe?g)$/;
-        if (!fileNamePattern.test(file.name)) {
-          setError('image', {
-            type: 'manual',
-            message:
-              'ファイル名は「参加形式_団体名」で指定してください（拡張子含む）',
-          });
-          return resolve(false);
-        }
-
         resolve(true);
       };
       img.onerror = () => {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolve #1864 

# 概要
画像の正方形チェック以外のファイル名パターンバリデーションを削除し、ファイル名形式に依存しない画像アップロードを可能にしました。

# 実装詳細
hooks.ts の validateImage 関数内からファイル名検証ロジックを丸ごと削除
画像読み込み後の正方形チェックのみを残し、ファイル名に関するエラーは発生しないように修正



# テスト項目
- [x] 正方形でない画像を選択した際に「画像は正方形にしてください」エラーが表示される
- [ ] 正方形の画像を選択した際にフォームに画像が正常にセットされる
- [x] いかなるファイル名でもアップロード可能であること

# 備考
既存の setError('image', …) メッセージには手を加えていません。
今後ファイル名検証が必要な場合は、React Hook Form／Zod スキーマで統一的に実装することを検討してください。
