### PR TITLE
fix:電力申請の結果の表記を変更

### DIFF
--- a/admin_view/nuxt-project/pages/power_orders/_id.vue
+++ b/admin_view/nuxt-project/pages/power_orders/_id.vue
@@ -34,7 +34,7 @@
             <td>{{ powerOrder.power_order.item }}</td>
           </tr>
           <tr>
-            <th>電力 [w]</th>
+            <th>消費電力 [w]</th>
             <td>{{ powerOrder.power_order.power }}</td>
           </tr>
           <tr>

--- a/user/src/components/Applications/Power/components/PowerSummaryView.tsx
+++ b/user/src/components/Applications/Power/components/PowerSummaryView.tsx
@@ -13,7 +13,7 @@ export const createFormItemsForDevice = (device: Device): FormItem[] => {
   if (device.url) {
     items.push({ label: '製品URL', content: device.url });
   }
-  items.push({ label: '電力量(W)', content: `${device.maxPower}W` });
+  items.push({ label: '消費電力[W]', content: `${device.maxPower}W` });
   return items;
 };
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1942 

# 概要
<!-- 開発内容の概要を記載 -->
- 電力申請の結果の表記を変更

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 管理者画面とユーザー画面の電力申請の結果を、電力[w]・電力量[w]から消費電力[w]に統一しました

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="511" height="771" alt="スクリーンショット 2025-11-10 191643" src="https://github.com/user-attachments/assets/5d0a2348-672b-4db5-be70-bf04e9c8481b" />
<img width="1507" height="807" alt="スクリーンショット 2025-11-10 191727" src="https://github.com/user-attachments/assets/3b2b94c6-9382-4377-9cdf-732eb45a3667" />

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- 変更が反映されているか


# 備考
<!-- 実装していて困った箇所・質問など -->
