### PR TITLE
[fix]開発中の機能を一番下に集約

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -40,6 +40,30 @@
           </li>
         </ul>
       </nav>
+      <!-- 開発中メニュー -->
+       <!-- 開発中メニュー（親） -->
+       <div class="menu-header">
+        <li @click="devOpen = !devOpen" :class="{ open: devOpen }"class="dev-header">
+          <span class="material-icons">chevron_right</span>
+          <h4>開発中</h4>
+        </li>
+      </div>
+      <nav class="menu">
+      <ul>
+      <!-- 開発中メニュー（子） -->
+      <li
+      v-for="item in development_items"
+      :key="item.title"
+      v-show="devOpen"
+      class="dev-child"
+    >
+      <nuxt-link :to="item.click">
+        <span class="material-icons">{{ item.icon }}</span>
+        {{ item.title }}
+      </nuxt-link>
+      </li>
+      </ul>
+      </nav>
     </div>
   </div>
 </template>
@@ -179,12 +203,7 @@ export default {
           icon: "assignment_return",
           click: "/assign_items",
         },
-        { title: "物品申請数調整", icon: "stadium", click: "/adjustment_order_items" },
-        { title: "物品貸出 時間・人数調整", icon: "assignment_return", click: "/adjustment_rental_time"},
-        { title: "物品移動計画", icon: "swap_horiz", click: "/assign_item_movements" },
         { title: "識別番号", icon: "format_list_numbered", click: "/group_identify" },
-        { title: "会場割り当て", icon: "event_seat", click: "/assign_places" },
-        { title: "ステージ割り当て", icon: "stadium", click: "/assign_stages" },
         { title: "お知らせ作成", icon: "newspaper", click: "/news" },
         { title: "書類印刷", icon: "print", click: "/print" },
         {
@@ -194,6 +213,15 @@ export default {
         },
       ],
       user: [],
+      //開発中
+      development_items: [
+        { title: "物品申請数調整", icon: "stadium", click: "/adjustment_order_items" },
+        { title: "物品貸出 時間・人数調整", icon: "assignment_return", click: "/adjustment_rental_time"},
+        { title: "物品移動計画", icon: "swap_horiz", click: "/assign_item_movements" },
+        { title: "会場割り当て", icon: "event_seat", click: "/assign_places" },
+        { title: "ステージ割り当て", icon: "stadium", click: "/assign_stages" },
+      ],
+      devOpen: false
     };
   },
   mounted() {
@@ -309,5 +337,22 @@ export default {
   padding: 20px 20px;
   display: flex;
   letter-spacing: 1px;
+}
+.dev-header {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.dev-header .material-icons {
+  transition: transform 0.2s;
+}
+
+.dev-header.open .material-icons {
+  transform: rotate(90deg);
+}
+
+.dev-child {
+  padding-left: 20px;
 }
 </style>

--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -40,29 +40,26 @@
           </li>
         </ul>
       </nav>
-      <!-- 開発中メニュー -->
-       <!-- 開発中メニュー（親） -->
-       <div class="menu-header">
-        <li @click="devOpen = !devOpen" :class="{ open: devOpen }"class="dev-header">
+      <!-- 開発中メニュー（親） -->
+        <div class="menu-header">
+         <li @click="isOpened = !isOpened" :class="{ open: isOpened }"class="sidebar-accordion">
           <span class="material-icons">chevron_right</span>
-          <h4>開発中</h4>
-        </li>
-      </div>
+           <h4>開発中</h4>
+         </li>
+        </div>
       <nav class="menu">
-      <ul>
-      <!-- 開発中メニュー（子） -->
-      <li
-      v-for="item in development_items"
-      :key="item.title"
-      v-show="devOpen"
-      class="dev-child"
-    >
-      <nuxt-link :to="item.click">
-        <span class="material-icons">{{ item.icon }}</span>
-        {{ item.title }}
-      </nuxt-link>
-      </li>
-      </ul>
+        <ul>
+          <!-- 開発中メニュー（子） -->
+          <li v-for="item in development_items"
+              :key="item.title"
+              v-show="isOpened"
+              class="accordion-child" >
+            <nuxt-link :to="item.click">
+             <span class="material-icons">{{ item.icon }}</span>
+             {{ item.title }}
+            </nuxt-link>
+          </li>
+        </ul>
       </nav>
     </div>
   </div>
@@ -221,7 +218,7 @@ export default {
         { title: "会場割り当て", icon: "event_seat", click: "/assign_places" },
         { title: "ステージ割り当て", icon: "stadium", click: "/assign_stages" },
       ],
-      devOpen: false
+      isOpened: false
     };
   },
   mounted() {
@@ -338,21 +335,22 @@ export default {
   display: flex;
   letter-spacing: 1px;
 }
-.dev-header {
+
+.sidebar-accordion {
   cursor: pointer;
   display: flex;
   align-items: center;
 }
 
-.dev-header .material-icons {
+.sidebar-accordion .material-icons {
   transition: transform 0.2s;
 }
 
-.dev-header.open .material-icons {
+.sidebar-accordion.open .material-icons {
   transform: rotate(90deg);
 }
 
-.dev-child {
+.accordion-child {
   padding-left: 20px;
 }
 </style>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2000 

# 概要
<!-- 開発内容の概要を記載 -->
- 開発中の機能の集約

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 管理者画面のメニューバーの一番下に「開発中」の項目をアコーディオンメニューとして追加
- 「物品申請数調整」「物品貸出 時間・人数調整」「物品移動計画」「会場割り当て」「ステージ割り当て」を開発中の機能として移動


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="937" height="907" alt="スクリーンショット 2026-02-09 182104" src="https://github.com/user-attachments/assets/99b8903d-5b1a-483f-9101-727863ef9d65" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- 変更が反映されているか
- 動作に問題がないか
- 移動した機能に漏れがないか

# 備考
<!-- 実装していて困った箇所・質問など -->
