### PR TITLE
API通信をSWRとSWRMutatinに統一

### DIFF
--- a/user/src/api/api.ts
+++ b/user/src/api/api.ts
@@ -4,84 +4,123 @@ import snakecaseKeys from 'snakecase-keys';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/**
- * APIのベースURL
- * 環境変数から読み込む
- */
+// ==========================================
+// 簡素化＆共通化したFetcher実装
+// ==========================================
+
+/** APIのベースURL */
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
-/**
- * APIのヘッダーを生成する関数
- * 認証情報を追加
- */
-export const headers = (session: Session): HeadersInit => {
-  const headers: HeadersInit = {
-    'Content-Type': 'application/json',
+type FetchOptions = {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  session?: Session;
+  query?: Record<string, unknown>;
+  body?: any;
+};
+
+type MutArg = { body?: any; query?: Record<string, any> };
+
+/** ヘッダー組み立て */
+function buildHeaders(session?: Session): HeadersInit {
+  const base: HeadersInit = { 'Content-Type': 'application/json' };
+  if (session) {
+    base['access-token'] = session.accessToken!;
+    base['client'] = session.client!;
+    base['uid'] = session.uid!;
+  }
+  return base;
+}
+
+/** クエリ文字列化 */
+function objectToQueryString(params: Record<string, unknown>): string {
+  const snake = snakecaseKeys(params, { deep: true });
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(snake)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      value.forEach((v) => searchParams.append(key, String(v)));
+    } else {
+      searchParams.append(key, String(value));
+    }
+  }
+  return searchParams.toString();
+}
+
+/** 汎用リクエスト */
+async function request<T>(
+  url: string,
+  { method = 'GET', session, query, body }: FetchOptions = {}
+): Promise<T> {
+  let full = url.startsWith('http') ? url : `${API_URL}${url}`;
+  if (query) {
+    full += `?${objectToQueryString(query)}`;
+  }
+  const res = await fetch(full, {
+    method,
+    headers: buildHeaders(session),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => ({}));
+    const err = new Error(`${method} ${full} failed (status ${res.status})`);
+    (err as any).info = errorBody;
+    (err as any).status = res.status;
+    throw err;
+  }
+  const json = await res.json();
+  return camelcaseKeys(json, { deep: true }) as T;
+}
+
+/** セッションあり・なし共通のfetcher */
+const createSessionFetcher =
+  (method: FetchOptions['method']) =>
+  <T>(
+    [url, session]: readonly [string, Session],
+    { arg }: { arg?: MutArg } = {}
+  ): Promise<T> => {
+    const opts: FetchOptions = { method, session };
+    if (arg?.body) opts.body = arg.body;
+    if (arg?.query) opts.query = arg.query;
+    return request<T>(url, opts);
   };
 
-  // 認証情報がある場合はヘッダーに追加
-  headers['access-token'] = session.accessToken!;
-  headers['client'] = session.client!;
-  headers['uid'] = session.uid!;
+const createNoSessionFetcher =
+  (method: FetchOptions['method']) =>
+  <T>(url: string, { arg }: { arg?: MutArg } = {}): Promise<T> => {
+    const opts: FetchOptions = { method };
+    if (arg?.body) opts.body = arg.body;
+    if (arg?.query) opts.query = arg.query;
+    return request<T>(url, opts);
+  };
 
-  return headers;
-};
+// GET用
+export const fetcher = <T>([url, session]: readonly [
+  string,
+  Session,
+]): Promise<T> => request<T>(url, { session });
+export const noSessionFetcher = <T>(url: string): Promise<T> => request<T>(url);
 
-/**
- * SWR用のフェッチャー関数
- * 認証情報をヘッダーに追加
- * レスポンスは自動的にキャメルケースに変換
- */
-export const fetcher = ([url, session]: [string, Session]) => {
-  const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
+// セッションありミューテーション
+export const postFetcherWithSession = createSessionFetcher('POST');
+export const putFetcherWithSession = createSessionFetcher('PUT');
+export const patchFetcherWithSession = createSessionFetcher('PATCH');
+export const deleteFetcherWithSession = createSessionFetcher('DELETE');
 
-  const requestHeaders = headers(session);
+// セッションなしミューテーション
+export const postFetcher = createNoSessionFetcher('POST');
+export const putFetcher = createNoSessionFetcher('PUT');
+export const patchFetcher = createNoSessionFetcher('PATCH');
+export const deleteFetcher = createNoSessionFetcher('DELETE');
 
-  return fetch(fullUrl, {
-    headers: requestHeaders,
-  })
-    .then(async (res) => {
-      if (!res.ok) {
-        throw new Error(`API Error: ${res.status}`);
-      }
-      const json = await res.json();
-      return camelcaseKeys(json, { deep: true });
-    })
-    .then((data) => {
-      return data;
-    })
-    .catch((error) => {
-      throw error;
-    });
-};
-
-export const noSessionFetcher = (url: string) => {
-  const fullUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
-  return fetch(fullUrl, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-    .then(async (res) => {
-      if (!res.ok) {
-        throw new Error(`API Error: ${res.status}`);
-      }
-      const json = await res.json();
-      return camelcaseKeys(json, { deep: true });
-    })
-    .then((data) => {
-      return data;
-    })
-    .catch((error) => {
-      throw error;
-    });
-};
+// ==========================================
+// 独自実装（将来的に削除予定）
+// ==========================================
 
 /**
- * POSTリクエスト用のfetcher関数
+ * POSTリクエスト用の関数（独自実装）
  * クエリパラメータとボディをサポート
  */
-export async function postFetcher(
+export async function legacyPostFetcher(
   url: string,
   { arg }: { arg: { body?: any; query?: { [key: string]: any } } }
 ): Promise<any> {
@@ -106,11 +145,11 @@ export async function postFetcher(
 }
 
 /**
- * PATCHリクエスト用のfetcher関数
+ * PATCHリクエスト用の関数（独自実装）
  * クエリパラメータとボディをサポート
  * エラー時はレスポンスの詳細をログ出力
  */
-export async function patchFetcher(
+export async function legacyPatchFetcher(
   url: string,
   { arg }: { arg: { body?: any; query?: { [key: string]: any } } }
 ): Promise<any> {
@@ -136,8 +175,12 @@ export async function patchFetcher(
 
   return response.json();
 }
-//DELETEリクエスト用のfetcher関数
-export async function deleteFetcher(
+
+/**
+ * DELETEリクエスト用の関数（独自実装）
+ * クエリパラメータをサポート
+ */
+export async function legacyDeleteFetcher(
   url: string,
   { arg }: { arg?: { query?: { [key: string]: any } } } = {}
 ): Promise<any> {
@@ -319,7 +362,7 @@ const sendRequest = async <T>(
   session: Session,
   options: RequestInit = {}
 ): Promise<ApiResponse<T>> => {
-  const defaultHeaders: HeadersInit = headers(session);
+  const defaultHeaders: HeadersInit = buildHeaders(session);
 
   const requestOptions: RequestInit = {
     ...options,
@@ -394,50 +437,3 @@ export const patchData = async <T>(
 ): Promise<ApiResponse<T>> => {
   return sendRequest<T>(url, session, createRequestOptions('PATCH', data));
 };
-
-/**
- * オブジェクトをクエリパラメータ文字列に変換する関数
- * キーは自動的にスネークケースに変換
- */
-function objectToQueryString(params: { [key: string]: any }): string {
-  const snakeParams = snakecaseKeys(params, { deep: true });
-  return Object.keys(snakeParams)
-    .map(
-      (key) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(snakeParams[key])}`
-    )
-    .join('&');
-}
-
-/**
- * POSTリクエスト用のfetcher関数
- * Headersに認証情報を追加
- * クエリパラメータとボディをサポート
- */
-export async function postFetcherWithSession(
-  [url, session]: [string, Session],
-  { arg }: { arg: { body?: any; query?: { [key: string]: any } } }
-): Promise<any> {
-  const requestHeaders = headers(session);
-  let finalUrl = url.startsWith('http') ? url : `${API_URL}${url}`;
-  if (arg.query) {
-    const queryStr = objectToQueryString(arg.query);
-    finalUrl = `${API_URL}${url}?${queryStr}`;
-  }
-
-  const response = await fetch(finalUrl, {
-    method: 'POST',
-    headers: requestHeaders,
-    body: JSON.stringify(arg.body),
-  });
-
-  if (!response.ok) {
-    const errorBody = await response.json();
-    const error = new Error('Error posting data');
-    (error as any).info = errorBody;
-    (error as any).status = response.status;
-    throw error;
-  }
-
-  return response.json();
-}

--- a/user/src/api/api.ts
+++ b/user/src/api/api.ts
@@ -18,17 +18,17 @@ type FetchOptions = {
   body?: any;
 };
 
-type MutArg = { body?: any; query?: Record<string, any> };
+type MutationArgs = { body?: any; query?: Record<string, any> };
 
 /** ヘッダー組み立て */
 function buildHeaders(session?: Session): HeadersInit {
-  const base: HeadersInit = { 'Content-Type': 'application/json' };
+  const haaders: HeadersInit = { 'Content-Type': 'application/json' };
   if (session) {
-    base['access-token'] = session.accessToken!;
-    base['client'] = session.client!;
-    base['uid'] = session.uid!;
+    haaders['access-token'] = session.accessToken!;
+    haaders['client'] = session.client!;
+    haaders['uid'] = session.uid!;
   }
-  return base;
+  return haaders;
 }
 
 /** クエリ文字列化 */
@@ -36,7 +36,7 @@ function objectToQueryString(params: Record<string, unknown>): string {
   const snake = snakecaseKeys(params, { deep: true });
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(snake)) {
-    if (value == null) continue;
+    if (value === null) continue;
     if (Array.isArray(value)) {
       value.forEach((v) => searchParams.append(key, String(v)));
     } else {
@@ -51,18 +51,18 @@ async function request<T>(
   url: string,
   { method = 'GET', session, query, body }: FetchOptions = {}
 ): Promise<T> {
-  let full = url.startsWith('http') ? url : `${API_URL}${url}`;
+  let fullURL = url.startsWith('http') ? url : `${API_URL}${url}`;
   if (query) {
-    full += `?${objectToQueryString(query)}`;
+    fullURL += `?${objectToQueryString(query)}`;
   }
-  const res = await fetch(full, {
+  const res = await fetch(fullURL, {
     method,
     headers: buildHeaders(session),
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => ({}));
-    const err = new Error(`${method} ${full} failed (status ${res.status})`);
+    const err = new Error(`${method} ${fullURL} failed (status ${res.status})`);
     (err as any).info = errorBody;
     (err as any).status = res.status;
     throw err;
@@ -71,12 +71,20 @@ async function request<T>(
   return camelcaseKeys(json, { deep: true }) as T;
 }
 
+// GET用
+export const authenticatedGetFetcher = <T>([url, session]: readonly [
+  string,
+  Session,
+]): Promise<T> => request<T>(url, { session });
+export const unauthenticatedGetFetcher = <T>(url: string): Promise<T> =>
+  request<T>(url);
+
 /** セッションあり・なし共通のfetcher */
-const createSessionFetcher =
+const authenticatedMutationFetcher =
   (method: FetchOptions['method']) =>
   <T>(
     [url, session]: readonly [string, Session],
-    { arg }: { arg?: MutArg } = {}
+    { arg }: { arg?: MutationArgs } = {}
   ): Promise<T> => {
     const opts: FetchOptions = { method, session };
     if (arg?.body) opts.body = arg.body;
@@ -84,33 +92,30 @@ const createSessionFetcher =
     return request<T>(url, opts);
   };
 
-const createNoSessionFetcher =
+const unauthenticatedMutationFetcher =
   (method: FetchOptions['method']) =>
-  <T>(url: string, { arg }: { arg?: MutArg } = {}): Promise<T> => {
+  <T>(url: string, { arg }: { arg?: MutationArgs } = {}): Promise<T> => {
     const opts: FetchOptions = { method };
     if (arg?.body) opts.body = arg.body;
     if (arg?.query) opts.query = arg.query;
     return request<T>(url, opts);
   };
 
-// GET用
-export const fetcher = <T>([url, session]: readonly [
-  string,
-  Session,
-]): Promise<T> => request<T>(url, { session });
-export const noSessionFetcher = <T>(url: string): Promise<T> => request<T>(url);
-
 // セッションありミューテーション
-export const postFetcherWithSession = createSessionFetcher('POST');
-export const putFetcherWithSession = createSessionFetcher('PUT');
-export const patchFetcherWithSession = createSessionFetcher('PATCH');
-export const deleteFetcherWithSession = createSessionFetcher('DELETE');
+export const authenticatedPostFetcher = authenticatedMutationFetcher('POST');
+export const authenticatedPutFetcher = authenticatedMutationFetcher('PUT');
+export const authenticatedPatchFetcher = authenticatedMutationFetcher('PATCH');
+export const authenticatedDeleteFetcher =
+  authenticatedMutationFetcher('DELETE');
 
 // セッションなしミューテーション
-export const postFetcher = createNoSessionFetcher('POST');
-export const putFetcher = createNoSessionFetcher('PUT');
-export const patchFetcher = createNoSessionFetcher('PATCH');
-export const deleteFetcher = createNoSessionFetcher('DELETE');
+export const unauthenticatedPostFetcher =
+  unauthenticatedMutationFetcher('POST');
+export const unauthenticatedPutFetcher = unauthenticatedMutationFetcher('PUT');
+export const unauthenticatedPatchFetcher =
+  unauthenticatedMutationFetcher('PATCH');
+export const unauthenticatedDeleteFetcher =
+  unauthenticatedMutationFetcher('DELETE');
 
 // ==========================================
 // 独自実装（将来的に削除予定）

--- a/user/src/api/api.ts
+++ b/user/src/api/api.ts
@@ -71,7 +71,7 @@ async function request<T>(
   return camelcaseKeys(json, { deep: true }) as T;
 }
 
-// GET用
+// GET用Fetcher
 export const authenticatedGetFetcher = <T>([url, session]: readonly [
   string,
   Session,
@@ -79,7 +79,7 @@ export const authenticatedGetFetcher = <T>([url, session]: readonly [
 export const unauthenticatedGetFetcher = <T>(url: string): Promise<T> =>
   request<T>(url);
 
-/** セッションあり・なし共通のfetcher */
+/** ミューテーション用Fetcherの共通化 */
 const authenticatedMutationFetcher =
   (method: FetchOptions['method']) =>
   <T>(
@@ -101,14 +101,14 @@ const unauthenticatedMutationFetcher =
     return request<T>(url, opts);
   };
 
-// セッションありミューテーション
+// 認証ありミューテーションFetcher（POST, PUT, PATCH, DELETE）
 export const authenticatedPostFetcher = authenticatedMutationFetcher('POST');
 export const authenticatedPutFetcher = authenticatedMutationFetcher('PUT');
 export const authenticatedPatchFetcher = authenticatedMutationFetcher('PATCH');
 export const authenticatedDeleteFetcher =
   authenticatedMutationFetcher('DELETE');
 
-// セッションなしミューテーション
+// 認証なしミューテーションFetcher（POST, PUT, PATCH, DELETE）
 export const unauthenticatedPostFetcher =
   unauthenticatedMutationFetcher('POST');
 export const unauthenticatedPutFetcher = unauthenticatedMutationFetcher('PUT');

--- a/user/src/api/api.ts
+++ b/user/src/api/api.ts
@@ -7,8 +7,15 @@ import snakecaseKeys from 'snakecase-keys';
 // ==========================================
 // 簡素化＆共通化したFetcher実装
 // ==========================================
-
 /** APIのベースURL */
+export type ApiError = Error & {
+  info?: {
+    exception?: string;
+    errors?: Record<string, string[]>;
+  };
+  status?: number;
+};
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
 type FetchOptions = {
@@ -62,7 +69,9 @@ async function request<T>(
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => ({}));
-    const err = new Error(`${method} ${fullURL} failed (status ${res.status})`);
+    const err = new Error(
+      `${method} ${fullURL} failed (status ${res.status})`
+    ) as ApiError;
     (err as any).info = errorBody;
     (err as any).status = res.status;
     throw err;

--- a/user/src/api/checkAllRegisteredApi.ts
+++ b/user/src/api/checkAllRegisteredApi.ts
@@ -1,4 +1,4 @@
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 
 // openapiの型定義に変えたい
 export type RegistrationStatus = {
@@ -36,7 +36,7 @@ export const useGetCheckAllRegisteredGroups = (groupId: number | undefined) => {
   const endpoint = `${API_ENDPOINTS.CHECK_ALL_REGISTERED}/${groupId}`;
 
   const { data, error, isLoading, mutate } =
-    useApiGet<ApiResponse<RegistrationStatus>>(endpoint);
+    useAuthenticatedGet<ApiResponse<RegistrationStatus>>(endpoint);
 
   const checkAllRegisteredGroups = data?.data ?? undefined;
 

--- a/user/src/api/groupApi.ts
+++ b/user/src/api/groupApi.ts
@@ -1,5 +1,5 @@
 import useSWRMutation from 'swr/mutation';
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 const API_ENDPOINTS = {
@@ -53,7 +53,7 @@ export const useGetGroups = (groupId: number | null) => {
     error,
     isLoading,
     mutate: mutateGroups,
-  } = useApiGet<ApiResponse<GroupResponse>>(endpoint);
+  } = useAuthenticatedGet<ApiResponse<GroupResponse>>(endpoint);
 
   return {
     groups: data?.status.code === 200 ? data?.data : undefined,
@@ -68,7 +68,7 @@ export const useGetGroupCategories = () => {
   const endpoint = `${API_ENDPOINTS.GROUP_CATEGORIES}`;
 
   const { data, error, isLoading } =
-    useApiGet<ApiResponse<GroupCategoryResponse[]>>(endpoint);
+    useAuthenticatedGet<ApiResponse<GroupCategoryResponse[]>>(endpoint);
 
   return {
     groupCategories: data?.status.code === 200 ? data?.data : undefined,
@@ -86,7 +86,9 @@ export const useGetGroupByUserId = (userId: number | undefined) => {
     error,
     isLoading,
     mutate: mutateGroupByUserId,
-  } = useApiGet<ApiResponse<GroupUserIdAndGroupCategoryIdResponse>>(endpoint);
+  } = useAuthenticatedGet<ApiResponse<GroupUserIdAndGroupCategoryIdResponse>>(
+    endpoint
+  );
 
   return {
     groupUserIdAndGroupCategoryId:

--- a/user/src/api/groupApi.ts
+++ b/user/src/api/groupApi.ts
@@ -1,6 +1,6 @@
 import useSWRMutation from 'swr/mutation';
 import { useApiGet } from '@/hooks/useApi';
-import { patchFetcher, postFetcher } from './api';
+import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 const API_ENDPOINTS = {
   GROUPS: '/groups',
@@ -99,12 +99,12 @@ export const useGetGroupByUserId = (userId: number | undefined) => {
 
 // 新しい団体申請を作成
 export const useCreateGroups = () => {
-  return useSWRMutation(API_ENDPOINTS.GROUPS, postFetcher);
+  return useSWRMutation(API_ENDPOINTS.GROUPS, legacyPostFetcher);
 };
 
 // 既存の団体申請を更新
 export const useUpdateGroups = (id: number) => {
-  return useSWRMutation(`${API_ENDPOINTS.GROUPS}/${id}`, patchFetcher);
+  return useSWRMutation(`${API_ENDPOINTS.GROUPS}/${id}`, legacyPatchFetcher);
 };
 
 export type GroupInfo = GroupResponse;

--- a/user/src/api/newsApi.ts
+++ b/user/src/api/newsApi.ts
@@ -1,4 +1,4 @@
-import { noSessionFetcher } from '@/api/api';
+import { unauthenticatedGetFetcher } from '@/api/api';
 import useSWR from 'swr';
 
 // openapiの型定義に変えたい
@@ -18,7 +18,10 @@ export const useGetNews = () => {
   const endpoint = `${API_ENDPOINTS.ANNOUNCEMENTS}`;
 
   // TODO: あとでsessionがいらないAPIのuseApiGetを作る
-  const { data, error, isLoading } = useSWR<News[]>(endpoint, noSessionFetcher);
+  const { data, error, isLoading } = useSWR<News[]>(
+    endpoint,
+    unauthenticatedGetFetcher
+  );
 
   const news = data;
 

--- a/user/src/api/powerApi.ts
+++ b/user/src/api/powerApi.ts
@@ -1,5 +1,5 @@
 import { Device } from '@/components/Applications/Power/types';
-import { useApiGet, useApiMutations } from '@/hooks/useApi';
+import { useApiMutations, useAuthenticatedGet } from '@/hooks/useApi';
 
 const API_ENDPOINTS = {
   POWER_ORDERS: '/power_orders',
@@ -63,7 +63,7 @@ export const useGetPowerOrders = (groupId: number | null) => {
     ? `${API_ENDPOINTS.POWER_ORDERS}/group/${groupId}`
     : null;
 
-  const { data, error, isLoading, mutate } = useApiGet<{
+  const { data, error, isLoading, mutate } = useAuthenticatedGet<{
     data: PowerOrderResponse[];
   }>(endpoint);
 

--- a/user/src/api/publicRelationsApi.ts
+++ b/user/src/api/publicRelationsApi.ts
@@ -1,5 +1,5 @@
 import useSWRMutation from 'swr/mutation';
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 // リクエスト用の型定義
@@ -54,7 +54,7 @@ export const usePublicRelationData = (groupId: number) => {
     error,
     isLoading,
     mutate,
-  } = useApiGet<ApiResponse<PublicRelationResponse>>(endpoint);
+  } = useAuthenticatedGet<ApiResponse<PublicRelationResponse>>(endpoint);
 
   // APIからのレスポンスを直接取得
   const publicRelation = response?.status.code === 200 ? response.data : null;

--- a/user/src/api/publicRelationsApi.ts
+++ b/user/src/api/publicRelationsApi.ts
@@ -1,6 +1,6 @@
 import useSWRMutation from 'swr/mutation';
 import { useApiGet } from '@/hooks/useApi';
-import { patchFetcher, postFetcher } from './api';
+import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 // リクエスト用の型定義
 export type PublicRelation = {
@@ -70,13 +70,13 @@ export const usePublicRelationData = (groupId: number) => {
 
 // SWR Mutationを使った新規作成用フック
 export const useCreatePublicRelation = () => {
-  return useSWRMutation(API_ENDPOINTS.PUBLIC_RELATIONS, postFetcher);
+  return useSWRMutation(API_ENDPOINTS.PUBLIC_RELATIONS, legacyPostFetcher);
 };
 
 // SWR Mutationを使った更新用フック
 export const useUpdatePublicRelation = (id: number) => {
   return useSWRMutation(
     `${API_ENDPOINTS.PUBLIC_RELATIONS}/${id}`,
-    patchFetcher
+    legacyPatchFetcher
   );
 };

--- a/user/src/api/rentItemsApi.ts
+++ b/user/src/api/rentItemsApi.ts
@@ -1,6 +1,6 @@
 // src/api/rentItemsApi.ts
 import { useApiGet, useApiMutations } from '@/hooks/useApi';
-import { patchFetcher, postFetcher } from './api';
+import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 // APIエンドポイント
 const API_ENDPOINTS = {
@@ -133,7 +133,7 @@ export const useMutateRentalOrders = () => {
       // 更新：既存データの数だけ更新を実行
       for (let i = 0; i < minLength; i++) {
         promises.push(
-          patchFetcher(
+          legacyPatchFetcher(
             `${API_ENDPOINTS.RENTAL_ORDERS}/${existingItems[i].id}`,
             {
               arg: { body: items[i] },
@@ -146,7 +146,7 @@ export const useMutateRentalOrders = () => {
       if (items.length > existingItems.length) {
         for (let i = existingItems.length; i < items.length; i++) {
           promises.push(
-            postFetcher(API_ENDPOINTS.RENTAL_ORDERS, {
+            legacyPostFetcher(API_ENDPOINTS.RENTAL_ORDERS, {
               arg: { body: items[i] },
             })
           );

--- a/user/src/api/rentItemsApi.ts
+++ b/user/src/api/rentItemsApi.ts
@@ -1,5 +1,5 @@
 // src/api/rentItemsApi.ts
-import { useApiGet, useApiMutations } from '@/hooks/useApi';
+import { useApiMutations, useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 // APIエンドポイント
@@ -73,7 +73,7 @@ export const useRentableItemsByType = (locationType: string) => {
     data: response,
     error,
     isLoading,
-  } = useApiGet<ApiResponse<RentalItem[]>>(endpoint);
+  } = useAuthenticatedGet<ApiResponse<RentalItem[]>>(endpoint);
 
   return {
     items: response?.data || [],
@@ -88,7 +88,9 @@ export const useAllRentableItems = () => {
     data: response,
     error,
     isLoading,
-  } = useApiGet<ApiResponse<RentalItem[]>>(API_ENDPOINTS.ALL_RENTABLE_ITEMS);
+  } = useAuthenticatedGet<ApiResponse<RentalItem[]>>(
+    API_ENDPOINTS.ALL_RENTABLE_ITEMS
+  );
 
   return {
     items: response?.data || [],
@@ -104,7 +106,7 @@ export const useRentalOrdersByGroupId = (groupId: number) => {
     error,
     isLoading,
     mutate,
-  } = useApiGet<ApiResponse<RentalOrder[]>>(
+  } = useAuthenticatedGet<ApiResponse<RentalOrder[]>>(
     `${API_ENDPOINTS.RENTAL_ORDERS}/group/${groupId}`
   );
 

--- a/user/src/api/stageApi.ts
+++ b/user/src/api/stageApi.ts
@@ -1,5 +1,5 @@
 import { addMinutes } from '@/components/Applications/Stage/hooks/useStageForm';
-import { useApiGet, useApiMutations } from '@/hooks/useApi';
+import { useApiMutations, useAuthenticatedGet } from '@/hooks/useApi';
 
 export type FesDate = {
   id: number;
@@ -64,19 +64,19 @@ export const useStageFormData = () => {
     data: fesDateResponse,
     error: fesDateError,
     isLoading: fesDateLoading,
-  } = useApiGet<ApiResponse<FesDate>>(API_ENDPOINTS.FES_DATES);
+  } = useAuthenticatedGet<ApiResponse<FesDate>>(API_ENDPOINTS.FES_DATES);
 
   const {
     data: sunnyStagesResponse,
     error: sunnyStagesError,
     isLoading: sunnyStagesLoading,
-  } = useApiGet<ApiResponse<Stage>>(API_ENDPOINTS.SUNNY_STAGES);
+  } = useAuthenticatedGet<ApiResponse<Stage>>(API_ENDPOINTS.SUNNY_STAGES);
 
   const {
     data: rainyStagesResponse,
     error: rainyStagesError,
     isLoading: rainyStagesLoading,
-  } = useApiGet<ApiResponse<Stage>>(API_ENDPOINTS.RAINY_STAGES);
+  } = useAuthenticatedGet<ApiResponse<Stage>>(API_ENDPOINTS.RAINY_STAGES);
 
   const isLoading = fesDateLoading || sunnyStagesLoading || rainyStagesLoading;
   const hasError = !!(fesDateError || sunnyStagesError || rainyStagesError);
@@ -96,9 +96,9 @@ export const useGetStageOrders = (groupId: number | null) => {
     ? `${API_ENDPOINTS.STAGE_ORDERS}?group_id=${groupId}`
     : null;
 
-  const { data, error, isLoading } = useApiGet<{ data: StageOrderResponse[] }>(
-    endpoint
-  );
+  const { data, error, isLoading } = useAuthenticatedGet<{
+    data: StageOrderResponse[];
+  }>(endpoint);
 
   const filteredOrders =
     data?.data?.filter((order) => order.groupId === groupId) || [];

--- a/user/src/api/stageOptionApi.ts
+++ b/user/src/api/stageOptionApi.ts
@@ -1,6 +1,6 @@
 import useSWRMutation from 'swr/mutation';
 import { useApiGet } from '@/hooks/useApi';
-import { patchFetcher, postFetcher } from './api';
+import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 const API_ENDPOINTS = {
   STAGE_OPTIONS: '/stage_common_options',
@@ -49,9 +49,12 @@ export const useGetStageOptions = (groupId: number | null) => {
 };
 
 export const useCreateStageOptions = () => {
-  return useSWRMutation(API_ENDPOINTS.STAGE_OPTIONS, postFetcher);
+  return useSWRMutation(API_ENDPOINTS.STAGE_OPTIONS, legacyPostFetcher);
 };
 
 export const useUpdateStageOptions = (id: number) => {
-  return useSWRMutation(`${API_ENDPOINTS.STAGE_OPTIONS}/${id}`, patchFetcher);
+  return useSWRMutation(
+    `${API_ENDPOINTS.STAGE_OPTIONS}/${id}`,
+    legacyPatchFetcher
+  );
 };

--- a/user/src/api/stageOptionApi.ts
+++ b/user/src/api/stageOptionApi.ts
@@ -1,5 +1,5 @@
 import useSWRMutation from 'swr/mutation';
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
 const API_ENDPOINTS = {
@@ -39,7 +39,7 @@ export const useGetStageOptions = (groupId: number | null) => {
     : null;
 
   const { data, error, isLoading } =
-    useApiGet<ApiResponse<StageOptionResponse>>(endpoint);
+    useAuthenticatedGet<ApiResponse<StageOptionResponse>>(endpoint);
 
   return {
     stageOptions: data?.status.code === 200 ? data?.data : undefined,

--- a/user/src/api/unRegisteredGroupApi.ts
+++ b/user/src/api/unRegisteredGroupApi.ts
@@ -1,4 +1,4 @@
-import { useApiGet, useApiMutations } from '@/hooks/useApi';
+import { useApiMutations, useAuthenticatedGet } from '@/hooks/useApi';
 
 export type UnregisteredGroupData = {
   group_id: number;
@@ -38,7 +38,7 @@ export const useGetUnregisteredGroup = (
       ? `${API_ENDPOINT}/group?group_id=${groupId}&order_type=${orderType}`
       : null;
 
-  const { data, error, isLoading, mutate } = useApiGet<{
+  const { data, error, isLoading, mutate } = useAuthenticatedGet<{
     data: UnregisteredGroupResponse[];
   }>(endpoint);
 

--- a/user/src/api/useUserDetailApi.ts
+++ b/user/src/api/useUserDetailApi.ts
@@ -1,4 +1,4 @@
-import { useApiGet, useApiPost } from '@/hooks/useApi';
+import { useAuthenticatedGet, useAuthenticatedPost } from '@/hooks/useApi';
 
 const API_ENDPOINTS = {
   USER_DETAILS: '/user_details',
@@ -36,7 +36,9 @@ export type UserInformation = {
 export const useGetUserDetails = (userId: number) => {
   const endpoint = `${API_ENDPOINTS.USER_DETAILS}?user_id=${userId}`;
 
-  const { data, error, isLoading } = useApiGet<{ data: UserDetails }>(endpoint);
+  const { data, error, isLoading } = useAuthenticatedGet<{ data: UserDetails }>(
+    endpoint
+  );
 
   return {
     userDetails: data?.data,
@@ -47,12 +49,12 @@ export const useGetUserDetails = (userId: number) => {
 
 export const useMutateUserDetails = () => {
   const endpoint = API_ENDPOINTS.USER_DETAILS_UPDATE;
-  return useApiPost(endpoint);
+  return useAuthenticatedPost(endpoint);
 };
 
 export const useGetCurrentUserInformation = () => {
   const endpoint = '/api/v1/current_user';
-  const { data, error, isLoading, mutate } = useApiGet<{
+  const { data, error, isLoading, mutate } = useAuthenticatedGet<{
     data: UserInformation;
   }>(endpoint);
 

--- a/user/src/api/useUserDetailApi.ts
+++ b/user/src/api/useUserDetailApi.ts
@@ -1,4 +1,4 @@
-import { useApiGet, useSwrMutation } from '@/hooks/useApi';
+import { useApiGet, useApiPost } from '@/hooks/useApi';
 
 const API_ENDPOINTS = {
   USER_DETAILS: '/user_details',
@@ -47,7 +47,7 @@ export const useGetUserDetails = (userId: number) => {
 
 export const useMutateUserDetails = () => {
   const endpoint = API_ENDPOINTS.USER_DETAILS_UPDATE;
-  return useSwrMutation(endpoint);
+  return useApiPost(endpoint);
 };
 
 export const useGetCurrentUserInformation = () => {

--- a/user/src/api/userPageSettingAPI.ts
+++ b/user/src/api/userPageSettingAPI.ts
@@ -1,4 +1,4 @@
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 
 const API_ENDPOINTS = {
   USER_PAGE_SETTINGS: '/user_page_settings',
@@ -38,7 +38,7 @@ export type UserPageSettings = {
 export const useGetUserPageSettings = () => {
   const endpoint = `${API_ENDPOINTS.USER_PAGE_SETTINGS}`;
 
-  const { data, error, isLoading } = useApiGet<{
+  const { data, error, isLoading } = useAuthenticatedGet<{
     data: UserPageSettings;
   }>(endpoint);
 

--- a/user/src/api/venueApplication.ts
+++ b/user/src/api/venueApplication.ts
@@ -1,6 +1,6 @@
 import useSWRMutation from 'swr/mutation';
 import { useApiGet } from '@/hooks/useApi';
-import { patchFetcher, postFetcher } from './api';
+import { legacyPatchFetcher, legacyPostFetcher } from './api';
 import { ApiResponse } from './stageOptionApi';
 
 export type FesDate = {
@@ -60,12 +60,15 @@ export const usePlacesData = (group_id: number) => {
 // データ送信用フック
 export const usePlacesOrderMutations = () => {
   const urlPath = API_ENDPOINTS.VENUE_MAPS;
-  return useSWRMutation(urlPath, postFetcher);
+  return useSWRMutation(urlPath, legacyPostFetcher);
 };
 
 // データ更新用フック
 export const useUpdatePlacesOrderMutations = (id: number) => {
-  return useSWRMutation(`${API_ENDPOINTS.VENUE_MAPS}/${id}`, patchFetcher);
+  return useSWRMutation(
+    `${API_ENDPOINTS.VENUE_MAPS}/${id}`,
+    legacyPatchFetcher
+  );
 };
 
 // 会場申請のデータ取得用フック

--- a/user/src/api/venueApplication.ts
+++ b/user/src/api/venueApplication.ts
@@ -1,5 +1,5 @@
 import useSWRMutation from 'swr/mutation';
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
 import { ApiResponse } from './stageOptionApi';
 
@@ -47,7 +47,7 @@ export const usePlacesData = (group_id: number) => {
     data: fesDateResponse,
     error: fesDateError,
     isLoading: fesDateLoading,
-  } = useApiGet<ApiDataResponse<Place>>(
+  } = useAuthenticatedGet<ApiDataResponse<Place>>(
     `${API_ENDPOINTS.PLACES}?group_id=${group_id}`
   );
   return {
@@ -78,7 +78,7 @@ export const useGetPlaceOrder = (groupId: number | null) => {
     : null;
 
   const { data, isLoading, mutate } =
-    useApiGet<ApiResponse<PlaceOrder>>(endpoint);
+    useAuthenticatedGet<ApiResponse<PlaceOrder>>(endpoint);
 
   return {
     placeOrder: data?.status.code == 200 ? data?.data : undefined,

--- a/user/src/api/viceRepresentativesApi.ts
+++ b/user/src/api/viceRepresentativesApi.ts
@@ -1,5 +1,5 @@
 import useSWRMutation from 'swr/mutation';
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 import {
   legacyDeleteFetcher,
   legacyPatchFetcher,
@@ -35,7 +35,7 @@ export const useGetViceRepresentatives = (groupId: number | null) => {
     error,
     isLoading,
     mutate: mutateViceRepresentative,
-  } = useApiGet<ApiResponse<ViceRepresentativeResponse>>(endpoint);
+  } = useAuthenticatedGet<ApiResponse<ViceRepresentativeResponse>>(endpoint);
 
   return {
     viceRepresentative: data?.status.code === 200 ? data.data : undefined,

--- a/user/src/api/viceRepresentativesApi.ts
+++ b/user/src/api/viceRepresentativesApi.ts
@@ -1,6 +1,10 @@
 import useSWRMutation from 'swr/mutation';
 import { useApiGet } from '@/hooks/useApi';
-import { deleteFetcher, patchFetcher, postFetcher } from './api';
+import {
+  legacyDeleteFetcher,
+  legacyPatchFetcher,
+  legacyPostFetcher,
+} from './api';
 
 const API_ENDPOINT = '/sub_reps';
 
@@ -42,13 +46,13 @@ export const useGetViceRepresentatives = (groupId: number | null) => {
 };
 
 export const useCreateViceRepresentative = () => {
-  return useSWRMutation(API_ENDPOINT, postFetcher);
+  return useSWRMutation(API_ENDPOINT, legacyPostFetcher);
 };
 
 export const useUpdateViceRepresentative = (id: number | undefined) => {
-  return useSWRMutation(`${API_ENDPOINT}/${id}`, patchFetcher);
+  return useSWRMutation(`${API_ENDPOINT}/${id}`, legacyPatchFetcher);
 };
 
 export const useDeleteViceRepresentative = (id: number | undefined) => {
-  return useSWRMutation(`${API_ENDPOINT}/${id}`, deleteFetcher);
+  return useSWRMutation(`${API_ENDPOINT}/${id}`, legacyDeleteFetcher);
 };

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormLogic.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormLogic.ts
@@ -12,7 +12,7 @@ import {
 import { useGetPlaceOrder } from '@/api/venueApplication';
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
-import { useApiGet } from '@/hooks/useApi';
+import { useAuthenticatedGet } from '@/hooks/useApi';
 import {
   ITEM_IDS,
   LOCATION_TYPES,
@@ -248,7 +248,7 @@ export const useRentItemsFormLogic = (
 
   // 全ての貸出物品データを取得（処理に使用）
   const { data: rentableItemsData, isLoading: rentableItemsLoading } =
-    useApiGet<{
+    useAuthenticatedGet<{
       data: Array<{
         id: number;
         name: string;

--- a/user/src/components/Applications/PublicRelations/PublicRelations.tsx
+++ b/user/src/components/Applications/PublicRelations/PublicRelations.tsx
@@ -79,7 +79,7 @@ const PublicRelations: FC<PublicRelationsProps> = ({
     >
       <Content
         isLoading={isLoading}
-        hasError={hasError}
+        hasError={!!hasError}
         isDeadline={isDeadline}
         isEditing={isEditing}
         toEdit={toEdit}

--- a/user/src/hooks/useApi.ts
+++ b/user/src/hooks/useApi.ts
@@ -1,14 +1,14 @@
 import {
-  deleteFetcher,
-  deleteFetcherWithSession,
-  fetcher,
-  noSessionFetcher,
-  patchFetcher,
-  patchFetcherWithSession,
-  postFetcher,
-  postFetcherWithSession,
-  putFetcher,
-  putFetcherWithSession,
+  authenticatedDeleteFetcher,
+  authenticatedGetFetcher,
+  authenticatedPatchFetcher,
+  authenticatedPostFetcher,
+  authenticatedPutFetcher,
+  unauthenticatedDeleteFetcher,
+  unauthenticatedGetFetcher,
+  unauthenticatedPatchFetcher,
+  unauthenticatedPostFetcher,
+  unauthenticatedPutFetcher,
 } from '@/api/api';
 // ==========================================
 // 独自実装（将来的に削除予定）
@@ -47,20 +47,20 @@ const createMutationHook = <Arg, Data, MK extends Key>(
  *   - isValidating: boolean - 再検証中かどうか
  *   - mutate: (data?: T | Promise<T>, shouldRevalidate?: boolean) => Promise<T | undefined> - データの更新関数
  */
-export const useApiGet = <T>(
+export const useAuthenticatedGet = <T>(
   url: string | null,
   options?: SWRConfiguration<T, Error>
 ) => {
   const { data: session, status } = useSession();
   const key =
     status === 'authenticated' && url ? ([url, session!] as const) : null;
-  return useSWR<T, Error>(key, fetcher, options);
+  return useSWR<T, Error>(key, authenticatedGetFetcher, options);
 };
 
-export const useApiGetNoAuth = <T>(
+export const useUnauthenticatedGet = <T>(
   url: string | null,
   options?: SWRConfiguration<T, Error>
-) => useSWR<T, Error>(url ?? null, noSessionFetcher, options);
+) => useSWR<T, Error>(url ?? null, unauthenticatedGetFetcher, options);
 
 /** 認証ありミューテーション */
 /**
@@ -75,38 +75,38 @@ export const useApiGetNoAuth = <T>(
  *   trigger: (arg?: { query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
  * }
  */
-export const useApiPost = createMutationHook<
+export const useAuthenticatedPost = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   readonly [string, Session]
->(postFetcherWithSession, (url) => {
+>(authenticatedPostFetcher, (url) => {
   const { data: session, status } = useSession();
   return status === 'authenticated' && url ? ([url, session!] as const) : null;
 });
 
-export const useApiPut = createMutationHook<
+export const useAuthenticatedPut = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   readonly [string, Session]
->(putFetcherWithSession, (url) => {
+>(authenticatedPutFetcher, (url) => {
   const { data: session, status } = useSession();
   return status === 'authenticated' && url ? ([url, session!] as const) : null;
 });
 
-export const useApiPatch = createMutationHook<
+export const useAuthenticatedPatch = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   readonly [string, Session]
->(patchFetcherWithSession, (url) => {
+>(authenticatedPatchFetcher, (url) => {
   const { data: session, status } = useSession();
   return status === 'authenticated' && url ? ([url, session!] as const) : null;
 });
 
-export const useApiDelete = createMutationHook<
+export const useAuthenticatedDelete = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   readonly [string, Session]
->(deleteFetcherWithSession, (url) => {
+>(authenticatedDeleteFetcher, (url) => {
   const { data: session, status } = useSession();
   return status === 'authenticated' && url ? ([url, session!] as const) : null;
 });
@@ -124,29 +124,29 @@ export const useApiDelete = createMutationHook<
  *   trigger: (arg?: { query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
  * }
  */
-export const useApiPostNoAuth = createMutationHook<
+export const useUnauthenticatedPost = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   string
->(postFetcher, (url) => url ?? null);
+>(unauthenticatedPostFetcher, (url) => url ?? null);
 
-export const useApiPutNoAuth = createMutationHook<
+export const useUnauthenticatedPut = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   string
->(putFetcher, (url) => url ?? null);
+>(unauthenticatedPutFetcher, (url) => url ?? null);
 
-export const useApiPatchNoAuth = createMutationHook<
+export const useUnauthenticatedPatch = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   string
->(patchFetcher, (url) => url ?? null);
+>(unauthenticatedPatchFetcher, (url) => url ?? null);
 
-export const useApiDeleteNoAuth = createMutationHook<
+export const useUnauthenticatedDelete = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
   string
->(deleteFetcher, (url) => url ?? null);
+>(unauthenticatedDeleteFetcher, (url) => url ?? null);
 
 // ==========================================
 // 独自実装（将来的に削除予定）

--- a/user/src/hooks/useApi.ts
+++ b/user/src/hooks/useApi.ts
@@ -1,39 +1,158 @@
 import {
-  deleteData,
+  deleteFetcher,
+  deleteFetcherWithSession,
   fetcher,
-  patchData,
-  postData,
+  noSessionFetcher,
+  patchFetcher,
+  patchFetcherWithSession,
+  postFetcher,
   postFetcherWithSession,
-  putData,
+  putFetcher,
+  putFetcherWithSession,
 } from '@/api/api';
+// ==========================================
+// 独自実装（将来的に削除予定）
+import { deleteData, patchData, postData, putData } from '@/api/api';
+import { Session } from 'next-auth';
+// ==========================================
+
 import { useSession } from 'next-auth/react';
-import useSWR from 'swr';
-import useSWRMutation from 'swr/mutation';
+import useSWR, { Key, SWRConfiguration } from 'swr';
+import useSWRMutation, { MutationFetcher } from 'swr/mutation';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// データ取得のための共通フック
-export const useApiGet = <T>(url: string | null, options?: any) => {
-  // sessionの状態を取得
-  const { data: session, status } = useSession();
-
-  const shouldFetch = status === 'authenticated' && url;
-
-  const { data, error, isLoading, mutate } = useSWR<T>(
-    shouldFetch ? [url, session] : null,
-    fetcher,
-    options
-  );
-
-  return {
-    data,
-    error,
-    isLoading,
-    mutate,
+/**
+ * Mutationフックの共通生成関数
+ * @template Arg ミューテーション時の引数型
+ * @template Data レスポンスデータ型
+ * @template MK mutaton key の型 (SWRのKeyに制約)
+ */
+const createMutationHook = <Arg, Data, MK extends Key>(
+  fetcherFn: MutationFetcher<Data, MK, Arg>,
+  getKey: (url: string | null) => MK | null
+) => {
+  return (url: string | null, options?: any) => {
+    const key = getKey(url);
+    return useSWRMutation<Data, Error, MK, Arg>(key!, fetcherFn, options);
   };
 };
 
-// データ送信のための関数を返すフック
+/**
+ * GETリクエスト用のフック
+ * @returns {SWRResponse<T, Error>} - データ、ローディング状態、エラー情報を含むオブジェクト
+ *   - data: T | undefined - 取得したデータ
+ *   - error: Error | undefined - エラー情報
+ *   - isLoading: boolean - ローディング中かどうか
+ *   - isValidating: boolean - 再検証中かどうか
+ *   - mutate: (data?: T | Promise<T>, shouldRevalidate?: boolean) => Promise<T | undefined> - データの更新関数
+ */
+export const useApiGet = <T>(
+  url: string | null,
+  options?: SWRConfiguration<T, Error>
+) => {
+  const { data: session, status } = useSession();
+  const key =
+    status === 'authenticated' && url ? ([url, session!] as const) : null;
+  return useSWR<T, Error>(key, fetcher, options);
+};
+
+export const useApiGetNoAuth = <T>(
+  url: string | null,
+  options?: SWRConfiguration<T, Error>
+) => useSWR<T, Error>(url ?? null, noSessionFetcher, options);
+
+/** 認証ありミューテーション */
+/**
+ * @returns {SWRMutationResponse<T, Error>} {
+ *   data: T | undefined;        // レスポンスデータ
+ *   error: Error | undefined;   // エラー情報
+ *   isMutating: boolean;        // ミューテーション実行中かどうか
+ *   reset: () => void;          // 状態のリセット関数
+ *   // POST,PUT,PATCH
+ *   trigger: (arg?: { body?: any; query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
+ *   // DELETE
+ *   trigger: (arg?: { query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
+ * }
+ */
+export const useApiPost = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  readonly [string, Session]
+>(postFetcherWithSession, (url) => {
+  const { data: session, status } = useSession();
+  return status === 'authenticated' && url ? ([url, session!] as const) : null;
+});
+
+export const useApiPut = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  readonly [string, Session]
+>(putFetcherWithSession, (url) => {
+  const { data: session, status } = useSession();
+  return status === 'authenticated' && url ? ([url, session!] as const) : null;
+});
+
+export const useApiPatch = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  readonly [string, Session]
+>(patchFetcherWithSession, (url) => {
+  const { data: session, status } = useSession();
+  return status === 'authenticated' && url ? ([url, session!] as const) : null;
+});
+
+export const useApiDelete = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  readonly [string, Session]
+>(deleteFetcherWithSession, (url) => {
+  const { data: session, status } = useSession();
+  return status === 'authenticated' && url ? ([url, session!] as const) : null;
+});
+
+/** 認証なしミューテーション */
+/**
+ * @returns {SWRMutationResponse<T, Error>} {
+ *   data: T | undefined;        // レスポンスデータ
+ *   error: Error | undefined;   // エラー情報
+ *   isMutating: boolean;        // ミューテーション実行中かどうか
+ *   reset: () => void;          // 状態のリセット関数
+ *   // POST,PUT,PATCH
+ *   trigger: (arg?: { body?: any; query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
+ *   // DELETE
+ *   trigger: (arg?: { query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
+ * }
+ */
+export const useApiPostNoAuth = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  string
+>(postFetcher, (url) => url ?? null);
+
+export const useApiPutNoAuth = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  string
+>(putFetcher, (url) => url ?? null);
+
+export const useApiPatchNoAuth = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  string
+>(patchFetcher, (url) => url ?? null);
+
+export const useApiDeleteNoAuth = createMutationHook<
+  { body?: any; query?: Record<string, any> },
+  any,
+  string
+>(deleteFetcher, (url) => url ?? null);
+
+// ==========================================
+// 独自実装（将来的に削除予定）
+// ==========================================
+
+// データ送信のための関数を返すフック（独自実装）
 export const useApiMutations = () => {
   const { data: session, status } = useSession();
 
@@ -61,18 +180,4 @@ export const useApiMutations = () => {
     remove: (url: string) => deleteData(url, session),
     patch: (url: string, data: any) => patchData(url, data, session),
   };
-};
-
-// データ送信のための共通フック
-export const useSwrMutation = (url: string | null, options?: any) => {
-  // sessionの状態を取得
-  const { data: session, status } = useSession();
-
-  const shouldFetch = status === 'authenticated' && url;
-
-  return useSWRMutation(
-    shouldFetch ? [url, session] : null,
-    postFetcherWithSession,
-    options
-  );
 };

--- a/user/src/hooks/useApi.ts
+++ b/user/src/hooks/useApi.ts
@@ -38,15 +38,7 @@ const createMutationHook = <Arg, Data, MK extends Key>(
   };
 };
 
-/**
- * GETリクエスト用のフック
- * @returns {SWRResponse<T, Error>} - データ、ローディング状態、エラー情報を含むオブジェクト
- *   - data: T | undefined - 取得したデータ
- *   - error: Error | undefined - エラー情報
- *   - isLoading: boolean - ローディング中かどうか
- *   - isValidating: boolean - 再検証中かどうか
- *   - mutate: (data?: T | Promise<T>, shouldRevalidate?: boolean) => Promise<T | undefined> - データの更新関数
- */
+/**　GETリクエスト用のフック　　*/
 export const useAuthenticatedGet = <T>(
   url: string | null,
   options?: SWRConfiguration<T, Error>
@@ -62,19 +54,7 @@ export const useUnauthenticatedGet = <T>(
   options?: SWRConfiguration<T, Error>
 ) => useSWR<T, Error>(url ?? null, unauthenticatedGetFetcher, options);
 
-/** 認証ありミューテーション */
-/**
- * @returns {SWRMutationResponse<T, Error>} {
- *   data: T | undefined;        // レスポンスデータ
- *   error: Error | undefined;   // エラー情報
- *   isMutating: boolean;        // ミューテーション実行中かどうか
- *   reset: () => void;          // 状態のリセット関数
- *   // POST,PUT,PATCH
- *   trigger: (arg?: { body?: any; query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
- *   // DELETE
- *   trigger: (arg?: { query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
- * }
- */
+/** 認証ありミューテーション用のフック */
 export const useAuthenticatedPost = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,
@@ -111,19 +91,7 @@ export const useAuthenticatedDelete = createMutationHook<
   return status === 'authenticated' && url ? ([url, session!] as const) : null;
 });
 
-/** 認証なしミューテーション */
-/**
- * @returns {SWRMutationResponse<T, Error>} {
- *   data: T | undefined;        // レスポンスデータ
- *   error: Error | undefined;   // エラー情報
- *   isMutating: boolean;        // ミューテーション実行中かどうか
- *   reset: () => void;          // 状態のリセット関数
- *   // POST,PUT,PATCH
- *   trigger: (arg?: { body?: any; query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
- *   // DELETE
- *   trigger: (arg?: { query?: Record<string, any> }) => Promise<T | undefined>; // ミューテーション実行関数
- * }
- */
+/** 認証なしミューテーション用のフック */
 export const useUnauthenticatedPost = createMutationHook<
   { body?: any; query?: Record<string, any> },
   any,

--- a/user/src/hooks/useApi.ts
+++ b/user/src/hooks/useApi.ts
@@ -12,7 +12,7 @@ import {
 } from '@/api/api';
 // ==========================================
 // 独自実装（将来的に削除予定）
-import { deleteData, patchData, postData, putData } from '@/api/api';
+import { ApiError, deleteData, patchData, postData, putData } from '@/api/api';
 import { Session } from 'next-auth';
 // ==========================================
 
@@ -34,25 +34,25 @@ const createMutationHook = <Arg, Data, MK extends Key>(
 ) => {
   return (url: string | null, options?: any) => {
     const key = getKey(url);
-    return useSWRMutation<Data, Error, MK, Arg>(key!, fetcherFn, options);
+    return useSWRMutation<Data, ApiError, MK, Arg>(key!, fetcherFn, options);
   };
 };
 
 /**　GETリクエスト用のフック　　*/
 export const useAuthenticatedGet = <T>(
   url: string | null,
-  options?: SWRConfiguration<T, Error>
+  options?: SWRConfiguration<T, ApiError>
 ) => {
   const { data: session, status } = useSession();
   const key =
     status === 'authenticated' && url ? ([url, session!] as const) : null;
-  return useSWR<T, Error>(key, authenticatedGetFetcher, options);
+  return useSWR<T, ApiError>(key, authenticatedGetFetcher, options);
 };
 
 export const useUnauthenticatedGet = <T>(
   url: string | null,
-  options?: SWRConfiguration<T, Error>
-) => useSWR<T, Error>(url ?? null, unauthenticatedGetFetcher, options);
+  options?: SWRConfiguration<T, ApiError>
+) => useSWR<T, ApiError>(url ?? null, unauthenticatedGetFetcher, options);
 
 /** 認証ありミューテーション用のフック */
 export const useAuthenticatedPost = createMutationHook<


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1911

# 概要
<!-- 開発内容の概要を記載 -->
修正前
- GET→SWR（認証あり）
- POST, PUT, PATCH, DELETE→独自（認証あり）

修正後
- GET→SWR（認証あり・なし）
- POST, PUT, PATCH, DELETE→SWRMutatios（認証あり・なし）

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `api/api.ts` にfetcher、 `hooks/useApi.ts` にswr, swrMutationのhooksを実装
- 修正前の実装は将来的に修正後の実装に切り替える
  - 修正前の関数は下の方に `legacy〇〇Fetcher` みたいな変数名に変えて置いてある
    - 使ってる方のファイルも修正済み

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 
- [ ] 
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->