### PR TITLE
団体申請後に更新する

### DIFF
--- a/user/src/api/groupApi.ts
+++ b/user/src/api/groupApi.ts
@@ -81,14 +81,19 @@ export const useGetGroupCategories = () => {
 export const useGetGroupByUserId = (userId: number | undefined) => {
   const endpoint = userId ? `${API_ENDPOINTS.GROUP_USERID}/${userId}` : null;
 
-  const { data, error, isLoading } =
-    useApiGet<ApiResponse<GroupUserIdAndGroupCategoryIdResponse>>(endpoint);
+  const {
+    data,
+    error,
+    isLoading,
+    mutate: mutateGroupByUserId,
+  } = useApiGet<ApiResponse<GroupUserIdAndGroupCategoryIdResponse>>(endpoint);
 
   return {
     groupUserIdAndGroupCategoryId:
       data?.status.code === 200 ? data?.data : undefined,
     isLoading,
     hasError: !!error,
+    mutateGroupByUserId,
   };
 };
 

--- a/user/src/api/groupApi.ts
+++ b/user/src/api/groupApi.ts
@@ -48,13 +48,18 @@ export type GroupUserIdAndGroupCategoryIdResponse = {
 export const useGetGroups = (groupId: number | null) => {
   const endpoint = groupId ? `${API_ENDPOINTS.GROUPS}/${groupId}` : null;
 
-  const { data, error, isLoading } =
-    useApiGet<ApiResponse<GroupResponse>>(endpoint);
+  const {
+    data,
+    error,
+    isLoading,
+    mutate: mutateGroups,
+  } = useApiGet<ApiResponse<GroupResponse>>(endpoint);
 
   return {
     groups: data?.status.code === 200 ? data?.data : undefined,
     isLoading,
     hasError: !!error,
+    mutateGroups,
   };
 };
 

--- a/user/src/components/Applications/Group/Group.tsx
+++ b/user/src/components/Applications/Group/Group.tsx
@@ -11,6 +11,7 @@ type GroupProps = {
   isRegistered?: boolean | undefined;
   groupId: number;
   userId: number;
+  mutateCheckAllRegisteredGroups: () => void;
 };
 
 type ContentProps = {
@@ -24,6 +25,7 @@ type ContentProps = {
   groupCategories?: GroupCategoryResponse[];
   userId: number;
   mutateGroups: () => void;
+  mutateCheckAllRegisteredGroups: () => void;
 };
 
 // 表示画面を切り替えるコンポーネント
@@ -38,6 +40,7 @@ const Content: FC<ContentProps> = ({
   groupCategories,
   userId,
   mutateGroups,
+  mutateCheckAllRegisteredGroups,
 }) => {
   // データ取得中など，ロード中に表示する画面
   if (isLoading) {
@@ -64,6 +67,7 @@ const Content: FC<ContentProps> = ({
         groupCategories={groupCategories}
         userId={userId}
         mutateGroups={mutateGroups}
+        mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
       />
     );
   }
@@ -77,6 +81,7 @@ const Group: FC<GroupProps> = ({
   isRegistered,
   groupId,
   userId,
+  mutateCheckAllRegisteredGroups,
 }) => {
   const {
     formItem,
@@ -106,6 +111,7 @@ const Group: FC<GroupProps> = ({
         groupCategories={groupCategories}
         userId={userId}
         mutateGroups={mutateGroups}
+        mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
       />
     </AccordionMenu>
   );

--- a/user/src/components/Applications/Group/Group.tsx
+++ b/user/src/components/Applications/Group/Group.tsx
@@ -12,6 +12,7 @@ type GroupProps = {
   groupId: number;
   userId: number;
   mutateCheckAllRegisteredGroups: () => void;
+  mutateGroupByUserId: () => void;
 };
 
 type ContentProps = {
@@ -26,6 +27,7 @@ type ContentProps = {
   userId: number;
   mutateGroups: () => void;
   mutateCheckAllRegisteredGroups: () => void;
+  mutateGroupByUserId: () => void;
 };
 
 // 表示画面を切り替えるコンポーネント
@@ -41,6 +43,7 @@ const Content: FC<ContentProps> = ({
   userId,
   mutateGroups,
   mutateCheckAllRegisteredGroups,
+  mutateGroupByUserId,
 }) => {
   // データ取得中など，ロード中に表示する画面
   if (isLoading) {
@@ -68,6 +71,7 @@ const Content: FC<ContentProps> = ({
         userId={userId}
         mutateGroups={mutateGroups}
         mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
+        mutateGroupByUserId={mutateGroupByUserId}
       />
     );
   }
@@ -82,6 +86,7 @@ const Group: FC<GroupProps> = ({
   groupId,
   userId,
   mutateCheckAllRegisteredGroups,
+  mutateGroupByUserId,
 }) => {
   const {
     formItem,
@@ -112,6 +117,7 @@ const Group: FC<GroupProps> = ({
         userId={userId}
         mutateGroups={mutateGroups}
         mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
+        mutateGroupByUserId={mutateGroupByUserId}
       />
     </AccordionMenu>
   );

--- a/user/src/components/Applications/Group/Group.tsx
+++ b/user/src/components/Applications/Group/Group.tsx
@@ -23,6 +23,7 @@ type ContentProps = {
   formItem: FormItem[];
   groupCategories?: GroupCategoryResponse[];
   userId: number;
+  mutateGroups: () => void;
 };
 
 // 表示画面を切り替えるコンポーネント
@@ -36,6 +37,7 @@ const Content: FC<ContentProps> = ({
   formItem,
   groupCategories,
   userId,
+  mutateGroups,
 }) => {
   // データ取得中など，ロード中に表示する画面
   if (isLoading) {
@@ -61,6 +63,7 @@ const Content: FC<ContentProps> = ({
         groups={groups}
         groupCategories={groupCategories}
         userId={userId}
+        mutateGroups={mutateGroups}
       />
     );
   }
@@ -83,6 +86,7 @@ const Group: FC<GroupProps> = ({
     isLoading,
     hasError,
     groupCategories,
+    mutateGroups,
   } = useGroupHooks(groupId);
   return (
     <AccordionMenu
@@ -101,6 +105,7 @@ const Group: FC<GroupProps> = ({
         formItem={formItem}
         groupCategories={groupCategories}
         userId={userId}
+        mutateGroups={mutateGroups}
       />
     </AccordionMenu>
   );

--- a/user/src/components/Applications/Group/GroupForm/GroupForm.tsx
+++ b/user/src/components/Applications/Group/GroupForm/GroupForm.tsx
@@ -15,6 +15,7 @@ type GroupFormProps = {
   toEdit?: () => void;
   groupCategories?: { id: number; name: string }[];
   userId: number;
+  mutateGroups: () => void;
 };
 
 const GroupForm: FC<GroupFormProps> = ({
@@ -22,6 +23,7 @@ const GroupForm: FC<GroupFormProps> = ({
   toEdit,
   groupCategories,
   userId,
+  mutateGroups,
 }) => {
   const {
     handleSubmit,
@@ -34,7 +36,7 @@ const GroupForm: FC<GroupFormProps> = ({
     updateIsMutating,
     validateEdit,
     values,
-  } = useGroupFormHooks(groups, userId);
+  } = useGroupFormHooks(groups, userId, mutateGroups);
 
   if (createError || updateError) {
     toast.error('送信に失敗しました。時間を置いて再度お試しください');

--- a/user/src/components/Applications/Group/GroupForm/GroupForm.tsx
+++ b/user/src/components/Applications/Group/GroupForm/GroupForm.tsx
@@ -16,6 +16,7 @@ type GroupFormProps = {
   groupCategories?: { id: number; name: string }[];
   userId: number;
   mutateGroups: () => void;
+  mutateCheckAllRegisteredGroups: () => void;
 };
 
 const GroupForm: FC<GroupFormProps> = ({
@@ -24,6 +25,7 @@ const GroupForm: FC<GroupFormProps> = ({
   groupCategories,
   userId,
   mutateGroups,
+  mutateCheckAllRegisteredGroups,
 }) => {
   const {
     handleSubmit,
@@ -36,7 +38,12 @@ const GroupForm: FC<GroupFormProps> = ({
     updateIsMutating,
     validateEdit,
     values,
-  } = useGroupFormHooks(groups, userId, mutateGroups);
+  } = useGroupFormHooks(
+    groups,
+    userId,
+    mutateGroups,
+    mutateCheckAllRegisteredGroups
+  );
 
   if (createError || updateError) {
     toast.error('送信に失敗しました。時間を置いて再度お試しください');

--- a/user/src/components/Applications/Group/GroupForm/GroupForm.tsx
+++ b/user/src/components/Applications/Group/GroupForm/GroupForm.tsx
@@ -17,6 +17,7 @@ type GroupFormProps = {
   userId: number;
   mutateGroups: () => void;
   mutateCheckAllRegisteredGroups: () => void;
+  mutateGroupByUserId: () => void;
 };
 
 const GroupForm: FC<GroupFormProps> = ({
@@ -26,6 +27,7 @@ const GroupForm: FC<GroupFormProps> = ({
   userId,
   mutateGroups,
   mutateCheckAllRegisteredGroups,
+  mutateGroupByUserId,
 }) => {
   const {
     handleSubmit,
@@ -42,7 +44,8 @@ const GroupForm: FC<GroupFormProps> = ({
     groups,
     userId,
     mutateGroups,
-    mutateCheckAllRegisteredGroups
+    mutateCheckAllRegisteredGroups,
+    mutateGroupByUserId
   );
 
   if (createError || updateError) {

--- a/user/src/components/Applications/Group/GroupForm/hooks.ts
+++ b/user/src/components/Applications/Group/GroupForm/hooks.ts
@@ -14,7 +14,8 @@ export const useGroupFormHooks = (
   groups: GroupResponse | undefined,
   userId: number,
   mutateGroups: () => void,
-  mutateCheckAllRegisteredGroups: () => void
+  mutateCheckAllRegisteredGroups: () => void,
+  mutateGroupByUserId: () => void
 ) => {
   // 団体カテゴリー一覧を取得
   const {
@@ -86,6 +87,7 @@ export const useGroupFormHooks = (
         await create({ query: formData });
         mutateGroups();
         mutateCheckAllRegisteredGroups();
+        mutateGroupByUserId();
         toast.success('送信しました');
       } catch {
         toast.error('送信に失敗しました。');

--- a/user/src/components/Applications/Group/GroupForm/hooks.ts
+++ b/user/src/components/Applications/Group/GroupForm/hooks.ts
@@ -7,14 +7,14 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
-import { mutate } from 'swr';
 import { GroupForm, groupSchema } from './schema';
 
 export const useGroupFormHooks = (
   // groupsがすでに申請されている場合，formに表示させるため，引数として渡す
   groups: GroupResponse | undefined,
   userId: number,
-  mutateGroups: () => void
+  mutateGroups: () => void,
+  mutateCheckAllRegisteredGroups: () => void
 ) => {
   // 団体カテゴリー一覧を取得
   const {
@@ -85,6 +85,7 @@ export const useGroupFormHooks = (
       try {
         await create({ query: formData });
         mutateGroups();
+        mutateCheckAllRegisteredGroups();
         toast.success('送信しました');
       } catch {
         toast.error('送信に失敗しました。');

--- a/user/src/components/Applications/Group/GroupForm/hooks.ts
+++ b/user/src/components/Applications/Group/GroupForm/hooks.ts
@@ -13,7 +13,8 @@ import { GroupForm, groupSchema } from './schema';
 export const useGroupFormHooks = (
   // groupsがすでに申請されている場合，formに表示させるため，引数として渡す
   groups: GroupResponse | undefined,
-  userId: number
+  userId: number,
+  mutateGroups: () => void
 ) => {
   // 団体カテゴリー一覧を取得
   const {
@@ -74,7 +75,7 @@ export const useGroupFormHooks = (
     if (groups) {
       try {
         await update({ query: formData });
-        mutate(`/groups/${formData.id}`);
+        mutateGroups();
         toast.success('送信しました');
       } catch {
         toast.error('送信に失敗しました。');
@@ -83,8 +84,7 @@ export const useGroupFormHooks = (
     } else {
       try {
         await create({ query: formData });
-        mutate(`/groups/${formData.userId}`);
-        mutate(`/check_all_registered/${formData.userId}`);
+        mutateGroups();
         toast.success('送信しました');
       } catch {
         toast.error('送信に失敗しました。');

--- a/user/src/components/Applications/Group/hooks.ts
+++ b/user/src/components/Applications/Group/hooks.ts
@@ -4,7 +4,7 @@ import { FormItem } from '@/components/FormList/type';
 import { groupLabels } from '../label';
 
 export const useGroupHooks = (groupId: number) => {
-  const { groups, isLoading, hasError } = useGetGroups(groupId);
+  const { groups, isLoading, hasError, mutateGroups } = useGetGroups(groupId);
   const { groupCategories } = useGetGroupCategories();
 
   // 団体申請のフォーム内容
@@ -61,5 +61,6 @@ export const useGroupHooks = (groupId: number) => {
     toEdit,
     formItem,
     groupCategories,
+    mutateGroups,
   };
 };

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -109,6 +109,7 @@ export default function HomePage() {
             isRegistered={checkAllRegisteredGroups?.group}
             groupId={groupId}
             userId={userId || 0}
+            mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           />
         ) : (
           <>

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -117,6 +117,7 @@ export default function HomePage() {
               isRegistered={checkAllRegisteredGroups?.group}
               groupId={groupId}
               userId={userId || 0}
+              mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
             />
             <ViceRepresentative
               isDeadline={!userPageSettings?.isEditSubRep}

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -15,7 +15,8 @@ import { useUser } from '@/hooks/useUser';
 export default function HomePage() {
   const { user } = useUser();
   const userId = user?.id;
-  const { groupUserIdAndGroupCategoryId } = useGetGroupByUserId(userId);
+  const { groupUserIdAndGroupCategoryId, mutateGroupByUserId } =
+    useGetGroupByUserId(userId);
   const groupId = groupUserIdAndGroupCategoryId?.id ?? 0;
   const groupCategoryId = groupUserIdAndGroupCategoryId?.groupCategoryId;
   const { userPageSettings } = useGetUserPageSettings();
@@ -110,6 +111,7 @@ export default function HomePage() {
             groupId={groupId}
             userId={userId || 0}
             mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
+            mutateGroupByUserId={mutateGroupByUserId}
           />
         ) : (
           <>
@@ -119,6 +121,7 @@ export default function HomePage() {
               groupId={groupId}
               userId={userId || 0}
               mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
+              mutateGroupByUserId={mutateGroupByUserId}
             />
             <ViceRepresentative
               isDeadline={!userPageSettings?.isEditSubRep}


### PR DESCRIPTION
# 対応Issue
resolve #1874 

# 概要
- mutateGroupsの追加
- mutateCheckAllRegisteredGroupsの追加
- mutateGroupByUserIdの追加

# 実装詳細
- なぜmutateGroupByUserIdを追加したか
  - 新規作成時に以下の3つのデータを更新する必要があるため：
    1. `mutateGroups`: グループの基本情報の更新
    2. `mutateCheckAllRegisteredGroups`: 登録状態の更新
    3. `mutateGroupByUserId`: ユーザーとグループの関連付けの更新
  - 特に`mutateGroupByUserId`は、ユーザーIDに基づいてグループ情報を取得するために必要
  - これにより、新規作成後にユーザーが所属するグループの情報が正しく表示される

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

# テスト項目
- [ ] 新規作成時にデータが正しく保存されるか
- [ ] 新規作成後に画面が正しく再レンダリングされるか
- [ ] ユーザーとグループの関連付けが正しく表示されるか

# 備考
<!-- 実装していて困った箇所・質問など -->
