### PR TITLE
[fix] 保健所提出書類のテンプレートを総務局現行様式に修正

### DIFF
--- a/admin_view/nuxt-project/pages/print/index.vue
+++ b/admin_view/nuxt-project/pages/print/index.vue
@@ -114,7 +114,7 @@
           </td>
         </tr>
         <tr>
-          <td>保健所提出書類（調理計画・従事者）</td>
+          <td>保健所提出書類（調理計画・調理工程・従事者・平面図）</td>
           <td>
             <InTableButton
               iconName="file_download"
@@ -213,8 +213,8 @@ export default {
     },
     async downloadHealthOfficeDocumentsPDF() {
       const endpoint = `/print_pdf/health_office_documents/${this.currentYearID}/output.pdf`;
-      await downloadFile(this.$axios,endpoint, '保健所提出書類（調理計画・従事者）');
-      this.openSnackBar("保健所提出書類（調理計画・従事者）をダウンロードしました");
+      await downloadFile(this.$axios,endpoint, '保健所提出書類（調理計画・調理工程・従事者・平面図）');
+      this.openSnackBar("保健所提出書類（調理計画・調理工程・従事者・平面図）をダウンロードしました");
     },
     async downloadPowerCSV() {
       const endpoint = `/api/v1/get_power_orders_csv/${this.currentYearID}`;

--- a/api/app/controllers/print_pdf_controller.rb
+++ b/api/app/controllers/print_pdf_controller.rb
@@ -52,9 +52,9 @@ class PrintPdfController < ApplicationController
     output_groups_with_categories('output_contact', 'output_contact_pdf', '連絡先リスト', 'Not Landscape')
   end
 
-  # 保健所提出書類（調理計画・従事者）の出力
+  # 保健所提出書類（調理計画・調理工程・従事者・平面図）の出力
   def output_health_office_documents_pdf
-    output_groups_of_health_office_document('output_health_office_documents', 'output_health_office_documents_pdf', '保健所提出書類（調理計画・従事者）', 'Not Landscape')
+    output_groups_of_health_office_document('output_health_office_documents', 'output_health_office_documents_pdf', '保健所提出書類（調理計画・調理工程・従事者・平面図）', 'Not Landscape')
   end
 
   # 全参加団体用
@@ -84,7 +84,7 @@ class PrintPdfController < ApplicationController
     if Group.exists?(fes_year_id: params[:fes_year_id])
       @groups = Group.where(fes_year_id: params[:fes_year_id]).where(group_category_id: 1)
       @fes_dates = FesDate.all
-      print_pdf(template_name, style_name, output_file_name, type)
+      print_pdf_with_header_footer(template_name, style_name, output_file_name, type)
     else
       render file: Rails.root.join('app/views/print_pdf/not_found.html').to_s, layout: false, content_type: 'text/html'
     end
@@ -122,6 +122,47 @@ class PrintPdfController < ApplicationController
               else
                 PDFKit.new(html, page_size: 'A4', encoding: 'UTF-8')
               end
+        pdf.stylesheets << Rails.root.join("app/views/print_pdf/#{style_name}.css").to_s
+
+        send_data pdf.to_pdf,
+                  filename: "#{output_file_name}.pdf",
+                  # disposition: "inline", # ダウンロードせず表示する
+                  type: 'application/pdf'
+      end
+    end
+  end
+
+  # ヘッダー・フッター付き印刷（保健所提出書類用）
+  def print_pdf_with_header_footer(template_name, style_name, output_file_name, type)
+    respond_to do |format|
+      format.pdf do
+        html = render_to_string template: "print_pdf/#{template_name}"
+        pdf_options = {
+          page_size: 'A4',
+          encoding: 'UTF-8',
+          margin_top: '25mm',
+          margin_bottom: '25mm',
+          margin_left: '10mm',
+          margin_right: '10mm',
+          header_spacing: 5,
+          footer_spacing: 5,
+          header_left: '技大祭実行委員会　総務局',
+          header_line: false,
+          footer_center: '[page] / [topage]',
+          footer_right: Time.now.getlocal('+09:00').strftime('%Y/%-m/%-d %-H:%M')+' Group Manager',
+          footer_line: false,
+          footer_font_size: 10,
+          header_font_size: 10,
+          outline: true
+        }
+
+        pdf = if type == 'Landscape'
+                pdf_options[:orientation] = 'Landscape'
+                PDFKit.new(html, pdf_options)
+              else
+                PDFKit.new(html, pdf_options)
+              end
+
         pdf.stylesheets << Rails.root.join("app/views/print_pdf/#{style_name}.css").to_s
 
         send_data pdf.to_pdf,

--- a/api/app/controllers/print_pdf_controller.rb
+++ b/api/app/controllers/print_pdf_controller.rb
@@ -149,19 +149,15 @@ class PrintPdfController < ApplicationController
           header_left: '技大祭実行委員会　総務局',
           header_line: false,
           footer_center: '[page] / [topage]',
-          footer_right: Time.now.getlocal('+09:00').strftime('%Y/%-m/%-d %-H:%M')+' Group Manager',
+          footer_right: "#{Time.now.getlocal('+09:00').strftime('%Y/%-m/%-d %-H:%M')} Group Manager",
           footer_line: false,
           footer_font_size: 10,
           header_font_size: 10,
           outline: true
         }
 
-        pdf = if type == 'Landscape'
-                pdf_options[:orientation] = 'Landscape'
-                PDFKit.new(html, pdf_options)
-              else
-                PDFKit.new(html, pdf_options)
-              end
+        pdf_options[:orientation] = 'Landscape' if type == 'Landscape'
+        pdf = PDFKit.new(html, pdf_options)
 
         pdf.stylesheets << Rails.root.join("app/views/print_pdf/#{style_name}.css").to_s
 

--- a/api/app/controllers/print_pdf_controller.rb
+++ b/api/app/controllers/print_pdf_controller.rb
@@ -81,8 +81,8 @@ class PrintPdfController < ApplicationController
 
   # 保健所提出書類（調理計画・従事者）
   def output_groups_of_health_office_document(template_name, style_name, output_file_name, type)
-    if Group.exists?(fes_year_id: params[:fes_year_id])
-      @groups = Group.where(fes_year_id: params[:fes_year_id]).where(group_category_id: 1)
+    @groups = Group.where(fes_year_id: params[:fes_year_id]).where(group_category_id: 1)
+    if @groups.exists?
       @fes_dates = FesDate.all
       print_pdf_with_header_footer(template_name, style_name, output_file_name, type)
     else

--- a/api/app/helpers/application_helper.rb
+++ b/api/app/helpers/application_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ApplicationHelper
+  # student_idからユーザータイプ（学外/教職員/学生）を判定して返す
+  def user_category_label(student_id)
+    return '学外' if student_id == UserDetail::STUDENT_ID_EXTERNAL
+    return '教職員' if student_id == UserDetail::STUDENT_ID_STAFF
+
+    '学生'
+  end
+end

--- a/api/app/models/user_detail.rb
+++ b/api/app/models/user_detail.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class UserDetail < ApplicationRecord
+  # 例外処理する学籍番号
+  # 学外
+  STUDENT_ID_EXTERNAL = 88888888
+  # 教職員
+  STUDENT_ID_STAFF = 99999999
+
   belongs_to :user
   belongs_to :department
   belongs_to :grade

--- a/api/app/views/print_pdf/output_health_office_documents.pdf.erb
+++ b/api/app/views/print_pdf/output_health_office_documents.pdf.erb
@@ -96,13 +96,7 @@
           <td class="Name"><%= group.user.name %></td>
           <td class="Category">
           <% student_id = (group.user.user_detail&.student_id || 0).to_i %>
-          <% if student_id == 88888888 %>
-            学外
-          <% elsif student_id == 99999999 %>
-            教職員
-          <% else %>
-            学生
-          <% end %>
+          <%= user_category_label(student_id) %>
           </td>
         </tr>
         <% if group.sub_rep %>
@@ -112,13 +106,7 @@
             <td class="Name"><%= group.sub_rep.name %></td>
             <td class="Category">
               <% sub_rep_student_id = (group.sub_rep&.student_id || 0).to_i %>
-              <% if sub_rep_student_id == 88888888 %>
-                学外
-              <% elsif sub_rep_student_id == 99999999 %>
-                教職員
-              <% else %>
-                学生
-              <% end %>
+              <%= user_category_label(sub_rep_student_id) %>
             </td>
           </tr>
         <% end %>
@@ -129,13 +117,7 @@
             <td class="Name"><%=employee.name %></td>
             <td class="Category">
               <% employee_student_id = (employee&.student_id || 0).to_i %>
-              <% if employee_student_id == 88888888 %>
-                学外
-              <% elsif employee_student_id == 99999999 %>
-                教職員
-              <% else %>
-                学生
-              <% end %>
+              <%= user_category_label(employee_student_id) %>
             </td>
           </tr>
         <% end %>

--- a/api/app/views/print_pdf/output_health_office_documents.pdf.erb
+++ b/api/app/views/print_pdf/output_health_office_documents.pdf.erb
@@ -74,13 +74,12 @@
             <h3><%= fp.name %></h3>
             <div class="detail-area">
               <% if cpo %>
-                <%= cpo.tent.present? ? simple_format(cpo.tent) : '調理行程が未登録です。' %><br>
+                <%= cpo.tent.present? ? simple_format(cpo.tent) : '調理工程が未登録です。' %><br>
               <% else %>
                 <span>（調理工程未登録）</span>
               <% end %>
             </div>
         <% end %>
-      <% else %>
       <% end %>
     <h2>3. 従事者名簿(※)</h2>
     <div class="detail-area">
@@ -153,12 +152,10 @@
         <div class="layout-image" style="page-break-inside: avoid; width: 100%;">
           <%= image_tag src, alt: "#{group.name} 平面図", style: "width: 100%; height: auto; border: 1px solid #ccc;" %>
         </div>
-      <% else %>
       <% end %>
     </div>
       <div class="page-break" style="page-break-after: always;"></div>
     <% end %>
-  <% else %>
   <% end %>
 </body>
 </html>

--- a/api/app/views/print_pdf/output_health_office_documents.pdf.erb
+++ b/api/app/views/print_pdf/output_health_office_documents.pdf.erb
@@ -5,7 +5,6 @@
   <title>保健所提出書類（調理計画・調理工程・従事者・平面図）</title>
 </head>
 <body>
-  <% if @groups.any? %>
     <% @groups.each do |group| %>
     <h1><%= group.name %></h1>
     <h2>1. 調理計画(※1)</h2>
@@ -138,6 +137,5 @@
     </div>
       <div class="page-break" style="page-break-after: always;"></div>
     <% end %>
-  <% end %>
 </body>
 </html>

--- a/api/app/views/print_pdf/output_health_office_documents.pdf.erb
+++ b/api/app/views/print_pdf/output_health_office_documents.pdf.erb
@@ -1,90 +1,164 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>保健所提出書類（調理計画・調理工程・従事者・平面図）</title>
+</head>
 <body>
-  <% @groups.each do |group| %>
-    <h1>従　事　者　名　簿　(※)</h1>
-    <table>
-      <tr>
-        <th class="first No">No.</th>
-        <th class="first Belonging">所属（クラス等）</th>
-        <th class="first Name">氏名</th>
-        <th class="first Category">保護者、生徒等の区分</th>
-      </tr>
-      <tr>
-        <td class="No">1</td>
-        <td class="Belonging"><%= group.name %></td>
-        <td class="Name"><%= group.user.name %></td>
-        <td class="Category">生徒</td>
-      </tr>
-      <% if group.sub_rep %>
+  <% if @groups.any? %>
+    <% @groups.each do |group| %>
+    <h1><%= group.name %></h1>
+    <h2>1. 調理計画(※1)</h2>
+    <div class="detail-area">
+      <table>
         <tr>
-          <td class="No">2</td>
-          <td class="Belonging"><%= group.name %></td>
-          <td class="Name"><%= group.sub_rep.name %></td>
-          <td class="Category">生徒</td>
+          <th rowspan="2">販売品名</th>
+          <th colspan="2">食品区分(※2)</br>(該当に◯)</th>
+          <th rowspan="2">提供予定</br>数量</th>
+          <th colspan="3">原材料の仕入状況</th>
+          <th rowspan="2">調理開始</br>日時</th>
         </tr>
-      <% end %>
-      <% group.employees.each_with_index do |employee, index| %>
         <tr>
-          <td class="No"><%= group.sub_rep ? index +3 : index +2 %></td>
-          <td class="Belonging"><%=group.name %></td>
-          <td class="Name"><%=employee.name %></td>
-          <td class="Category">生徒</td>
+          <td>加熱調理</br>食品</td>
+          <td>既製食品</td>
+          <td>原材料名</td>
+          <td>仕入先</td>
+          <td>仕入日</td>
         </tr>
-      <% end %>
-    </table>
-    <div class="attention">
-      <p>※  食品を管理する人についてのみ記入すること。</p>
+        <% group.food_products.each do |food_product| %>
+          <% food_product.purchase_lists.each do |purchase_list| %>
+            <tr>
+              <td><%= food_product.name %></td>
+              <td><%= food_product.is_cooking ? '◯' : '' %></td>
+              <td><%= food_product.is_cooking ? '' : '◯' %></td>
+              <td><%= (food_product.first_day_num + food_product.second_day_num) / 2 %></td>
+              <td><%= purchase_list.items %></td>
+              <td><%= purchase_list.shop&.name %></td>
+              <td>
+                <% pd = purchase_list.purchase_date %>
+                <% formatted_pd = if pd.respond_to?(:strftime)
+                  pd.strftime("%-m/%-d")
+                elsif pd.present?
+                  begin
+                    Date.parse(pd.to_s).strftime("%-m/%-d")
+                  rescue
+                    pd.to_s
+                  end
+                else
+                  ""
+                end %>
+                <%= formatted_pd %>
+              </td>
+              <td>
+                <% @fes_dates.select { |fes_date| fes_date.fes_year_id == group.fes_year_id && fes_date.days_num == 1 }.each do |fes_date| %>
+                  <%= fes_date.date %><br>
+                <% end %>
+                <% @fes_dates.select { |fes_date| fes_date.fes_year_id == group.fes_year_id && fes_date.days_num == 2 }.each do |fes_date| %>
+                  <%= fes_date.date %><br>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </table>
+      <div class="attention">
+        <p>※1  バザーが2日以上の場合は1日ごとに記載すること。</p>
+        <p>※2  現地で加熱調理するものは「加熱調理食品」欄に◯を記入</p>
+        <span>営業許可施設で調理された既製食品を現地で盛り付けるものは、「既製食品」欄に◯を記入</span>
+      </div>
     </div>
-    <div class="page-break"></div>
-    <h1>調理計画(※1)</h1>
-    <table>
-      <tr>
-        <th rowspan="2">販売品名</th>
-        <th colspan="2">食品区分(※2)</br>(該当に◯)</th>
-        <th rowspan="2">提供予定</br>数量</th>
-        <th colspan="3">原材料の仕入状況</th>
-        <th rowspan="2">調理開始</br>日時</th>
-      </tr>
-      <tr>
-        <td>加熱調理</br>食品</td>
-        <td>既製食品</td>
-        <td>原材料名</td>
-        <td>仕入先</td>
-        <td>仕入日</td>
-      </tr>
-      <% group.food_products.each do |food_product| %>
-        <% food_product.purchase_lists.each do |purchase_list| %>
+    <h2>2. 調理工程</h2>
+      <% if group.food_products.any? %>
+        <% group.food_products.each do |fp| %>
+          <% cpo = fp.cooking_process_order %>
+            <h3><%= fp.name %></h3>
+            <div class="detail-area">
+              <% if cpo %>
+                <%= cpo.tent.present? ? simple_format(cpo.tent) : '調理行程が未登録です。' %><br>
+              <% else %>
+                <span>（調理工程未登録）</span>
+              <% end %>
+            </div>
+        <% end %>
+      <% else %>
+      <% end %>
+    <h2>3. 従事者名簿(※)</h2>
+    <div class="detail-area">
+      <table>
+        <tr>
+          <th class="first No">No.</th>
+          <th class="first Belonging">所属（クラス等）</th>
+          <th class="first Name">氏名</th>
+          <th class="first Category">保護者、生徒等の区分</th>
+        </tr>
+        <tr>
+          <td class="No">1</td>
+          <td class="Belonging"><%= group.name %></td>
+          <td class="Name"><%= group.user.name %></td>
+          <td class="Category">
+          <% student_id = (group.user.user_detail&.student_id || 0).to_i %>
+          <% if student_id == 88888888 %>
+            学外
+          <% elsif student_id == 99999999 %>
+            教職員
+          <% else %>
+            学生
+          <% end %>
+          </td>
+        </tr>
+        <% if group.sub_rep %>
           <tr>
-            <td><%= food_product.name %></td>
-            <td><%= food_product.is_cooking ? '◯' : '' %></td>
-            <td><%= food_product.is_cooking ? '' : '◯' %></td>
-            <td><%= (food_product.first_day_num + food_product.second_day_num) / 2 %></td>
-            <td><%= purchase_list.items %></td>
-            <td><%= Shop.find(purchase_list.shop_id).name %></td>
-            <td>
-              <% @fes_dates.select { |fes_date| fes_date.fes_year_id == group.fes_year_id && fes_date.days_num == 0 }.each do |fes_date| %>
-                <%= fes_date.date %><br>
-              <% end %>
-              <% @fes_dates.select { |fes_date| fes_date.fes_year_id == group.fes_year_id && fes_date.days_num == 1 }.each do |fes_date| %>
-                <%= fes_date.date %><br>
-              <% end %>
-            </td>
-            <td>
-              <% @fes_dates.select { |fes_date| fes_date.fes_year_id == group.fes_year_id && fes_date.days_num == 1 }.each do |fes_date| %>
-                <%= fes_date.date %><br>
-              <% end %>
-              <% @fes_dates.select { |fes_date| fes_date.fes_year_id == group.fes_year_id && fes_date.days_num == 2 }.each do |fes_date| %>
-                <%= fes_date.date %><br>
+            <td class="No">2</td>
+            <td class="Belonging"><%= group.name %></td>
+            <td class="Name"><%= group.sub_rep.name %></td>
+            <td class="Category">
+              <% sub_rep_student_id = (group.sub_rep&.student_id || 0).to_i %>
+              <% if sub_rep_student_id == 88888888 %>
+                学外
+              <% elsif sub_rep_student_id == 99999999 %>
+                教職員
+              <% else %>
+                学生
               <% end %>
             </td>
           </tr>
         <% end %>
-      <% end %>
-    </table>
-    <div class="attention">
-      <p>※1  バザーが2日以上の場合は1日ごとに記載すること。</p>
-      <p>※2  現地で加熱調理するものは「加熱調理食品」欄に◯を記入</p>
-      <span>営業許可施設で調理された既製食品を現地で盛り付けるものは、「既製食品」欄に◯を記入</span>
+        <% group.employees.each_with_index do |employee, index| %>
+          <tr>
+            <td class="No"><%= group.sub_rep ? index +3 : index +2 %></td>
+            <td class="Belonging"><%=group.name %></td>
+            <td class="Name"><%=employee.name %></td>
+            <td class="Category">
+              <% employee_student_id = (employee&.student_id || 0).to_i %>
+              <% if employee_student_id == 88888888 %>
+                学外
+              <% elsif employee_student_id == 99999999 %>
+                教職員
+              <% else %>
+                学生
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+      <div class="attention">
+        <p>※  食品を管理する人についてのみ記入すること。</p>
+      </div>
     </div>
-    <div class="page-break"></div>
+    <h2>4. 平面図</h2>
+    <div class="detail-area">
+      <% if group.venue_map && group.venue_map.picture_path.present? %>
+        <% path = group.venue_map.picture_path %>
+        <% src = path.start_with?("http") ? path : "#{request.base_url}#{path}" %>
+        <div class="layout-image" style="page-break-inside: avoid; width: 100%;">
+          <%= image_tag src, alt: "#{group.name} 平面図", style: "width: 100%; height: auto; border: 1px solid #ccc;" %>
+        </div>
+      <% else %>
+      <% end %>
+    </div>
+      <div class="page-break" style="page-break-after: always;"></div>
+    <% end %>
+  <% else %>
   <% end %>
 </body>
+</html>

--- a/api/app/views/print_pdf/output_health_office_documents_pdf.css
+++ b/api/app/views/print_pdf/output_health_office_documents_pdf.css
@@ -1,22 +1,32 @@
-h1 {
+body {
+    width: 90%;
+    margin: 0 auto;
+  }
+
+  .detail-area {
+    width: 90%;
+    margin: 0 auto;
+  }
+
+  h1 {
     text-align: center;
   }
 
   .attention, p, span {
-    margin-left: 5%;
+    margin-left: 0;
     margin-bottom: 0;
     margin-top: 0;
-  }
-
-  body {
-    width: 100%;
   }
 
   table {
     border-collapse: collapse;
     margin: auto;
-    width: 80%;
     table-layout: fixed;
+    width: 100%;
+  }
+
+  h3, h4, h5 {
+    margin-left: 15px;
   }
 
   th, td {
@@ -46,6 +56,6 @@ h1 {
     page-break-after: always;
   }
 
-  h1, th {
+  th {
     font-weight: normal;
   }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #1991 

# 概要
<!-- 開発内容の概要を記載 -->
-  総務局の保健所提出様式に合わせて並び替えと調理工程・平面図を追加
- 未実装だった、従業員名簿の学生・学外・教職員の区分判別を実装
- 管理者画面を改修に合わせて表示を編集
- 印刷後に扱いやすいように出力日時・ページ番号を追加
- 仕入れ日の表示を実装
- PDFアウトラインの有効化

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 調理工程を追加
- 平面図を追加
- 並びを現行フォーマットに合わせて変更
- 従業員名簿の区分を学籍番号で判別するように実装
 - 学籍番号88888888なら学外、99999999なら教職員、それ以外なら学生と表示するように実装（申請資料に合わせて）
- 仕入れ日が実施日-1日から申請データを参照するように変更
- ヘッダーとフッターを追加　ヘッダーの追加に合わせてprint_controllerも修正
- 各種表示に　調理工程・平面図を追加
- h1に団体名を表示し、各項目をh2で表示するように修正
- PDFアウトラインを有効化し、<h>タグで自動生成されるように実装
- スタイルの微修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 表示が崩れないか
- [ ] テンプレートと相互が無いか
- [ ] 団体名が正しく表示されるか
- [ ] 販売品が正しく表示されるか
- [ ] 食品区分が正しく表示されるか
- [ ] 提供予定数量が正しく表示されるか
- [ ] 原材料名・仕入先・仕入れ日が正しく表示されるか
- [ ] 調理開始日時が正しく表示されるか
- [ ] 調理工程と販売品名が正しく、セットで表示されるか
- [ ] 従事者名簿が全員表示されるか、区分が正しく表示されるか
- [ ] 平面図の画像が正しく表示されるか

# 備考
<!-- 実装していて困った箇所・質問など -->
- 提供予定数量が平均化されて表示されているが、正しいか総務に確認する必要があるかもしれない