### PR TITLE
物品申請のバリデーション修正

### DIFF
--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -369,6 +369,26 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
             </div>
           ))}
 
+          {/* エラーメッセージを追加・登録ボタンの上に移動 */}
+          {submitError && (
+            <div className="relative mt-4 w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
+              {submitError}
+            </div>
+          )}
+
+          {errors.root?.message && (
+            <div className="relative mt-4 w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
+              {errors.root.message.toString()}
+            </div>
+          )}
+
+          {/* フォームバリデーションエラーがあれば表示（アイテム制限関連のエラーも含む） */}
+          {errors.items?.message && (
+            <div className="relative mt-4 w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
+              {errors.items.message.toString()}
+            </div>
+          )}
+
           <div className="mb-2 mt-4 flex justify-center gap-4">
             <MultiItemFormButton
               type="button"
@@ -387,25 +407,6 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
             </Button>
           </div>
         </>
-      )}
-
-      {submitError && (
-        <div className="relative mt-4 w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
-          {submitError}
-        </div>
-      )}
-
-      {errors.root?.message && (
-        <div className="relative mt-4 w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
-          {errors.root.message.toString()}
-        </div>
-      )}
-
-      {/* フォームバリデーションエラーがあれば表示（アイテム制限関連のエラーも含む） */}
-      {errors.items?.message && (
-        <div className="relative mt-4 w-full rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">
-          {errors.items.message.toString()}
-        </div>
       )}
     </form>
   );

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -268,8 +268,6 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
                           value={field.value}
                           onChange={(value) => {
                             field.onChange(value);
-                            form.trigger(`items.${index}.itemId`);
-
                             // 物品変更時に個数が上限を超えていたら1にリセットする
                             const maxCount = getMaxCountByItemId(value);
                             const currentCount = form.getValues(
@@ -280,6 +278,8 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
                                 shouldValidate: true,
                               });
                             }
+                            // 物品変更時にバリデーションを実行
+                            form.trigger('items');
                           }}
                           required
                           options={filteredOptions}
@@ -320,10 +320,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
                             field.onChange(numValue);
 
                             // 再検証を強制実行
-                            setTimeout(
-                              () => form.trigger(`items.${index}.count`),
-                              0
-                            );
+                            form.trigger('items');
                           }}
                           required
                           options={Array.from({ length: maxCount }, (_, i) => ({

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormLogic.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormLogic.ts
@@ -52,6 +52,15 @@ const SPECIAL_COUNT_ITEM_IDS = [
   Number(ITEM_IDS.CHAIR), // 椅子
 ];
 
+// 1個までに制限する物品ID
+const SINGLE_ITEM_IDS = [
+  Number(ITEM_IDS.LONG_TABLE), // 長机
+  Number(ITEM_IDS.DISPLAY_BOARD), // 掲示板
+  Number(ITEM_IDS.TENT), // テント
+  Number(ITEM_IDS.PARTITION), // パーテーション
+  5, // パーテーション足
+];
+
 // デフォルトの個数制限
 const DEFAULT_MAX_COUNT = 20;
 // 椅子と机の個数制限 (会場タイプによって異なる)
@@ -123,6 +132,11 @@ export const useRentItemsFormLogic = (
     }
 
     const numItemId = Number(itemId);
+
+    // 1個までに制限する物品の場合
+    if (SINGLE_ITEM_IDS.includes(numItemId)) {
+      return 1;
+    }
 
     // 椅子または机の場合
     if (SPECIAL_COUNT_ITEM_IDS.includes(numItemId)) {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1888 

# 概要
<!-- 開発内容の概要を記載 -->
- テント、パーテーション、パーテーション足、掲示板は個数の選択肢を1にした
- バリデーションエラーメッセージの位置を追加ボタン/登録ボタンの上に置き、エラーメッセージを必ず読めるようにした
- 削除ボタンを押したときのみバリデーションが発火していたので、物品名・個数を選択した時にバリデーションがかかるように修正

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 
- [ ] 
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
