### PR TITLE
[admin] 調理工程申請CSV出力に販売品名を追加

### DIFF
--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -475,16 +475,17 @@ class Api::V1::OutputCsvController < ApplicationController
   end
 
   def output_cooking_process_orders_csv
-    @cooking_process_orders = CookingProcessOrder.all
+    @cooking_process_orders = CookingProcessOrder.includes(:group, :food_product).all
     bom = "\uFEFF"
     csv_data = CSV.generate(bom) do |csv|
-      column_name = %w(参加団体名 営業前:調理場 営業中:調理場 テント内)
+      column_name = %w(参加団体名 販売品名 営業前:調理場 営業中:調理場 テント内)
       csv << column_name
       @cooking_process_orders.each do |cooking_process_order|
         column_values = [
           cooking_process_order.group.name,
-          cooking_process_order.pre_open_kitchen ? "申請する" : "申請しない",  
-          cooking_process_order.during_open_kitchen ? "申請する" : "申請しない",  
+          cooking_process_order.food_product.name,
+          cooking_process_order.pre_open_kitchen ? "申請する" : "申請しない",
+          cooking_process_order.during_open_kitchen ? "申請する" : "申請しない",
           cooking_process_order.tent
         ]
         csv << column_values


### PR DESCRIPTION
# 対応Issue
- resolved #1955

# 概要
- 調理工程申請CSV出力に販売品名カラムを追加

# 実装詳細
- CSVに「販売品名」カラムを追加（団体名の次に配置）
- パフォーマンス改善のため `includes(:group, :food_product)` を追加してN+1問題を解決

# 画面スクリーンショット等
なし（CSV出力の変更のため）

# テスト項目
- [ ] CSV出力で販売品名が正しく表示されるか
- [ ] 新しいカラム名（営業前、営業中）が正しく表示されるか
- [ ] 販売品情報の取得でN+1問題が発生していないか

# 備考
新しいCSV出力形式：
1. 参加団体名
2. 販売品名（新規追加）
3. 営業前: 調理場
4. 営業中: 調理場
5. テント内