### PR TITLE
[fix] 物品割り当て（assign_items）を在庫登録（stock_items）に変更

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -196,9 +196,9 @@ export default {
       operation_items: [
         { title: "ダッシュボード", icon: "dashboard", click: "/dashboard" },
         {
-          title: "物品割り当て",
+          title: "在庫登録",
           icon: "assignment_return",
-          click: "/assign_items",
+          click: "/stock_items",
         },
         { title: "識別番号", icon: "format_list_numbered", click: "/group_identify" },
         { title: "お知らせ作成", icon: "newspaper", click: "/news" },

--- a/admin_view/nuxt-project/pages/stock_items/_id.vue
+++ b/admin_view/nuxt-project/pages/stock_items/_id.vue
@@ -32,7 +32,7 @@
               <tr
                 v-for="(stockerItem, index) in stockerItems"
                 :key="index"
-                @click="() => $router.push({ path: `/assign_items/` + id})"
+                @click="() => $router.push({ path: `/stock_items/` + id})"
               >
                 <td>{{ stockerItem.rental_item.name }}</td>
                 <td>{{ stockerItem.stocker_item.num }}</td>
@@ -63,7 +63,7 @@
               <tr
                 v-for="(assignRentalItem, index) in assignRentalItems"
                 :key="index"
-                @click="() => $router.push({ path: '/assign_items/' + id})"
+                @click="() => $router.push({ path: '/stock_items/' + id})"
               >
                 <td>{{ assignRentalItem.group.name}}</td>
                 <td>{{ assignRentalItem.rental_item.name }}</td>
@@ -338,16 +338,14 @@
 </template>
 
 <script>
-import axios from "axios";
 import { mapState } from "vuex";
-import moment from "moment";
 
 export default {
   watchQuery: ["page"],
   data() {
     return {
       warningStatus: {},
-      isWarning: false, 
+      isWarning: false,
       assignRentalItemId: null,
       stockerItemId: null,
       stockerItemDeleteId: null,
@@ -516,7 +514,7 @@ export default {
 
       await this.$axios.$put(placeUrl).then((response) => {
         this.closePlaceEditModal();
-        this.$router.push("/assign_items")
+        this.$router.push("/stock_items")
       })
       .catch(error => {
         console.log(error)
@@ -526,7 +524,7 @@ export default {
     async deletePlace() {
       const delPlaceUrl = "/stocker_places/" + this.id;
       const delPlaceRes = await this.$axios.$delete(delPlaceUrl);
-      this.$router.push("/assign_items");
+      this.$router.push("/stock_items");
     },
 
     async submitItem() {
@@ -714,7 +712,7 @@ export default {
     closeAssignDeleteModal() {
       this.isOpenAssignDeleteModal = false;
     },
-    
+
     sorted_assignRentalItems(index) {
       console.log(index);
       if(index == 0){
@@ -749,7 +747,7 @@ export default {
           }
           return 0;
         });
-        
+
         return this.assignRentalItems;
       } else {
         return this.assignRentalItems;
@@ -764,7 +762,7 @@ export default {
   text-align: center;
   vertical-align: middle;
   padding: 25px;
-  background-color: #ffac5d; 
+  background-color: #ffac5d;
 }
 .normal-table td.warning:hover {
   background-color: #ffac5d !important;

--- a/admin_view/nuxt-project/pages/stock_items/index.vue
+++ b/admin_view/nuxt-project/pages/stock_items/index.vue
@@ -2,10 +2,10 @@
   <div class="main-content" v-if="this.$role(roleID).stocker_places.read">
     <SubHeader pageTitle="在庫場所">
       <CommonButton v-if="this.$role(roleID).stocker_places.create" iconName="add_circle" :on_click="openAddModal">
-        追加   
+        追加
       </CommonButton>
     </SubHeader>
-    
+
     <Card width="100%">
       <Table>
         <template v-slot:table-header>
@@ -16,8 +16,8 @@
         <template v-slot:table-body>
           <tr
             v-for="(stocker_place, index) in stockerPlaces"
-            @click="() => $router.push({ path: `/assign_items/` + stocker_place.id})"
-            :key="index" 
+            @click="() => $router.push({ path: `/stock_items/` + stocker_place.id})"
+            :key="index"
           >
             <td>{{ stocker_place.id }}</td>
             <td>{{ stocker_place.name }}</td>
@@ -64,7 +64,7 @@
             </option>
           </select>
         </div> -->
-      </template>  
+      </template>
       <template v-slot:method>
         <CommonButton iconName="add_circle" :on_click="submit"
           >登録</CommonButton
@@ -141,10 +141,10 @@ export default {
         this.stocker_place.data.push(response.data);
         console.log(response)
       })
-      .catch(error => 
+      .catch(error =>
       {
         console.log(error)
-      }) 
+      })
       ;
       console.log(this.stocker_place)
     },


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2010 

# 概要
<!-- 開発内容の概要を記載 -->
- 「物品割り当て」の新しい画面を実装するために、今までの画面を「在庫登録」に変更

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- ディレクトリ名を「assign_items」から「stock_items」に変更

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/88c2fcfd-0c9c-4de5-b478-b335ceb99202" />

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] リンク切れを起こさないか
- [ ] 物品割り当て・ディレクトリ名の指定修正漏れがないか

# 備考
<!-- 実装していて困った箇所・質問など -->
