### PR TITLE
[fix] 物品申請の修正ボタンデザイン統一

### DIFF
--- a/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
+++ b/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
@@ -117,12 +117,13 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
               </>
             )}
             {!isEditing && isExist && !isDeadline && (
-              <div className="flex justify-center">
+              <div className="mt-4 flex w-full items-center justify-center gap-4">
                 <Button
-                  type="button"
-                  onClick={handleEditClick}
                   size="pc"
                   color="main"
+                  type="button"
+                  icon="pencil"
+                  onClick={handleEditClick}
                 >
                   修正
                 </Button>

--- a/user/src/components/Applications/CookingProcessOrder/CookingProcessOrderForm/CookingProcessOrderForm.stories.tsx
+++ b/user/src/components/Applications/CookingProcessOrder/CookingProcessOrderForm/CookingProcessOrderForm.stories.tsx
@@ -1,11 +1,35 @@
 import '@globals';
 import { Meta, StoryObj } from '@storybook/react';
+import { FormProvider, useForm } from 'react-hook-form';
 import CookingProcessOrderForm from './CookingProcessOrderForm';
+
+// FormProviderでラップするためのデコレーター
+const FormProviderDecorator = (Story: any, context: any) => {
+  const methods = useForm({
+    defaultValues: {
+      cookingProcessOrders: [
+        {
+          preOpenKitchen: false,
+          duringOpenKitchen: false,
+          tent: '',
+          confirmCookingProcess: [],
+        },
+      ],
+    },
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <Story {...context} />
+    </FormProvider>
+  );
+};
 
 export default {
   title: 'Components/Applications/CookingProcessOrderForm',
   tags: ['autodocs'],
   component: CookingProcessOrderForm,
+  decorators: [FormProviderDecorator],
   parameters: {
     docs: {
       source: {
@@ -18,5 +42,44 @@ export default {
 type Story = StoryObj<typeof CookingProcessOrderForm>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    index: 0,
+    foodProductName: 'コーヒー',
+  },
+};
+
+export const WithSampleData: Story = {
+  args: {
+    index: 0,
+    foodProductName: 'ケーキ',
+  },
+  decorators: [
+    (Story) => {
+      const methods = useForm({
+        defaultValues: {
+          cookingProcessOrders: [
+            {
+              preOpenKitchen: true,
+              duringOpenKitchen: false,
+              tent: '1. ケーキの材料を準備する\n2. オーブンを180度に予熱する\n3. 生地を作って焼く\n4. 冷ましてから盛り付ける',
+              confirmCookingProcess: ['1', '2'],
+            },
+          ],
+        },
+      });
+
+      return (
+        <FormProvider {...methods}>
+          <Story />
+        </FormProvider>
+      );
+    },
+  ],
+};
+
+export const EmptyForm: Story = {
+  args: {
+    index: 0,
+    foodProductName: 'からあげ',
+  },
 };

--- a/user/src/components/Applications/CookingProcessOrder/CookingProcessOrderForm/CookingProcessOrderForm.stories.tsx
+++ b/user/src/components/Applications/CookingProcessOrder/CookingProcessOrderForm/CookingProcessOrderForm.stories.tsx
@@ -1,10 +1,9 @@
 import '@globals';
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryContext, StoryFn, StoryObj } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import CookingProcessOrderForm from './CookingProcessOrderForm';
 
-// FormProviderでラップするためのデコレーター
-const FormProviderDecorator = (Story: any, context: any) => {
+const FormProviderDecorator = (Story: StoryFn, context: StoryContext) => {
   const methods = useForm({
     defaultValues: {
       cookingProcessOrders: [

--- a/user/src/components/Applications/FoodProduct/FoodProductForm/FoodProductForm.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProductForm/FoodProductForm.tsx
@@ -124,13 +124,13 @@ const FoodProductForm: FC<FoodProductFormProps> = ({
           );
         })}
 
-        <div className="mt-6 flex justify-center">
+        <div className="mt-4 flex w-full items-center justify-center gap-4">
           <Button
-            type="button"
             size="pc"
             color="main"
+            type="button"
+            icon="pencil"
             onClick={toEdit}
-            icon="edit"
           >
             修正
           </Button>

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -1,7 +1,7 @@
 // src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
 import { FC } from 'react';
 import { Controller } from 'react-hook-form';
-import { RiDeleteBinLine, RiEdit2Line } from 'react-icons/ri';
+import { RiDeleteBinLine } from 'react-icons/ri';
 import { useRentItemsFormLogic } from '@/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormLogic';
 import Button from '@/components/Button';
 import Radio from '@/components/Form/Radio';
@@ -76,17 +76,16 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
             <p>学校から借用する備品はありません。</p>
           </div>
           {isDeadline && (
-            <div className="mt-4 flex justify-center">
-              <MultiItemFormButton
-                type="button"
+            <div className="mt-4 flex w-full items-center justify-center gap-4">
+              <Button
                 size="pc"
-                color="edit"
+                color="main"
+                type="button"
+                icon="pencil"
                 onClick={openEditMode}
               >
-                <div className="flex items-center">
-                  <RiEdit2Line size={18} className="mr-1" /> 修正
-                </div>
-              </MultiItemFormButton>
+                修正
+              </Button>
             </div>
           )}
         </div>
@@ -141,17 +140,16 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
         </div>
 
         {isDeadline && (
-          <div className="mt-6 text-center">
-            <MultiItemFormButton
-              type="button"
+          <div className="mt-4 flex w-full items-center justify-center gap-4">
+            <Button
               size="pc"
-              color="edit"
+              color="main"
+              type="button"
+              icon="pencil"
               onClick={openEditMode}
             >
-              <div className="flex items-center">
-                <RiEdit2Line size={18} className="mr-1" /> 修正
-              </div>
-            </MultiItemFormButton>
+              修正
+            </Button>
           </div>
         )}
       </div>

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
@@ -177,14 +177,13 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
         );
       })}
       {!isDeadline && (
-        <div className="mt-4 flex justify-center space-x-4">
+        <div className="mt-4 flex w-full items-center justify-center gap-4">
           <Button
-            type="button"
             size="pc"
             color="main"
-            variant
-            onClick={toggleEdit}
+            type="button"
             icon="pencil"
+            onClick={toggleEdit}
           >
             修正
           </Button>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1944 

# 概要
<!-- 開発内容の概要を記載 -->
以下の修正ボタンを統一したデザインに変更
- 物品申請
- 販売品申請
- 購入品申請
- 調理工程申請

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- ボタンのアイコンを変更
- その他ボタンまわりの余白なども併せて統一

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
修正ボタンがこのタイプに統一されていればOK
![image](https://github.com/user-attachments/assets/76c464f9-86d7-47e3-90bc-2bbc125618b0)

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] ボタンが他のアイコンと同じになっているか 
- [ ] 違うフォームが表示されないか
- [ ] 申請あり・なしの両方で同じデザインのボタンが表示されるか

# 備考
<!-- 実装していて困った箇所・質問など -->
