### PR TITLE
[fix]お知らせ欄を更新日時順に変更

### DIFF
--- a/api/app/controllers/news_controller.rb
+++ b/api/app/controllers/news_controller.rb
@@ -6,7 +6,7 @@ class NewsController < ApplicationController
   # GET /news
   # GET /news.json
   def index
-    @news = News.order(id: 'DESC')
+    @news = News.order(Updated_at: :desc)
     render json: @news
   end
 

--- a/api/app/controllers/news_controller.rb
+++ b/api/app/controllers/news_controller.rb
@@ -6,7 +6,7 @@ class NewsController < ApplicationController
   # GET /news
   # GET /news.json
   def index
-    @news = News.order(Updated_at: :desc)
+    @news = News.order(updated_at: :desc)
     render json: @news
   end
 

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -10,7 +10,7 @@ type NewsListProps = {
 const NewsList: FC<NewsListProps> = () => {
   const { news, error, isLoading } = useGetNews();
 
-  const sortedNews = (news || []).slice().sort((a, b) => a.id - b.id);
+  const sortedNews = news || [];
 
   const formattedDates = sortedNews.map((item) => {
     const date = new Date(item.createdAt);

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -9,16 +9,15 @@ type NewsListProps = {
 
 const NewsList: FC<NewsListProps> = () => {
   const { news, error, isLoading } = useGetNews();
+  if (news == undefined) return [];
 
-  const sortedNews = news || [];
-
-  const formattedDates = sortedNews.map((item) => {
+  const formattedDates = news.map((item) => {
     const date = new Date(item.createdAt);
     const formattedDate = format(date, 'yyyy/MM/dd');
     return formattedDate;
   });
 
-  const newsList = sortedNews.map((item, index) => {
+  const newsList = news.map((item, index) => {
     const date = formattedDates[index] ?? 'お知らせはありません。';
 
     return (


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1941 

# 概要
<!-- 開発内容の概要を記載 -->
- お知らせ欄を更新日時順が新しい順に表示されるように変更

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="365" height="588" alt="スクリーンショット 2025-11-10 190254" src="https://github.com/user-attachments/assets/d891d066-39fb-409f-a2bb-005c0c233ec8" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- お知らせ欄が新しい順に表示されているか
- お知らせを 管理者画面から新規作成、編集した場合も更新順に表示されるか

# 備考
<!-- 実装していて困った箇所・質問など -->
前のPRのレビューで指摘されたconst部分消したらエラーになったのでそのままにしてあります
