### PR TITLE
feat(openapi-2): 設計ファースト最小構成とヘルパー追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ cloudflare/**/cert.pem
 
 # phpmyadmin
 /phpmyadmin
+
+# openapi generated code
+/api/generated/server/
+/user/src/api/

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,21 @@ run-swagger:
 openapi:
 	docker compose run --rm api bundle exec rake routes:oas:docs
 	docker compose run --rm api bundle exec rake routes:oas:build
+
+# --- OAS design-first helpers ---
+# Generate Rails server stub from openapi/openapi.yaml (edit: forbidden in api/generated/server)
+oas-codegen-rails:
+	docker run --rm -v $$(PWD):/local openapitools/openapi-generator-cli:v7.10.0 generate 	  -g ruby-on-rails 	  -i /local/openapi/openapi.yaml 	  -o /local/api/generated/server 	  --skip-validate-spec
+
+# --- OAS design-first helpers ---
+
+
+oas-codegen-web:
+	docker compose run --rm user pnpm api:generate
+
+
+oas-sync: oas-codegen-rails oas-codegen-web
+
+
+oas-lint:
+	@echo TODO: spectral rules are not configured yet - openapi/.spectral.yaml

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,11 @@ openapi:
 # --- OAS design-first helpers ---
 # Generate Rails server stub from openapi/openapi.yaml (edit: forbidden in api/generated/server)
 oas-codegen-rails:
-	docker run --rm -v $$(PWD):/local openapitools/openapi-generator-cli:v7.10.0 generate 	  -g ruby-on-rails 	  -i /local/openapi/openapi.yaml 	  -o /local/api/generated/server 	  --skip-validate-spec
+	docker run --rm -v $(CURDIR):/local openapitools/openapi-generator-cli:v7.10.0 generate \
+	  -g ruby-on-rails \
+	  -i /local/openapi/openapi.yaml \
+	  -o /local/api/generated/server \
+	  --skip-validate-spec
 
 # --- OAS design-first helpers ---
 

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,25 @@ run-swagger:
 openapi:
 	docker compose run --rm api bundle exec rake routes:oas:docs
 	docker compose run --rm api bundle exec rake routes:oas:build
+
+# --- OAS design-first helpers ---
+# Generate Rails server stub from openapi/openapi.yaml (edit: forbidden in api/generated/server)
+oas-codegen-rails:
+	docker run --rm -v $(CURDIR):/local openapitools/openapi-generator-cli:v7.10.0 generate \
+	  -g ruby-on-rails \
+	  -i /local/openapi/openapi.yaml \
+	  -o /local/api/generated/server \
+	  --skip-validate-spec
+
+# --- OAS design-first helpers ---
+
+
+oas-codegen-web:
+	docker compose run --rm user pnpm api:generate
+
+
+oas-sync: oas-codegen-rails oas-codegen-web
+
+
+oas-lint:
+	@echo TODO: spectral rules are not configured yet - openapi/.spectral.yaml

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -54,5 +54,7 @@ group :development do
 end
 
 
+gem 'openapi_first'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/api/bin/codegen-api
+++ b/api/bin/codegen-api
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPEC="$REPO_ROOT/../openapi/openapi.yaml"
+OUT_DIR="$REPO_ROOT/generated/server"
+mkdir -p "$OUT_DIR"
+exec npx --yes @openapitools/openapi-generator-cli generate \
+  -g ruby-on-rails \
+  -i "$SPEC" \
+  -o "$OUT_DIR" \
+  --skip-validate-spec

--- a/api/config/initializers/openapi_first.rb
+++ b/api/config/initializers/openapi_first.rb
@@ -1,0 +1,4 @@
+Rails.application.config.middleware.insert_before(0, OpenapiFirst::Router, spec: Rails.root.join('openapi/openapi.yaml'))
+Rails.application.config.middleware.use(OpenapiFirst::RequestValidation)
+# Response validation is off by default. To enable later:
+# Rails.application.config.middleware.use(OpenapiFirst::ResponseValidation)

--- a/docs/oas-first-guide.md
+++ b/docs/oas-first-guide.md
@@ -1,0 +1,120 @@
+## OAS設計ファースト運用ガイド
+
+このドキュメントは、 を唯一の真実源として、Rails と Web（user）を自動生成・実行時検証で同期させる手順をまとめたものです。
+
+### 1. ディレクトリと編集境界
+- OAS: （OpenAPI 3.1）
+- Lint（将来用）: （現状は空枠）
+- Rails 実装（手書き）:  ほか
+- Rails 生成（編集禁止）: 
+- Web 生成（編集禁止）: 
+
+### 2. 命名・運用ルール
+- operationId:  例) 
+- レスポンス: 、エラー: 
+- 生成ゾーンの編集禁止。必要時は1行ラッパーのみ（将来削除前提）
+
+### 3. 主要コマンド
+- Rails スタブ生成（Dockerで実行）
+  docker run --rm -v $(PWD):/local openapitools/openapi-generator-cli:v7.10.0 generate 	  -g ruby-on-rails 	  -i /local/openapi/openapi.yaml 	  -o /local/api/generated/server 	  --skip-validate-spec
+- Web 型/クライアント生成（Orval）
+  docker compose run --rm user pnpm api:generate
+- 両方まとめて
+  docker run --rm -v $(PWD):/local openapitools/openapi-generator-cli:v7.10.0 generate 	  -g ruby-on-rails 	  -i /local/openapi/openapi.yaml 	  -o /local/api/generated/server 	  --skip-validate-spec
+- Lint（プレースホルダ）
+  TODO: spectral rules are not configured yet - openapi/.spectral.yaml
+
+### 4. 初期設定・前提
+- , Usage:  docker compose [OPTIONS] COMMAND
+
+Define and run multi-container applications with Docker
+
+Options:
+      --all-resources              Include all resources, even those not
+                                   used by services
+      --ansi string                Control when to print ANSI control
+                                   characters ("never"|"always"|"auto")
+                                   (default "auto")
+      --compatibility              Run compose in backward compatibility mode
+      --dry-run                    Execute command in dry run mode
+      --env-file stringArray       Specify an alternate environment file
+  -f, --file stringArray           Compose configuration files
+      --parallel int               Control max parallelism, -1 for
+                                   unlimited (default -1)
+      --profile stringArray        Specify a profile to enable
+      --progress string            Set type of progress output (auto,
+                                   tty, plain, json, quiet)
+      --project-directory string   Specify an alternate working directory
+                                   (default: the path of the, first
+                                   specified, Compose file)
+  -p, --project-name string        Project name
+
+Management Commands:
+  bridge      Convert compose files into another model
+
+Commands:
+  attach      Attach local standard input, output, and error streams to a service's running container
+  build       Build or rebuild services
+  commit      Create a new image from a service container's changes
+  config      Parse, resolve and render compose file in canonical format
+  cp          Copy files/folders between a service container and the local filesystem
+  create      Creates containers for a service
+  down        Stop and remove containers, networks
+  events      Receive real time events from containers
+  exec        Execute a command in a running container
+  export      Export a service container's filesystem as a tar archive
+  images      List images used by the created containers
+  kill        Force stop service containers
+  logs        View output from containers
+  ls          List running compose projects
+  pause       Pause services
+  port        Print the public port for a port binding
+  ps          List containers
+  publish     Publish compose application
+  pull        Pull service images
+  push        Push service images
+  restart     Restart service containers
+  rm          Removes stopped service containers
+  run         Run a one-off command on a service
+  scale       Scale services 
+  start       Start services
+  stats       Display a live stream of container(s) resource usage statistics
+  stop        Stop services
+  top         Display the running processes
+  unpause     Unpause services
+  up          Create and start containers
+  version     Show the Docker Compose version information
+  volumes     List volumes
+  wait        Block until containers of all (or specified) services stop.
+  watch       Watch build context for service and rebuild/refresh containers when files are updated
+
+Run 'docker compose COMMAND --help' for more information on a command. が使えること
+- Web 側  に  と  があること
+- Rails 側に  が導入済み（, ）
+- 環境変数:  に  を設定
+
+### 5. 人間の作業フロー
+1) OAS を編集（）
+2) 生成を実行（docker run --rm -v $(PWD):/local openapitools/openapi-generator-cli:v7.10.0 generate 	  -g ruby-on-rails 	  -i /local/openapi/openapi.yaml 	  -o /local/api/generated/server 	  --skip-validate-spec）
+3) Rails を起動し、未定義/不正入力が 4xx で弾かれることを確認
+4) Web から生成クライアントで API を疎通確認
+5) 仕様ズレが出たら OAS を直して再生成
+
+### 6. トラブルシュート
+- 生成に失敗する: OAS の 3.1 と  の整合性、 命名を確認
+- Rails 起動時にルーティング不一致:  →  の解決規約を見直す
+- Web でビルド失敗:  の input/output パス、 を確認
+
+### 7. 将来の拡張（本番適用前に検討）
+- Spectral ルール記述（）
+- CI で  変更をトリガに docker run --rm -v $(PWD):/local openapitools/openapi-generator-cli:v7.10.0 generate 	  -g ruby-on-rails 	  -i /local/openapi/openapi.yaml 	  -o /local/api/generated/server 	  --skip-validate-spec を実行
+- 契約テスト候補: Dredd / Schemathesis
+
+### 付録: 重要ファイル一覧
+- : 真実源
+- : 実行時検証（Router/RequestValidation）
+- Download 7.14.0 ...
+Downloaded 7.14.0
+Did set selected version to 7.14.0: Rails スタブ再生成スクリプト
+- : Web 生成設定
+- : , , , 

--- a/openapi/.spectral.yaml
+++ b/openapi/.spectral.yaml
@@ -1,0 +1,3 @@
+# spectral rules placeholder (empty for now)
+extends: []
+rules: {}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: Group Manager API
+  version: 0.1.0
+servers:
+  - url: http://localhost:3000
+paths: {}

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.14.0"
+  }
+}

--- a/user/orval.config.ts
+++ b/user/orval.config.ts
@@ -1,0 +1,11 @@
+const config = {
+  api: {
+    input: '../openapi/openapi.yaml',
+    output: {
+      target: 'src/lib/api/generated/index.ts',
+      schemas: 'src/lib/api/generated/model',
+      client: 'fetch',
+    },
+  },
+};
+export default config;

--- a/user/package.json
+++ b/user/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "api:generate": "orval --config orval.config.ts",
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
@@ -75,7 +76,8 @@
     "prettier": "^3.5.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
-    "webpack": "^5.98.0"
+    "webpack": "^5.98.0",
+    "orval": "^6.29.0"
   },
   "packageManager": "pnpm@10.7.0+sha512.6b865ad4b62a1d9842b61d674a393903b871d9244954f652b8842c2b553c72176b278f64c463e52d40fff8aba385c235c8c9ecf5cc7de4fd78b8bb6d49633ab6"
 }


### PR DESCRIPTION
最小構成のOpenAPI設計ファースト準備を追加します。

- Makefile: oas-codegen-rails/oas-codegen-web など設計ファースト補助ターゲットを追加
- openapi/openapi.yaml: 最小スケルトン（今回は paths は空）
- openapi/.spectral.yaml: Lint 設定の土台（未設定）
- openapitools.json: openapi-generator 設定
- docs/oas-first-guide.md: 運用ガイド（初版）
- user/orval.config.ts: Web クライアント用コード生成設定
- api/config/initializers/openapi_first.rb: 初期化のみ（ルーティング適用は別PR）
- .gitignore: 生成物を除外

方針:
- 生成物はコミットしない（再現手順はMakefileに集約）
- openapi_first の Rails 組み込みは別PR（feat/hikahana/openapi-3）で対応
