### PR TITLE
調理工程申請の不具合修正と命名規則の統一

### DIFF
--- a/admin_view/nuxt-project/pages/cooking_process_order/_id.vue
+++ b/admin_view/nuxt-project/pages/cooking_process_order/_id.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="main-content">
     <SubHeader
-      v-bind:pageTitle="cooking_process_order.group.name"
+      v-if="cooking_process_order"
+      v-bind:pageTitle="`${cooking_process_order.group.name} - ${cooking_process_order.food_product.name}`"
       pageSubTitle="調理工程申請一覧"
     >
       <CommonButton
@@ -26,7 +27,11 @@
           <VerticalTable>
             <tr>
               <th colspan="2">ID</th>
-              <td>{{ cooking_process_order.group.id }}</td>
+              <td>{{ cooking_process_order.food_product.id }}</td>
+            </tr>
+            <tr>
+              <th colspan="2">販売品名</th>
+              <td>{{ cooking_process_order.food_product.name }}</td>
             </tr>
             <tr>
               <th colspan="2">参加団体</th>
@@ -157,13 +162,11 @@ export default {
   data() {
     return {
       cooking_process_order: {},
-      groups: [],
       isOpenEditModal: false,
       isOpenDeleteModal: false,
       isOpenSnackBar: false,
       snackMessage: null,
-      group_id: null,
-      routeId: null,
+      food_product_id: null,
       pre_open_kitchen: null,
       during_open_kitchen: null,
       tent: "",
@@ -175,18 +178,17 @@ export default {
     }),
   },
   async asyncData({ $axios, route }) {
-    const routeId = route.path.replace("/cooking_process_order", "");
-    const url = "/api/v1/get_cooking_process_order_for_admin_view/" + routeId;
+    const foodProductId = route.params.id;
+    const url = `/api/v1/get_cooking_process_order_by_food_product_id/${foodProductId}`;
     const res = await $axios.$get(url);
     return {
-      cooking_process_order: res.data[0],
-      route: url,
+      cooking_process_order: res.data,
     };
   },
   methods: {
     openEditModal() {
       if (this.cooking_process_order.cooking_process_order) {
-        this.group_id = this.cooking_process_order.group.id;
+        this.food_product_id = this.cooking_process_order.food_product.id;
         this.pre_open_kitchen =
           this.cooking_process_order.cooking_process_order.pre_open_kitchen;
         this.during_open_kitchen =
@@ -195,7 +197,7 @@ export default {
           this.cooking_process_order.cooking_process_order.tent;
         this.isOpenEditModal = true;
       } else {
-        this.group_id = this.cooking_process_order.group.id;
+        this.food_product_id = this.cooking_process_order.food_product.id;
         this.pre_open_kitchen = null;
         this.during_open_kitchen = null;
         this.tent = null;
@@ -221,9 +223,9 @@ export default {
       this.isOpenSnackBar = false;
     },
     async reload(id) {
-      const url = "/api/v1/get_cooking_process_order_for_admin_view/" + id;
+      const url = `/api/v1/get_cooking_process_order_by_food_product_id/${this.cooking_process_order.food_product.id}`;
       const res = await this.$axios.$get(url);
-      this.cooking_process_order = res.data[0];
+      this.cooking_process_order = res.data;
     },
     async edit() {
       if (
@@ -235,20 +237,21 @@ export default {
         return;
       }
       const cookingProcessOrderData = {
+        food_product_id: this.food_product_id,
         pre_open_kitchen: this.pre_open_kitchen,
         during_open_kitchen: this.during_open_kitchen,
         tent: this.tent,
       };
       if (this.cooking_process_order.cooking_process_order) {
         // 既存の調理工程を編集
-        const editUrl = `/cooking_process_orders/${this.cooking_process_order.cooking_process_order.id}?group_id=${this.group_id}`;
+        const editUrl = `/cooking_process_orders/${this.cooking_process_order.cooking_process_order.id}`;
         try {
           const response = await this.$axios.$put(
             editUrl,
-            cookingProcessOrderData
+            { cooking_process_order: cookingProcessOrderData }
           );
           this.openSnackBar("調理工程を編集しました");
-          this.reload(response.data.group_id);
+          this.reload();
           this.closeEditModal();
         } catch (error) {
           this.openSnackBar(
@@ -257,14 +260,14 @@ export default {
         }
       } else {
         // 新しい調理工程を登録
-        const postUrl = `/cooking_process_orders?group_id=${this.group_id}`;
+        const postUrl = `/cooking_process_orders`;
         try {
           const response = await this.$axios.$post(
             postUrl,
-            cookingProcessOrderData
+            { cooking_process_order: cookingProcessOrderData }
           );
           this.openSnackBar("調理工程を登録しました");
-          this.reload(response.data.group_id);
+          this.reload();
           this.closeEditModal();
         } catch (error) {
           this.openSnackBar(

--- a/admin_view/nuxt-project/pages/cooking_process_order/index.vue
+++ b/admin_view/nuxt-project/pages/cooking_process_order/index.vue
@@ -49,20 +49,20 @@
         </template>
         <template v-slot:table-body>
           <tr
-            v-for="(cooking_process_order, index) in cooking_process_orders"
-            :key="index"
+            v-for="food_product in food_products"
+            :key="food_product.id"
             @click="
               () =>
                 $router.push({
-                  path:
-                    `/cooking_process_order/` + cooking_process_order.group.id,
+                  path: `/cooking_process_order/${food_product.id}`,
                 })
             "
           >
-            <td>{{ cooking_process_order.group.id }}</td>
-            <td>{{ cooking_process_order.group.name }}</td>
+            <td>{{ food_product.id }}</td>
+            <td>{{ food_product.group.name }}</td>
+            <td>{{ food_product.name }}</td>
             <td>
-              <div v-if="cooking_process_order.cooking_process_order">
+              <div v-if="food_product.cooking_process_order">
                 登録済み
               </div>
               <div v-else>未登録</div>
@@ -79,10 +79,10 @@
     >
       <template v-slot:form>
         <div>
-          <h3>参加団体</h3>
-          <select v-model="group_id">
-            <option v-for="group in groups" :key="group.id" :value="group.id">
-              {{ group.name }}
+          <h3>販売品</h3>
+          <select v-model="food_product_id">
+            <option v-for="food_product in food_products_have_no_cooking_process_order" :key="food_product.id" :value="food_product.id">
+              {{ food_product.group.name }} - {{ food_product.name }}
             </option>
           </select>
         </div>
@@ -156,12 +156,12 @@ export default {
   watchQuery: ["page"],
   data() {
     return {
-      headers: ["ID", "参加団体", "申請状況"],
+      headers: ["ID", "参加団体", "販売品名", "申請状況"],
       isOpenAddModal: false,
       isOpenSnackBar: false,
-      group_id: "",
-      cooking_process_orders: [],
-      groups: [],
+      food_product_id: null,
+      food_products: [],
+      food_products_have_no_cooking_process_order: [],
       dialog: false,
       snackMessage: "",
       refYears: "Years",
@@ -186,7 +186,7 @@ export default {
     });
 
     return {
-      cooking_process_orders: cooking_process_ordersRes.data,
+      food_products: cooking_process_ordersRes.data,
       yearList: yearsRes.data,
       refYearID: currentYearRes.data.fes_year_id,
       refYears: currentYears[0].year_num,
@@ -205,9 +205,9 @@ export default {
   methods: {
 
     async openAddModal() {
-      const groupUrl = "/api/v1/get_groups_have_no_cooking_process_order";
-      const groupRes = await this.$axios.$get(groupUrl);
-      this.groups = groupRes.data;
+      const url = "/api/v1/get_food_products_have_no_cooking_process_order";
+      const res = await this.$axios.$get(url);
+      this.food_products_have_no_cooking_process_order = res.data;
       this.isOpenAddModal = true;
     },
     closeAddModal() {
@@ -226,33 +226,33 @@ export default {
         "/api/v1/get_refinement_cooking_process_orders?fes_year_id=" +
         this.refYearID;
       this.$axios.post(url).then((res) => {
-        this.cooking_process_orders = res.data.data;
+        this.food_products = res.data.data;
       });
     },
     async submit() {
       // フォーム入力のバリデーション
       if (
-        !this.group_id ||
-        !this.pre_open_kitchen ||
-        !this.during_open_kitchen ||
+        !this.food_product_id ||
+        this.pre_open_kitchen === null ||
+        this.during_open_kitchen === null ||
         !this.tent
       ) {
-        this.openSnackBar("参加団体と全ての調理工程申請を入力してください");
+        this.openSnackBar("販売品と全ての調理工程申請を入力してください");
         return;
       }
       const cookingProcessOrderData = {
+        food_product_id: this.food_product_id,
         pre_open_kitchen: this.pre_open_kitchen,
         during_open_kitchen: this.during_open_kitchen,
         tent: this.tent,
       };
 
-      // POSTリクエストのURL
-      const postCookingProcessOrderUrl = `/cooking_process_orders?group_id=${this.group_id}`;
+      const url = `/cooking_process_orders`;
 
       try {
         const response = await this.$axios.$post(
-          postCookingProcessOrderUrl,
-          cookingProcessOrderData
+          url,
+          { cooking_process_order: cookingProcessOrderData }
         );
         this.openSnackBar("調理工程申請を登録しました");
         this.clearForm();
@@ -265,9 +265,9 @@ export default {
       }
     },
     clearForm() {
-      this.group_id = null;
-      this.pre_open_kitchen = "";
-      this.during_open_kitchen = "";
+      this.food_product_id = null;
+      this.pre_open_kitchen = null;
+      this.during_open_kitchen = null;
       this.tent = "";
     },
 
@@ -280,14 +280,12 @@ export default {
       } else {
         this.refYears = name_list[item_id - 1].year_num;
       }
-      this.cooking_process_orders = [];
+      this.food_products = [];
       const refUrl =
         "/api/v1/get_refinement_cooking_process_orders?fes_year_id=" +
         this.refYearID;
       const refRes = await this.$axios.$post(refUrl);
-      for (const res of refRes.data) {
-        this.cooking_process_orders.push(res);
-      }
+      this.food_products = refRes.data;
       const storedSearchText = localStorage.getItem(
         this.$route.path + "SearchText"
       );
@@ -298,13 +296,11 @@ export default {
     },
     async searchCookingProcessOrders() {
       localStorage.setItem(this.$route.path + "SearchText", this.searchText);
-      this.cooking_process_orders = [];
+      this.food_products = [];
       const searchUrl =
         "/api/v1/get_search_cooking_process_orders?word=" + this.searchText;
       const refRes = await this.$axios.$post(searchUrl);
-      for (const res of refRes.data) {
-        this.cooking_process_orders.push(res);
-      }
+      this.food_products = refRes.data;
     },
     // TODO: get_cooking_process_orders_csvを年数指定できるように
     async downloadCSV() {

--- a/api/app/controllers/api/v1/cooking_process_orders_api_controller.rb
+++ b/api/app/controllers/api/v1/cooking_process_orders_api_controller.rb
@@ -8,29 +8,39 @@ class Api::V1::CookingProcessOrdersApiController < ApplicationController
   # 絞り込み機能
   def get_refinement_cooking_process_orders
     fes_year_id = params[:fes_year_id].to_i
-    # 両方ともALL
-    if fes_year_id == 0
-      @groups = Group.with_cooking_process_orders
-      # fes_year_idだけ指定
-    elsif fes_year_id != 0
-      @groups = Group.with_cooking_process_order_narrow_down_by_fes_year(fes_year_id)
+    
+    @food_products = FoodProduct.joins(:group).includes(:group, :cooking_process_order)
+    
+    if fes_year_id != 0
+      @food_products = @food_products.where(groups: { fes_year_id: fes_year_id })
     end
+    
+    @food_products = @food_products.order('groups.id')
 
-    if @groups.count == 0
-      render json: fmt(not_found, [], "Not found groups")
+    if @food_products.empty?
+      render json: fmt(not_found, [], "Not found food products")
     else
-      render json: fmt(ok, @groups)
+      render json: fmt(ok, @food_products.as_json(include: [:group, :cooking_process_order]))
     end
   end
 
   # あいまい検索機能
   def get_search_cooking_process_orders
     word = params[:word]
-    @groups = Group.with_cooking_process_order_narrow_down_by_search_word(word)
-    if @groups.count == 0
-      render json: fmt(not_found, [], "Not found groups")
+    @food_products = FoodProduct.joins(:group).includes(:group, :cooking_process_order)
+                                .where("food_products.name LIKE :word OR groups.name LIKE :word", word: "%#{word}%")
+                                .order('groups.id')
+    
+    if @food_products.empty?
+      render json: fmt(not_found, [], "Not found food products")
     else
-      render json: fmt(ok, @groups)
+      render json: fmt(ok, @food_products.as_json(include: [:group, :cooking_process_order]))
     end
+  end
+
+  # GET /api/v1/get_cooking_process_order_by_food_product_id/:food_product_id - 販売品IDに紐づく調理工程申請を取得
+  def get_cooking_process_order_by_food_product_id
+    @cooking_process_order = CookingProcessOrder.with_group_by_food_product_id(params[:food_product_id])
+    render json: fmt(ok, @cooking_process_order)
   end
 end

--- a/api/app/controllers/api/v1/food_products_api_controller.rb
+++ b/api/app/controllers/api/v1/food_products_api_controller.rb
@@ -93,4 +93,10 @@ class Api::V1::FoodProductsApiController < ApplicationController
     end
   end
 
+  def get_food_products_have_no_cooking_process_order
+    @food_products = FoodProduct.left_joins(:cooking_process_order)
+                                .where(cooking_process_orders: { id: nil })
+                                .where(is_cooking: true)
+    render json: fmt(ok, @food_products.as_json(include: :group))
+  end
 end

--- a/api/app/controllers/cooking_process_orders_controller.rb
+++ b/api/app/controllers/cooking_process_orders_controller.rb
@@ -25,7 +25,8 @@ class CookingProcessOrdersController < ApplicationController
   # POST /cooking_process_orders
   def create
     @cooking_process_order = CookingProcessOrder.new(cooking_process_order_params)
-    @cooking_process_order.group_id = params[:group_id]
+    food_product = FoodProduct.find(params[:cooking_process_order][:food_product_id])
+    @cooking_process_order.group_id = food_product.group_id
     if @cooking_process_order.save
       render json: fmt(created, @cooking_process_order)
     else

--- a/api/app/models/cooking_process_order.rb
+++ b/api/app/models/cooking_process_order.rb
@@ -25,7 +25,8 @@ class CookingProcessOrder < ApplicationRecord
 
   # food_product_id を受け取り、関連する調理工程、団体、販売品情報をハッシュで返す
   def self.with_group_by_food_product_id(food_product_id)
-    food_product = FoodProduct.find(food_product_id)
+    food_product = FoodProduct.find_by(id: food_product_id)
+    return nil unless food_product
     cooking_process_order = food_product.cooking_process_order
     {
       "cooking_process_order": cooking_process_order,

--- a/api/app/models/cooking_process_order.rb
+++ b/api/app/models/cooking_process_order.rb
@@ -1,6 +1,7 @@
 class CookingProcessOrder < ApplicationRecord
   # group_id という名前の外部キーを持つ group への belongs_to 関連
   belongs_to :group
+  belongs_to :food_product
 
   # 全ての CookingProcessOrder レコードとそれらの group をプリロードしてハッシュで返すクラスメソッド
   def self.with_groups
@@ -19,6 +20,17 @@ class CookingProcessOrder < ApplicationRecord
     {
       "cooking_process_order": cooking_process_order,
       "group": cooking_process_order.group
+    }
+  end
+
+  # food_product_id を受け取り、関連する調理工程、団体、販売品情報をハッシュで返す
+  def self.with_group_by_food_product_id(food_product_id)
+    food_product = FoodProduct.find(food_product_id)
+    cooking_process_order = food_product.cooking_process_order
+    {
+      "cooking_process_order": cooking_process_order,
+      "group": food_product.group,
+      "food_product": food_product
     }
   end
 

--- a/api/app/models/food_product.rb
+++ b/api/app/models/food_product.rb
@@ -1,7 +1,7 @@
 class FoodProduct < ApplicationRecord
     belongs_to :group
     has_many :purchase_lists, dependent: :destroy
-    has_many :cooking_process_orders, dependent: :destroy
+    has_one :cooking_process_order, dependent: :destroy
 
     def self.with_groups
       @record = FoodProduct.preload(:group)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
       post "get_refinement_food_products" => "food_products_api#get_refinement_food_products"
       post "get_search_food_products" => "food_products_api#get_search_food_products"
       get "get_food_products_by_group_id/:group_id" => "food_products_api#get_food_products_by_group_id"
+      get "get_food_products_have_no_cooking_process_order" => "food_products_api#get_food_products_have_no_cooking_process_order"
 
       #---購入品申請ページ
       get "get_purchase_list_index_for_admin_view" => "purchase_lists_api#get_purchase_list_index_for_admin_view"
@@ -240,6 +241,7 @@ Rails.application.routes.draw do
       get "get_cooking_process_order_for_admin_view/:id" => "cooking_process_orders_api#get_cooking_process_order_for_admin_view"
       post "get_refinement_cooking_process_orders" => "cooking_process_orders_api#get_refinement_cooking_process_orders"
       post "get_search_cooking_process_orders" => "cooking_process_orders_api#get_search_cooking_process_orders"
+      get "get_cooking_process_order_by_food_product_id/:food_product_id" => "cooking_process_orders_api#get_cooking_process_order_by_food_product_id"
       get "get_groups_have_no_cooking_process_order" => "groups_api#get_groups_have_no_cooking_process_order"
 
       #---実行委員担当者申請ページ


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolved #1940

# 概要
<!-- 開発内容の概要を記載 -->
管理者画面の調理工程申請ページを改修しました。
従来は団体を基準に一覧・詳細を表示していましたが、販売品申請ページと同様に、販売品を基準として表示するように変更しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- **APIの改修**
  - `cooking_process_orders_api_controller` の一覧取得APIを、`FoodProduct` を基準にデータを取得するように変更しました。(`joins`, `includes` を使用してN+1問題を解消)
  - 絞り込み(開催年度)と検索(団体名・販売品名)機能も上記に合わせて修正しました。
  - 調理工程が未登録の販売品を取得するAPI (`get_food_products_not_have_cooking_process_order`) を追加しました。
  - `cooking_process_orders_controller` の `create`, `update` アクションを、`food_product_id` を基準に登録・更新するように修正しました。
- **フロントエンドの改修 (admin_view)**
  - 一覧ページ (`cooking_process_order/index.vue`)
    - 販売品を基準に一覧を表示するように変更しました。
    - 追加モーダルで、団体ではなく「調理工程が未登録の販売品」を選択して登録できるように変更しました。
  - 詳細ページ (`cooking_process_order/_id.vue`)
    - 編集モーダルで、未登録の場合の新規登録と、登録済みの場合の編集が正しく行えるように修正しました。
- **モデルの改修**
  - `FoodProduct` と `CookingProcessOrder` の関連を `1対1 (has_one)` に修正しました。
  - `Group` モデルから、今回の改修で不要になった非効率なデータ取得メソッドを削除しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/a779bac2-c42d-4c30-a6eb-4f57c0d541a8" />
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/99696f11-b921-43c5-aced-9e02ba82085d" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 管理者画面の調理工程申請ページ (`/cooking_process_order`) が正しく表示されるか。
- [x] 開催年度での絞り込みが正しく動作するか。
- [x] 検索バーで団体名または販売品名で検索できるか。
- [x] 「追加」ボタンからモーダルを開き、調理工程が未登録の販売品を選択して新規登録できるか。
- [x] 一覧の項目をクリックして詳細ページ (`/cooking_process_order/:id`) に遷移できるか。
- [x] 詳細ページで「編集」ボタンを押し、内容を更新できるか。（未登録からの新規登録も含む）
- [x] 詳細ページで「削除」ボタンを押し、削除できるか。

# 備考
<!-- 実装していて困った箇所・質問など -->