### PR TITLE
団体削除時にkeyで繋がっているもの全てを削除するように修正。

### DIFF
--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -82,7 +82,6 @@ class GroupsController < ApplicationController
   # DELETE /groups/1
   # DELETE /groups/1.json
   def destroy
-    @group.un_registered_groups.destroy_all
     @group.destroy
     render json: fmt(ok, [], "Deleted group id = "+params[:id])
 

--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -82,6 +82,7 @@ class GroupsController < ApplicationController
   # DELETE /groups/1
   # DELETE /groups/1.json
   def destroy
+    @group.un_registered_groups.destroy_all
     @group.destroy
     render json: fmt(ok, [], "Deleted group id = "+params[:id])
 

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -16,6 +16,7 @@ class Group < ApplicationRecord
     has_one :venue_map
     has_one :announcement
     has_one :cooking_process_order
+    has_many :un_registered_groups, dependent: :destroy
     has_many :fire_equipment_orders
 
     ### group_category (参加団体カテゴリ)


### PR DESCRIPTION
## Summary
- ensure groups delete associated unregistered records before removal
- update destroy action for groups to delete referenced unregistered info

## Testing
- `cd api && bundle exec rake test` *(fails: rbenv version `3.0.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c47a9279c832b98cdf2f4b4faf6f8

再現するの忘れてた――――――
ローカルで消せることを確認しました。
```

  RentalOrder Load (0.6ms)  SELECT `rental_orders`.* FROM `rental_orders` WHERE `rental_orders`.`group_id` = 1

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  RentalOrder Destroy (0.6ms)  DELETE FROM `rental_orders` WHERE `rental_orders`.`id` = 1

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  AssignRentalItem Load (1.3ms)  SELECT `assign_rental_items`.* FROM `assign_rental_items` WHERE `assign_rental_items`.`group_id` = 1

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  AssignRentalItem Destroy (0.6ms)  DELETE FROM `assign_rental_items` WHERE `assign_rental_items`.`id` = 1

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  GroupIdentification Load (1.7ms)  SELECT `group_identifications`.* FROM `group_identifications` WHERE `group_identifications`.`group_id` = 1 LIMIT 1

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  Group Destroy (1.0ms)  DELETE FROM `groups` WHERE `groups`.`id` = 1

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  TRANSACTION (30.9ms)  COMMIT

  ↳ app/controllers/groups_controller.rb:86:in `destroy'

  User Load (0.8ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1

  ↳ app/controllers/groups_controller.rb:97:in `destroy'

  GroupCategory Load (0.7ms)  SELECT `group_categories`.* FROM `group_categories` WHERE `group_categories`.`id` = 1 LIMIT 1

  ↳ app/controllers/groups_controller.rb:99:in `destroy'

Completed 200 OK in 721ms (Views: 3.7ms | ActiveRecord: 139.6ms | Allocations: 56916)
```