### PR TITLE
feat: add health center submission api crud

### DIFF
--- a/api/app/controllers/comments_controller.rb
+++ b/api/app/controllers/comments_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  before_action :set_health_center_submission_status, only: %i[index create]
+  before_action :set_comment, only: %i[show update destroy]
+
+  # GET /health_center_submission_statuses/:health_center_submission_status_id/comments
+  def index
+    comments = @health_center_submission_status.comments.order(:created_at)
+    render json: fmt(ok, comments), status: :ok
+  end
+
+  # GET /comments/1
+  def show
+    render json: fmt(ok, @comment), status: :ok
+  end
+
+  # POST /health_center_submission_statuses/:health_center_submission_status_id/comments
+  def create
+    comment = @health_center_submission_status.comments.build(comment_params)
+
+    if comment.save
+      render json: fmt(created, comment), status: :created
+    else
+      render json: fmt(unprocessable_entity, [], comment.errors.full_messages.join(', ')), status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /comments/1
+  def update
+    if @comment.update(comment_params)
+      render json: fmt(ok, @comment, "Updated comment id = #{params[:id]}"), status: :ok
+    else
+      render json: fmt(unprocessable_entity, [], @comment.errors.full_messages.join(', ')), status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /comments/1
+  def destroy
+    @comment.destroy
+    render json: fmt(ok, [], "Deleted comment = #{params[:id]}"), status: :ok
+  end
+
+  private
+
+  def set_health_center_submission_status
+    @health_center_submission_status = HealthCenterSubmissionStatus.find_by(id: params[:health_center_submission_status_id])
+    return if @health_center_submission_status
+
+    render json: fmt(not_found, [],
+                     "Not found health_center_submission_status id = #{params[:health_center_submission_status_id]}"),
+           status: :not_found
+  end
+
+  def set_comment
+    @comment = Comment.find_by(id: params[:id])
+    return if @comment
+
+    render json: fmt(not_found, [], "Not found comment id = #{params[:id]}"), status: :not_found
+  end
+
+  def comment_params
+    source = params[:comment] || params
+    ActionController::Parameters.new(source.to_unsafe_h).permit(:body)
+  end
+end

--- a/api/app/controllers/health_center_submission_status_comments_controller.rb
+++ b/api/app/controllers/health_center_submission_status_comments_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class HealthCenterSubmissionStatusCommentsController < ApplicationController
+  before_action :authenticate_api_user!
   before_action :set_health_center_submission_status
   before_action :set_comment, only: %i[show update destroy]
 
@@ -17,7 +18,8 @@ class HealthCenterSubmissionStatusCommentsController < ApplicationController
 
   # POST /health_center_submission_statuses/:health_center_submission_status_id/comments
   def create
-    comment = @health_center_submission_status.comments.build(comment_params)
+    # 投稿者はログイン中ユーザーとして扱い、その users.id を comments.author_id に保存する
+    comment = @health_center_submission_status.comments.build(comment_params.merge(author_id: current_api_user.id))
 
     if comment.save
       render json: fmt(created, comment), status: :created

--- a/api/app/controllers/health_center_submission_status_comments_controller.rb
+++ b/api/app/controllers/health_center_submission_status_comments_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class CommentsController < ApplicationController
-  before_action :set_health_center_submission_status, only: %i[index create]
+class HealthCenterSubmissionStatusCommentsController < ApplicationController
+  before_action :set_health_center_submission_status
   before_action :set_comment, only: %i[show update destroy]
 
   # GET /health_center_submission_statuses/:health_center_submission_status_id/comments
@@ -10,7 +10,7 @@ class CommentsController < ApplicationController
     render json: fmt(ok, comments), status: :ok
   end
 
-  # GET /comments/1
+  # GET /health_center_submission_statuses/:health_center_submission_status_id/comments/:id
   def show
     render json: fmt(ok, @comment), status: :ok
   end
@@ -26,7 +26,7 @@ class CommentsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /comments/1
+  # PATCH/PUT /health_center_submission_statuses/:health_center_submission_status_id/comments/:id
   def update
     if @comment.update(comment_params)
       render json: fmt(ok, @comment, "Updated comment id = #{params[:id]}"), status: :ok
@@ -35,7 +35,7 @@ class CommentsController < ApplicationController
     end
   end
 
-  # DELETE /comments/1
+  # DELETE /health_center_submission_statuses/:health_center_submission_status_id/comments/:id
   def destroy
     @comment.destroy
     render json: fmt(ok, [], "Deleted comment = #{params[:id]}"), status: :ok
@@ -53,7 +53,7 @@ class CommentsController < ApplicationController
   end
 
   def set_comment
-    @comment = Comment.find_by(id: params[:id])
+    @comment = @health_center_submission_status.comments.find_by(id: params[:id])
     return if @comment
 
     render json: fmt(not_found, [], "Not found comment id = #{params[:id]}"), status: :not_found

--- a/api/app/controllers/health_center_submission_statuses_controller.rb
+++ b/api/app/controllers/health_center_submission_statuses_controller.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class HealthCenterSubmissionStatusesController < ApplicationController
+  before_action :set_health_center_submission_status, only: %i[show update destroy]
+
+  # GET /health_center_submission_statuses
+  def index
+    statuses = HealthCenterSubmissionStatus.order(:group_id, :application_type)
+    render json: fmt(ok, statuses), status: :ok
+  end
+
+  # GET /health_center_submission_statuses/1
+  def show
+    render json: fmt(ok, @health_center_submission_status), status: :ok
+  end
+
+  # POST /health_center_submission_statuses
+  def create
+    health_center_submission_status = HealthCenterSubmissionStatus.new(health_center_submission_status_params)
+
+    if health_center_submission_status.save
+      render json: fmt(created, health_center_submission_status), status: :created
+    else
+      render json: fmt(unprocessable_entity, [], health_center_submission_status.errors.full_messages.join(', ')),
+             status: :unprocessable_entity
+    end
+  rescue ArgumentError => e
+    render json: fmt(unprocessable_entity, [], e.message), status: :unprocessable_entity
+  end
+
+  # PATCH/PUT /health_center_submission_statuses/1
+  def update
+    if @health_center_submission_status.update(health_center_submission_status_params)
+      render json: fmt(ok, @health_center_submission_status,
+                       "Updated health_center_submission_status id = #{params[:id]}"), status: :ok
+    else
+      render json: fmt(unprocessable_entity, [], @health_center_submission_status.errors.full_messages.join(', ')),
+             status: :unprocessable_entity
+    end
+  rescue ArgumentError => e
+    render json: fmt(unprocessable_entity, [], e.message), status: :unprocessable_entity
+  end
+
+  # DELETE /health_center_submission_statuses/1
+  def destroy
+    @health_center_submission_status.destroy
+    render json: fmt(ok, [], "Deleted health_center_submission_status = #{params[:id]}"), status: :ok
+  end
+
+  # GET /health_center_submission_statuses/group/:group_id
+  def get_by_group_id
+    statuses = HealthCenterSubmissionStatus.where(group_id: params[:group_id]).order(:application_type)
+
+    if statuses.exists?
+      render json: fmt(ok, statuses), status: :ok
+    else
+      render json: fmt(not_found, [], "Not found health_center_submission_statuses for group_id = #{params[:group_id]}"),
+             status: :not_found
+    end
+  end
+
+  private
+
+  def set_health_center_submission_status
+    @health_center_submission_status = HealthCenterSubmissionStatus.find_by(id: params[:id])
+    return if @health_center_submission_status
+
+    render json: fmt(not_found, [], "Not found health_center_submission_status id = #{params[:id]}"), status: :not_found
+  end
+
+  def health_center_submission_status_params
+    source = params[:health_center_submission_status] || params
+    ActionController::Parameters.new(source.to_unsafe_h).permit(:group_id, :application_type, :status)
+  end
+end

--- a/api/app/models/comment.rb
+++ b/api/app/models/comment.rb
@@ -2,6 +2,8 @@
 
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
+  belongs_to :author, class_name: 'User', foreign_key: :author_id
 
   validates :body, presence: true
+  validates :author_id, presence: true
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -136,9 +136,10 @@ Rails.application.routes.draw do
     collection do
       get 'group/:group_id', to: 'health_center_submission_statuses#get_by_group_id'
     end
-    resources :comments, only: %i[index create]
+    resources :comments,
+              controller: 'health_center_submission_status_comments',
+              only: %i[index show create update destroy]
   end
-  resources :comments, only: %i[show update destroy]
   resources :fire_equipment_orders do
     collection do
       get 'group/:group_id', to: 'fire_equipment_orders#get_by_group_id'

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -132,6 +132,13 @@ Rails.application.routes.draw do
       get 'group', to: 'un_registered_groups#group'
     end
   end
+  resources :health_center_submission_statuses do
+    collection do
+      get 'group/:group_id', to: 'health_center_submission_statuses#get_by_group_id'
+    end
+    resources :comments, only: %i[index create]
+  end
+  resources :comments, only: %i[show update destroy]
   resources :fire_equipment_orders do
     collection do
       get 'group/:group_id', to: 'fire_equipment_orders#get_by_group_id'

--- a/api/db/migrate/20260409031500_add_author_id_to_comments.rb
+++ b/api/db/migrate/20260409031500_add_author_id_to_comments.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddAuthorIdToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :comments,
+                  :author,
+                  null: false,
+                  foreign_key: { to_table: :users },
+                  comment: '投稿したユーザーの users.id を保存するカラム'
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_24_000002) do
+ActiveRecord::Schema.define(version: 2026_04_09_031500) do
 
   create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "group_id"
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2026_03_24_000002) do
     t.text "body", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "author_id", null: false, comment: "current_api_user.id を保存するカラム"
+    t.index ["author_id"], name: "index_comments_on_author_id"
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
   end
 
@@ -484,6 +486,7 @@ ActiveRecord::Schema.define(version: 2026_03_24_000002) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "comments", "users", column: "author_id"
   add_foreign_key "cooking_process_orders", "food_products"
   add_foreign_key "cooking_process_orders", "groups"
   add_foreign_key "fire_equipment_orders", "groups"


### PR DESCRIPTION
# 対応Issue
resolve #0

# 概要
- 保健所申請のステータス管理 API を実装しました
- 保健所申請ステータスに紐づくコメント API を実装しました

# 実装詳細
- `HealthCenterSubmissionStatusesController` を追加
- `CommentsController` を追加
- `health_center_submission_statuses` の CRUD API を追加
- `group_id` 単位で申請ステータスを取得する API を追加
- `health_center_submission_statuses` に紐づく `comments` の一覧・作成 API を追加
- `comments` の詳細・更新・削除 API を追加
- `routes.rb` に関連ルーティングを追加

# 画面スクリーンショット等


# テスト項目
- [ ] `health_center_submission_statuses` の CRUD が動作すること
- [ ] `group_id` 指定で保健所申請ステータス一覧を取得できること
- [ ] `comments` の CRUD が動作すること

# 備考
- 今回は保健所申請 API の実装にスコープを絞っています
- 既存の controller test / fixture の広範な修正は別タスクとして切り出しています
- Docker 上で一時データを作成し、CRUD の実リクエストによる動作確認を実施済みです