### PR TITLE
従業員一覧csvに代表・副代表を追加

### DIFF
--- a/admin_view/nuxt-project/pages/employees/index.vue
+++ b/admin_view/nuxt-project/pages/employees/index.vue
@@ -270,7 +270,8 @@ export default {
     async downloadCSV() {
       const url =
         this.$config.apiURL + "/api/v1/get_employees_csv/" + this.refYearID;
-      await downloadFile(this.$axios,url, "従業員一覧_CSV", "text/csv");
+      const fname = `従業員一覧_${this.refYearID === 0 ? '全' : this.refYears}年度`;
+      await downloadFile(this.$axios, url, fname, "text/csv");
       this.openSnackBar("従業員一覧のCSVをダウンロードしました");
     },
   },

--- a/admin_view/nuxt-project/pages/employees/index.vue
+++ b/admin_view/nuxt-project/pages/employees/index.vue
@@ -143,6 +143,25 @@ export default {
       roleID: (state) => state.users.role,
     }),
   },
+  async asyncData({ $axios }) {
+    const currentYearUrl = "/user_page_settings/1";
+    const currentYearRes = await $axios.$get(currentYearUrl);
+    const url =
+      "/api/v1/get_refinement_employees?fes_year_id=" +
+      currentYearRes.data.fes_year_id;
+    const employeesRes = await $axios.$post(url);
+    const yearsUrl = "/fes_years";
+    const yearsRes = await $axios.$get(yearsUrl);
+    const currentYears = yearsRes.data.filter(function (element) {
+      return element.id == currentYearRes.data.fes_year_id;
+    });
+    return {
+      employees: employeesRes.data,
+      yearList: yearsRes.data,
+      refYearID: currentYearRes.data.fes_year_id,
+      refYears: currentYears[0].year_num,
+    };
+  },
   mounted() {
     window.addEventListener('scroll', this.saveScrollPosition);
 

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -296,10 +296,12 @@ class Api::V1::OutputCsvController < ApplicationController
 
   def output_employees_csv
     if params[:fes_year_id].to_i == 0
-      groups = Group.preload(:employees, :sub_rep, user: :user_detail)
+      # 食品団体（食販）のみ対象
+      groups = Group.where(group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
       filename_year = "全"
     else
-      groups = Group.where(fes_year_id: params[:fes_year_id]).preload(:employees, :sub_rep, user: :user_detail)
+      # 開催年かつ食品団体（食販）のみ対象
+      groups = Group.where(fes_year_id: params[:fes_year_id], group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
       filename_year = FesYear.find(params[:fes_year_id]).year_num
     end
     bom = "\uFEFF"

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -296,32 +296,51 @@ class Api::V1::OutputCsvController < ApplicationController
 
   def output_employees_csv
     if params[:fes_year_id].to_i == 0
-      @employees = Group.preload(:employees).map{ |group| group.employees }
+      groups = Group.preload(:employees, :sub_rep, user: :user_detail)
       filename_year = "全"
     else
-      @employees = Group.where(fes_year_id:params[:fes_year_id]).preload(:employees).map{ |group| group.employees }
+      groups = Group.where(fes_year_id: params[:fes_year_id]).preload(:employees, :sub_rep, user: :user_detail)
       filename_year = FesYear.find(params[:fes_year_id]).year_num
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom) do |csv|
       column_name = %w(参加団体名 名前 学籍番号)
       csv << column_name
-      @employees.each do |group|
-        # データが存在しない場合はスキップする
-        if group.nil?
-          next
-        end
-        group.each do |employee|
-          # データが存在しない場合はスキップする
-          if employee.nil?
-            next
+      groups.each do |group|
+        next if group.nil?
+
+        # 1団体内で重複（代表・副代表・従業員の重複含む）を排除するためのキー集合
+        used = {}
+
+        # 代表
+        rep = group.user
+        rep_name = rep&.name
+        rep_student_id = rep&.user_detail&.student_id
+        if rep_name.present?
+          key = "#{rep_name}\t#{rep_student_id}"
+          unless used[key]
+            csv << [group.name, rep_name, rep_student_id]
+            used[key] = true
           end
-          column_values = [
-            employee.group.name,
-            employee.name,
-            employee.student_id
-          ]
-          csv << column_values
+        end
+
+        # 副代表（存在しない場合はスキップ）
+        sub_rep = group.sub_rep
+        if sub_rep
+          key = "#{sub_rep.name}\t#{sub_rep.student_id}"
+          unless used[key]
+            csv << [group.name, sub_rep.name, sub_rep.student_id]
+            used[key] = true
+          end
+        end
+
+        # 従業員
+        (group.employees || []).each do |employee|
+          next if employee.nil?
+          key = "#{employee.name}\t#{employee.student_id}"
+          next if used[key]
+          csv << [group.name, employee.name, employee.student_id]
+          used[key] = true
         end
       end
     end
@@ -413,13 +432,13 @@ class Api::V1::OutputCsvController < ApplicationController
       @groups = Group.where(fes_year_id: params[:fes_year_id]).preload(:user, :sub_rep, user: :user_detail) # 必要な関連を事前にロード
       filename_year = FesYear.find(params[:fes_year_id]).year_num
     end
-  
+
     @categories = []
     for i in 1..6 do
       group = @groups.where(group_category_id: i)
       @categories << group
     end
-  
+
     bom = "\uFEFF"
     csv_data = CSV.generate(bom) do |csv|
       column_name = %w(参加団体形式 団体番号 団体名 氏名 電話番号 メールアドレス 備考欄)
@@ -452,10 +471,10 @@ class Api::V1::OutputCsvController < ApplicationController
         end
       end
     end
-  
+
     send_data(csv_data, filename: "連絡先リスト_#{filename_year}年度.csv")
   end
-  
+
 
   def output_announcements_csv
     @announcements = Announcement.all


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1961 

# 概要
<!-- 開発内容の概要を記載 -->
- 検便で使用する際に代表・副代表も一覧で取得されて欲しいという要望があったため
- また、絞り込みができていなかったのでついでに治しました。
# 実装詳細
<!-- 具体的な開発内容を記載 -->
- output_csv関数に代表・副代表の団体名、名前、学籍番号

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="427" height="377" alt="image" src="https://github.com/user-attachments/assets/68b6d0a6-a691-4adc-b008-eb9292796eef" />
<img width="256" height="384" alt="image" src="https://github.com/user-attachments/assets/06fc9bf3-aa99-4cf1-8d96-c7685315b4aa" />
[従業員一覧_全年度.csv](https://github.com/user-attachments/files/21685002/_.csv)

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] csv出力が正しく動作するか
- [x] csvの名称が正式か
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
