### PR TITLE
feat: 物品割当に貸出場所を追加

### DIFF
--- a/admin_view/nuxt-project/pages/assign_rental_items/_id.vue
+++ b/admin_view/nuxt-project/pages/assign_rental_items/_id.vue
@@ -83,6 +83,10 @@
                 <td class="caption">{{ stocker_place }}</td>
               </tr>
               <tr>
+                <th>貸出場所：</th>
+                <td class="caption">{{ pickup_place }}</td>
+              </tr>
+              <tr>
                 <th>登録日時：</th>
                 <td class="caption">
                   {{ assign_rental_item.created_at | formatDate }}
@@ -146,8 +150,16 @@
                     :rules="[rules.required]"
                   />
                   <v-select
-                    label="場所"
-                    v-model="place_id"
+                    label="在庫場所"
+                    v-model="stocker_place_id"
+                    :items="places"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                  />
+                  <v-select
+                    label="貸出場所"
+                    v-model="rental_place_id"
                     :items="places"
                     item-text="name"
                     item-value="id"
@@ -230,15 +242,16 @@ export default {
       item: [],
       item_id: [],
       item_list: [],
-      place: [],
       places: [],
-      place_id: [],
+      stocker_place_id: [],
+      rental_place_id: [],
       stocker_place: [],
-      stocker_item: [],
+      pickup_place: [],
       num: [],
       expand: false,
       edit_dialog: false,
       delete_dialog: false,
+      success_snackbar: false,
       rules: {
         required: (value) => !!value || "入力してください",
       },
@@ -249,10 +262,10 @@ export default {
       selfRoleId: (state) => state.users.role,
     }),
   },
-  
+
   mounted() {
     window.scrollTo(0, 0);
-    
+
     this.$store.dispatch("users/getUser");
     this.$axios
       .get("/stocker_places", {
@@ -290,20 +303,26 @@ export default {
         },
       })
       .then((response) => {
-        this.data = response.data;
-        this.assign_rental_item = response.data.assign_rental_item;
-        this.id = response.data.assign_rental_item.id;
-        this.group = response.data.group;
-        this.group_id = response.data.assign_rental_item.group_id;
-        this.place = response.data.place;
-        this.place_id = response.data.assign_rental_item.stocker_place_id;
-        this.item = response.data.item;
-        this.item_id = response.data.assign_rental_item.rental_item_id;
-        this.num = response.data.assign_rental_item.num;
-        this.stocker_place = response.data.stocker_place;
+        this.applyAssignRentalItemResponse(response.data);
       });
   },
   methods: {
+    applyAssignRentalItemResponse(data) {
+      this.data = data;
+      this.assign_rental_item = data.assign_rental_item;
+      this.id = data.assign_rental_item.id;
+      this.group = data.group ? data.group.name : "";
+      this.group_id = data.assign_rental_item.group_id;
+      this.stocker_place_id = data.assign_rental_item.stocker_place_id;
+      this.rental_place_id =
+        data.assign_rental_item.rental_place_id ||
+        data.assign_rental_item.stocker_place_id;
+      this.item = data.rental_item ? data.rental_item.name : "";
+      this.item_id = data.assign_rental_item.rental_item_id;
+      this.num = data.assign_rental_item.num;
+      this.stocker_place = data.stocker_place;
+      this.pickup_place = data.pickup_place;
+    },
     reload: function () {
       console.log("reload");
       const url = "/api/v1/get_assign_rental_item/" + this.$route.params.id;
@@ -314,17 +333,7 @@ export default {
           },
         })
         .then((response) => {
-          this.data = response.data;
-          this.assign_rental_item = response.data.assign_rental_item;
-          this.id = response.data.assign_rental_item.id;
-          this.group = response.data.group;
-          this.group_id = response.data.assign_rental_item.group_id;
-          this.place = response.data.place;
-          this.place_id = response.data.assign_rental_item.stocker_place_id;
-          this.item = response.data.item;
-          this.item_id = response.data.assign_rental_item.rental_item_id;
-          this.num = response.data.assign_rental_item.num;
-          this.stocker_place = response.data.stocker_place;
+          this.applyAssignRentalItemResponse(response.data);
         });
     },
     edit_dialog_open: function () {
@@ -337,7 +346,9 @@ export default {
         "?group_id=" +
         this.group_id +
         "&stocker_place_id=" +
-        this.place_id +
+        this.stocker_place_id +
+        "&rental_place_id=" +
+        (this.rental_place_id || this.stocker_place_id) +
         "&num=" +
         this.num +
         "&rental_item_id=" +

--- a/admin_view/nuxt-project/pages/assign_rental_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_rental_items/index.vue
@@ -85,6 +85,14 @@
                     item-value="id"
                     outlined
                   ></v-select>
+                  <v-select
+                    label="貸出場所"
+                    v-model="rentalPlaceId"
+                    :items="places"
+                    item-text="name"
+                    item-value="id"
+                    outlined
+                  ></v-select>
                 </v-form>
               </v-col>
             </v-row>
@@ -148,14 +156,17 @@ export default {
       itemId: [],
       foodProductId: [],
       placeId: [],
+      rentalPlaceId: [],
+      places: [],
       item: [],
       item_list: [],
       headers: [
         { text: "ID", value: "assign_rental_item.id" },
-        { text: "参加団体", value: "group" },
-        { text: "物品", value: "item" },
+        { text: "参加団体", value: "group.name" },
+        { text: "物品", value: "rental_item.name" },
         { text: "個数", value: "assign_rental_item.num" },
         { text: "在庫場所", value: "stocker_place" },
+        { text: "貸出場所", value: "pickup_place" },
         { text: "日時", value: "assign_rental_item.created_at" },
         { text: "編集日時", value: "assign_rental_item.updated_at" },
       ],
@@ -168,7 +179,7 @@ export default {
   },
   mounted() {
     window.scrollTo(0, 0);
-    
+
     this.$store.dispatch("users/getUser");
     this.$axios
       .get("/api/v1/get_assign_rental_items", {
@@ -233,6 +244,7 @@ export default {
       params.append("rental_item_id", this.itemId);
       params.append("num", this.num);
       params.append("stocker_place_id", this.placeId);
+      params.append("rental_place_id", this.rentalPlaceId || this.placeId);
       this.$axios.post("/assign_rental_items", params).then((response) => {
         console.log(response);
         this.dialog = false;
@@ -241,6 +253,7 @@ export default {
         this.itemId = "";
         this.num = "";
         this.placeId = "";
+        this.rentalPlaceId = "";
       });
     },
   },

--- a/admin_view/nuxt-project/pages/stock_items/_id.vue
+++ b/admin_view/nuxt-project/pages/stock_items/_id.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="main-content">
-    <SubHeader
-      v-bind:pageTitle="placeName.name"
-      pageSubTitle="物品申請"
-    >
-      <CommonButton v-if="this.$role(roleID).stocker_places.update" iconName="edit" :on_click="openPlaceEditModal">
+    <SubHeader v-bind:pageTitle="placeName.name" pageSubTitle="物品申請">
+      <CommonButton
+        v-if="this.$role(roleID).stocker_places.update"
+        iconName="edit"
+        :on_click="openPlaceEditModal"
+      >
         編集
       </CommonButton>
-      <CommonButton v-if="this.$role(roleID).stocker_places.delete" iconName="delete" :on_click="openPlaceDeleteModal">
+      <CommonButton
+        v-if="this.$role(roleID).stocker_places.delete"
+        iconName="delete"
+        :on_click="openPlaceDeleteModal"
+      >
         削除
       </CommonButton>
     </SubHeader>
@@ -16,7 +21,11 @@
       <Column width="100%">
         <Card width="100%">
           <SubHeader pageTitle="在庫物品">
-            <CommonButton v-if="this.$role(this.roleID).rental_items.create" iconName="add_circle" :on_click="openItemAddModal">
+            <CommonButton
+              v-if="this.$role(this.roleID).rental_items.create"
+              iconName="add_circle"
+              :on_click="openItemAddModal"
+            >
               追加
             </CommonButton>
           </SubHeader>
@@ -32,28 +41,55 @@
               <tr
                 v-for="(stockerItem, index) in stockerItems"
                 :key="index"
-                @click="() => $router.push({ path: `/stock_items/` + id})"
+                @click="() => $router.push({ path: `/stock_items/` + id })"
               >
                 <td>{{ stockerItem.rental_item.name }}</td>
                 <td>{{ stockerItem.stocker_item.num }}</td>
-                <td :class="{ warning: warningStatus[index], 'no-hover': warningStatus[index] }">
-                    {{ calculateDifference(stockerItem, index) }}
+                <td
+                  :class="{
+                    warning: warningStatus[index],
+                    'no-hover': warningStatus[index],
+                  }"
+                >
+                  {{ calculateDifference(stockerItem, index) }}
                 </td>
-                <td><btn  @click="openItemEditModal(stockerItem.stocker_item.id, stockerItem.stocker_item.num)">編集</btn></td>
-                <td><btn  @click="openItemDeleteModal(stockerItem.stocker_item.id)">削除</btn></td>
+                <td>
+                  <btn
+                    @click="
+                      openItemEditModal(
+                        stockerItem.stocker_item.id,
+                        stockerItem.stocker_item.num
+                      )
+                    "
+                    >編集</btn
+                  >
+                </td>
+                <td>
+                  <btn @click="openItemDeleteModal(stockerItem.stocker_item.id)"
+                    >削除</btn
+                  >
+                </td>
               </tr>
             </template>
           </Table>
         </Card>
         <Card width="100%">
           <SubHeader pageTitle="割り当て">
-            <CommonButton v-if="this.$role(roleID).assign_items.create" iconName="add_circle" :on_click="openAssignAddModal">
+            <CommonButton
+              v-if="this.$role(roleID).assign_items.create"
+              iconName="add_circle"
+              :on_click="openAssignAddModal"
+            >
               追加
             </CommonButton>
           </SubHeader>
           <Table>
             <template v-slot:table-header>
-              <th v-for="(header, index) in stocker_headers" v-bind:key="index" @click = "sorted_assignRentalItems(index)">
+              <th
+                v-for="(header, index) in stocker_headers"
+                v-bind:key="index"
+                @click="sorted_assignRentalItems(index)"
+              >
                 {{ header }}
               </th>
               <th>編集</th>
@@ -63,13 +99,35 @@
               <tr
                 v-for="(assignRentalItem, index) in assignRentalItems"
                 :key="index"
-                @click="() => $router.push({ path: '/stock_items/' + id})"
+                @click="() => $router.push({ path: '/stock_items/' + id })"
               >
-                <td>{{ assignRentalItem.group.name}}</td>
+                <td>{{ assignRentalItem.group.name }}</td>
                 <td>{{ assignRentalItem.rental_item.name }}</td>
+                <td>{{ assignRentalItem.pickup_place }}</td>
                 <td>{{ assignRentalItem.assign_rental_item.num }}</td>
-                <td><btn  @click="openAssignEditModal(assignRentalItem.assign_rental_item.id, assignRentalItem.assign_rental_item.num)">編集</btn></td>
-                <td><btn  @click="openAssignDeleteModal(assignRentalItem.assign_rental_item.id)">削除</btn></td>
+                <td>
+                  <btn
+                    @click="
+                      openAssignEditModal(
+                        assignRentalItem.assign_rental_item.id,
+                        assignRentalItem.assign_rental_item.num,
+                        assignRentalItem.assign_rental_item.rental_place_id ||
+                          id
+                      )
+                    "
+                    >編集</btn
+                  >
+                </td>
+                <td>
+                  <btn
+                    @click="
+                      openAssignDeleteModal(
+                        assignRentalItem.assign_rental_item.id
+                      )
+                    "
+                    >削除</btn
+                  >
+                </td>
               </tr>
             </template>
           </Table>
@@ -110,35 +168,33 @@
           <h3>物品名</h3>
           <select v-model="stockerItemName">
             <option disabled value="">選択してください</option>
-            <option
-              v-for="i in allRentableItems"
-              :key="i.id"
-              :value="i.id"
-            >
+            <option v-for="i in allRentableItems" :key="i.id" :value="i.id">
               {{ i.name }}
             </option>
           </select>
         </div>
         <div>
           <h3>個数</h3>
-          <input v-model="stockerItemNum" type="number" placeholder="入力してください" />
+          <input
+            v-model="stockerItemNum"
+            type="number"
+            placeholder="入力してください"
+          />
         </div>
         <div>
           <h3>開催年</h3>
           <select v-model="itemFesYear">
             <option disabled value="">選択してください</option>
-            <option
-              v-for="year in itemYear"
-              :key="year.id"
-              :value="year.id"
-            >
+            <option v-for="year in itemYear" :key="year.id" :value="year.id">
               {{ year.year_num }}
             </option>
           </select>
         </div>
       </template>
       <template v-slot:method>
-        <CommonButton iconName="add_circle" :on_click="submitItem">登録</CommonButton>
+        <CommonButton iconName="add_circle" :on_click="submitItem"
+          >登録</CommonButton
+        >
       </template>
     </AddModal>
 
@@ -150,10 +206,7 @@
       <template v-slot:form>
         <div class="assign-item-name-container">
           <h3>物品名</h3>
-          <select
-            class="assign-item-name-select"
-            v-model="assignItemName"
-          >
+          <select class="assign-item-name-select" v-model="assignItemName">
             <option disabled value="">選択してください</option>
             <option
               v-for="i in stockerItems"
@@ -165,6 +218,22 @@
           </select>
         </div>
         <div v-if="assignItemName" class="assign-item-list-wrapper">
+          <div class="assign-item-name-container">
+            <h3>貸出場所</h3>
+            <select
+              class="assign-item-name-select"
+              v-model="assignRentalPlaceId"
+            >
+              <option disabled value="">選択してください</option>
+              <option
+                v-for="place in stockerPlaces"
+                :key="place.id"
+                :value="place.id"
+              >
+                {{ place.name }}
+              </option>
+            </select>
+          </div>
           <div
             v-for="(assign, index) in assignItemsNumAndGroup"
             :key="index"
@@ -173,17 +242,26 @@
             <div class="assign-item-list-container">
               <!-- 団体名のセレクトボックス -->
               <div class="assign-item-list-group">
-                <div v-if="index === 0" class="assign-item-list-label-group-label">
+                <div
+                  v-if="index === 0"
+                  class="assign-item-list-label-group-label"
+                >
                   <h3>団体名</h3>
                 </div>
-                <select v-model="assign.group" class="assign-item-list-group-select">
+                <select
+                  v-model="assign.group"
+                  class="assign-item-list-group-select"
+                >
                   <option disabled value="">選択してください</option>
                   <!-- 団体名を重複して選択できないようにする -->
                   <option
                     v-for="group in groups"
                     :key="group.id"
                     :value="group.id"
-                    v-if="!getSelectedGroupIds().includes(group.id) || assign.group === group.id"
+                    v-if="
+                      !getSelectedGroupIds().includes(group.id) ||
+                      assign.group === group.id
+                    "
                   >
                     {{ group.name }}
                   </option>
@@ -203,14 +281,22 @@
               </div>
               <!-- 削除ボタン -->
               <div class="assign-item-list-delete">
-                <button class="assign-item-list-delete-btn delete-btn-effect" @click.prevent="() => assignItemsNumAndGroup.splice(index, 1)">
+                <button
+                  class="assign-item-list-delete-btn delete-btn-effect"
+                  @click.prevent="() => assignItemsNumAndGroup.splice(index, 1)"
+                >
                   <span class="material-icons"> delete </span>
                 </button>
               </div>
             </div>
           </div>
           <div>
-            <button class="assign-item-list-add-btn add-btn-effect" @click.prevent="addAssignItem">団体を追加</button>
+            <button
+              class="assign-item-list-add-btn add-btn-effect"
+              @click.prevent="addAssignItem"
+            >
+              団体を追加
+            </button>
           </div>
         </div>
       </template>
@@ -271,7 +357,11 @@
       <template v-slot:form>
         <div>
           <h3>個数</h3>
-          <input v-model="stockerItemNum" type="number" placeholder="入力してください" />
+          <input
+            v-model="stockerItemNum"
+            type="number"
+            placeholder="入力してください"
+          />
         </div>
       </template>
       <template v-slot:method>
@@ -287,7 +377,24 @@
       <template v-slot:form>
         <div>
           <h3>個数</h3>
-          <input v-model="assignItemNum" type="number" placeholder="入力してください" />
+          <input
+            v-model="assignItemNum"
+            type="number"
+            placeholder="入力してください"
+          />
+        </div>
+        <div>
+          <h3>貸出場所</h3>
+          <select v-model="assignRentalPlaceId">
+            <option disabled value="">選択してください</option>
+            <option
+              v-for="place in stockerPlaces"
+              :key="place.id"
+              :value="place.id"
+            >
+              {{ place.name }}
+            </option>
+          </select>
         </div>
       </template>
       <template v-slot:method>
@@ -310,7 +417,9 @@
 
     <DeleteModal
       @close="closeItemDeleteModal"
-      v-if="isOpenItemDeleteModal && this.$role(this.roleID).rental_items.delete"
+      v-if="
+        isOpenItemDeleteModal && this.$role(this.roleID).rental_items.delete
+      "
       title="在庫物品の削除"
     >
       <template v-slot:method>
@@ -333,7 +442,6 @@
         >
       </template>
     </DeleteModal>
-
   </div>
 </template>
 
@@ -352,6 +460,7 @@ export default {
       assignRentalItemDeleteId: null,
       assignItemName: "",
       assignItemNum: null,
+      assignRentalPlaceId: "",
       assignItemsNumAndGroup: [{ group: "", num: 0 }], // 物品割当の団体名と個数
       stockerItemName: "",
       stockerItemNum: null,
@@ -367,16 +476,8 @@ export default {
       roomName: null,
       refRole: [],
       id: this.$route.params.id,
-      rental_headers: [
-        "物品名",
-        "個数",
-        "残数",
-      ],
-      stocker_headers: [
-        "団体名",
-        "物品",
-        "個数",
-      ],
+      rental_headers: ["物品名", "個数", "残数"],
+      stocker_headers: ["団体名", "物品", "貸出場所", "個数"],
       stockItemStatus: [],
       stockItemStatusList: [
         { id: 1, name: "未登録" },
@@ -421,27 +522,25 @@ export default {
       rules: {
         required: (value) => !!value || "入力してください",
       },
-      clicked_index:-1,
-      sort_key_1:"",
-      sort_key_2:"",
+      clicked_index: -1,
+      sort_key_1: "",
+      sort_key_2: "",
       sort_asc: true,
     };
   },
 
   //部屋ごとの物品、割当状況を出力
-  async asyncData({ $axios, params}) {
+  async asyncData({ $axios, params }) {
     const stockerItemsUrl =
-      "/api/v1/get_refinement_stocker_item?stocker_place_id=" +
-      params.id;
+      "/api/v1/get_refinement_stocker_item?stocker_place_id=" + params.id;
     const stockerItemsRes = await $axios.$post(stockerItemsUrl);
 
     const assignRentalItemsUrl =
-      "/api/v1/get_refinement_assign_rental_item?stocker_place_id=" +
-      params.id;
+      "/api/v1/get_refinement_assign_rental_item?stocker_place_id=" + params.id;
     const assignRentalItemsRes = await $axios.$post(assignRentalItemsUrl);
 
     const stockerPlacesUrl = "/stocker_places";
-    const stockerPlacesRes = await $axios.$get(stockerPlacesUrl)
+    const stockerPlacesRes = await $axios.$get(stockerPlacesUrl);
 
     const groupsUrl = "/groups";
     const groupsRes = await $axios.$get(groupsUrl);
@@ -486,20 +585,20 @@ export default {
   },
   methods: {
     calculateDifference(stockerItem, index) {
-        const matchingAssignRentalItems = this.assignRentalItems.filter(
-            item => item.rental_item.name === stockerItem.rental_item.name
+      const matchingAssignRentalItems = this.assignRentalItems.filter(
+        (item) => item.rental_item.name === stockerItem.rental_item.name
+      );
+      let difference = stockerItem.stocker_item.num;
+      if (matchingAssignRentalItems.length > 0) {
+        const totalAssignedNum = matchingAssignRentalItems.reduce(
+          (total, item) => total + item.assign_rental_item.num,
+          0
         );
-        let difference = stockerItem.stocker_item.num;
-        if (matchingAssignRentalItems.length > 0) {
-            const totalAssignedNum = matchingAssignRentalItems.reduce(
-                (total, item) => total + item.assign_rental_item.num,
-                0
-            );
-            difference = stockerItem.stocker_item.num - totalAssignedNum;
-        }
-        this.$set(this.warningStatus, index, difference < 0);
-        return difference;
-      },
+        difference = stockerItem.stocker_item.num - totalAssignedNum;
+      }
+      this.$set(this.warningStatus, index, difference < 0);
+      return difference;
+    },
 
     async editPlace() {
       const placeUrl =
@@ -512,13 +611,15 @@ export default {
         "&assign_item_status=" +
         this.assignItemStatus;
 
-      await this.$axios.$put(placeUrl).then((response) => {
-        this.closePlaceEditModal();
-        this.$router.push("/stock_items")
-      })
-      .catch(error => {
-        console.log(error)
-      });
+      await this.$axios
+        .$put(placeUrl)
+        .then((response) => {
+          this.closePlaceEditModal();
+          this.$router.push("/stock_items");
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     },
 
     async deletePlace() {
@@ -538,18 +639,20 @@ export default {
         this.itemFesYear +
         "&stocker_place_id=" +
         this.id;
-      console.log(submitItemUrl)
-      await this.$axios.$post(submitItemUrl).then((response) => {
-        this.stockerItemName = "";
-        this.itemFesYear = "";
-        this.stockerItemNum = null;
-        this.id;
-        this.closeItemAddModal();
-        location.reload();
-      })
-      .catch(error => {
-        console.log(error)
-      });
+      console.log(submitItemUrl);
+      await this.$axios
+        .$post(submitItemUrl)
+        .then((response) => {
+          this.stockerItemName = "";
+          this.itemFesYear = "";
+          this.stockerItemNum = null;
+          this.id;
+          this.closeItemAddModal();
+          location.reload();
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     },
 
     async editItem() {
@@ -562,17 +665,19 @@ export default {
         this.id;
 
       await this.$axios.$put(itemUrl).then((response) => {
-          location.reload();
-          this.closeItemEditModal();
+        location.reload();
+        this.closeItemEditModal();
       });
     },
 
     async deleteItem() {
       const delItemUrl = "/stocker_items/" + this.stockerItemDeleteId;
-      const delItemRes = await this.$axios.$delete(delItemUrl).then((response) => {
-        location.reload();
-        this.closeItemEditModal();
-      });
+      const delItemRes = await this.$axios
+        .$delete(delItemUrl)
+        .then((response) => {
+          location.reload();
+          this.closeItemEditModal();
+        });
     },
     getSelectedGroupIds() {
       return this.assignItemsNumAndGroup.map((assign) => assign.group);
@@ -582,48 +687,51 @@ export default {
     },
     async submitAssign() {
       const assignUrl = "/assign_rental_items";
-          // バリデーションフラグ
+      // バリデーションフラグ
       let isValid = true;
       // バリデーションメッセージ
       let validationMessages = [];
 
       // アイテムごとのバリデーション
-      this.assignItemsNumAndGroup.forEach(item => {
-      if (!item.group) {
-        validationMessages.push("団体名が選択されていません。");
-        isValid = false;
+      this.assignItemsNumAndGroup.forEach((item) => {
+        if (!item.group) {
+          validationMessages.push("団体名が選択されていません。");
+          isValid = false;
+        }
+        if (!item.num || isNaN(item.num) || item.num <= 0) {
+          validationMessages.push("個数は正の数である必要があります。");
+          isValid = false;
+        }
+      });
+      if (!isValid) {
+        // バリデーションメッセージを表示
+        alert(validationMessages.join("\n"));
+        return; // ここで処理を終了し、リセットせずにモーダルをそのまま表示
       }
-      if (!item.num || isNaN(item.num) || item.num <= 0) {
-        validationMessages.push("個数は正の数である必要があります。");
-        isValid = false;
+      try {
+        const payload = {
+          items: this.assignItemsNumAndGroup.map((item) => ({
+            group_id: item.group,
+            num: item.num,
+          })),
+          rentalItemId: this.assignItemName,
+          stockerPlaceId: this.id,
+          rentalPlaceId: this.assignRentalPlaceId || this.id,
+        };
+        const response = await this.$axios.$post(assignUrl, payload);
+        console.log(response.data);
+        // バリデーションに成功したら、ここでデータをリセット
+        this.assignItemsNumAndGroup = [{ group: "", num: 0 }];
+        this.assignItemName = "";
+        this.assignItemNum = null;
+        this.assignRentalPlaceId = this.id;
+        this.id;
+        location.reload();
+        this.closeAssignAddModal();
+      } catch (error) {
+        console.error(error);
+        alert("登録処理中にエラーが発生しました。");
       }
-    });
-    if (!isValid) {
-      // バリデーションメッセージを表示
-      alert(validationMessages.join("\n"));
-      return; // ここで処理を終了し、リセットせずにモーダルをそのまま表示
-    }
-    try {
-      const payload = {
-        items: this.assignItemsNumAndGroup.map(item => ({
-          group_id: item.group,
-          num: item.num
-        })),
-        rentalItemId: this.assignItemName,
-        stockerPlaceId: this.id,
-      };
-      const response = await this.$axios.$post(assignUrl, payload);
-      console.log(response.data);
-      // バリデーションに成功したら、ここでデータをリセット
-      this.assignItemsNumAndGroup = [{ group: "", num: 0 }];
-      this.assignItemName = "";
-      this.assignItemNum = null;
-      this.id;
-      location.reload();
-      this.closeAssignAddModal();
-    } catch (error) {
-      console.error(error);
-      alert('登録処理中にエラーが発生しました。')};
     },
 
     async editAssign() {
@@ -633,7 +741,9 @@ export default {
         "?num=" +
         this.assignItemNum +
         "&stocker_place_id=" +
-        this.id;
+        this.id +
+        "&rental_place_id=" +
+        (this.assignRentalPlaceId || this.id);
       await this.$axios.$put(assignUrl).then((response) => {
         location.reload();
         this.closeAssignEditModal();
@@ -641,7 +751,8 @@ export default {
     },
 
     async deleteAssign() {
-      const delAssignUrl = "/assign_rental_items/" + this.assignRentalItemDeleteId;
+      const delAssignUrl =
+        "/assign_rental_items/" + this.assignRentalItemDeleteId;
       const delAssignRes = await this.$axios.$delete(delAssignUrl);
       location.reload();
       this.closeAssignEditModal();
@@ -655,6 +766,7 @@ export default {
     },
     openAssignAddModal() {
       this.itemFesYear = this.refYearID;
+      this.assignRentalPlaceId = this.id;
       this.isOpenAssignAddModal = false;
       this.isOpenAssignAddModal = true;
     },
@@ -662,9 +774,9 @@ export default {
       this.isOpenAssignAddModal = false;
     },
     openPlaceEditModal() {
-      this.roomName = this.placeName.name
-      this.stockItemStatus = this.placeName.stock_item_status
-      this.assignItemStatus = this.placeName.assign_item_status
+      this.roomName = this.placeName.name;
+      this.stockItemStatus = this.placeName.stock_item_status;
+      this.assignItemStatus = this.placeName.assign_item_status;
       this.isOpenPlaceEditModal = false;
       this.isOpenPlaceEditModal = true;
     },
@@ -680,9 +792,10 @@ export default {
     closeItemEditModal() {
       this.isOpenItemEditModal = false;
     },
-    openAssignEditModal(id, num) {
+    openAssignEditModal(id, num, rentalPlaceId) {
       this.assignRentalItemId = id;
       this.assignItemNum = num;
+      this.assignRentalPlaceId = rentalPlaceId || this.id;
       this.isOpenAssignEditModal = false;
       this.isOpenAssignEditModal = true;
     },
@@ -715,23 +828,23 @@ export default {
 
     sorted_assignRentalItems(index) {
       console.log(index);
-      if(index == 0){
+      if (index == 0) {
         this.sort_key_1 = "group";
         this.sort_key_2 = "name";
-        if(this.clicked_index == index){
+        if (this.clicked_index == index) {
           this.sort_asc = !this.sort_asc;
-        } else{
+        } else {
           this.sort_asc = true;
         }
-      } else if(index == 1){
+      } else if (index == 1) {
         this.sort_key_1 = "rental_item";
         this.sort_key_2 = "name";
-        if(this.clicked_index == index){
+        if (this.clicked_index == index) {
           this.sort_asc = !this.sort_asc;
-        } else{
+        } else {
           this.sort_asc = true;
         }
-      } else{
+      } else {
         this.sort_key = "";
       }
       this.clicked_index = index;
@@ -739,11 +852,17 @@ export default {
         let set = 1;
         this.sort_asc ? (set = 1) : (set = -1);
         this.assignRentalItems.sort((a, b) => {
-          if (a[this.sort_key_1][this.sort_key_2] < b[this.sort_key_1][this.sort_key_2]) {
-            return -1*set;
+          if (
+            a[this.sort_key_1][this.sort_key_2] <
+            b[this.sort_key_1][this.sort_key_2]
+          ) {
+            return -1 * set;
           }
-          if (a[this.sort_key_1][this.sort_key_2] > b[this.sort_key_1][this.sort_key_2]) {
-            return 1*set;
+          if (
+            a[this.sort_key_1][this.sort_key_2] >
+            b[this.sort_key_1][this.sort_key_2]
+          ) {
+            return 1 * set;
           }
           return 0;
         });
@@ -766,9 +885,9 @@ export default {
 }
 .normal-table td.warning:hover {
   background-color: #ffac5d !important;
-  background: none;  /* 線形グラデーションを上書きして無効にします */
-  -webkit-background-clip: initial !important;  /* デフォルトの状態に戻します */
-  -webkit-text-fill-color: black !important;    /* テキストの色を黒に設定します */
+  background: none; /* 線形グラデーションを上書きして無効にします */
+  -webkit-background-clip: initial !important; /* デフォルトの状態に戻します */
+  -webkit-text-fill-color: black !important; /* テキストの色を黒に設定します */
 }
 .assign-item-name-container {
   display: flex;

--- a/api/app/controllers/api/v1/assign_rental_items_api_controller.rb
+++ b/api/app/controllers/api/v1/assign_rental_items_api_controller.rb
@@ -52,11 +52,7 @@ class Api::V1::AssignRentalItemsApiController < ApplicationController
 
   def fit_assign_rental_item_index_for_admin_view(assign_rental_items)
     assign_rental_items.map do |assign_rental_item|
-      {
-        assign_rental_item: assign_rental_item,
-        rental_item: assign_rental_item.rental_item,
-        group: assign_rental_item.group
-      }
+      AssignRentalItem.build_with_relations(assign_rental_item)
     end
   end
 
@@ -64,9 +60,9 @@ class Api::V1::AssignRentalItemsApiController < ApplicationController
   def get_refinement_assign_rental_item
     stocker_place_id = params[:stocker_place_id].to_i
     @assign_rental_items = if stocker_place_id == 0
-                             AssignRentalItem.all
+                             AssignRentalItem.includes(:group, :rental_item, :stocker_place, :rental_place)
                            else
-                             AssignRentalItem.where(stocker_place_id: stocker_place_id)
+                             AssignRentalItem.includes(:group, :rental_item, :stocker_place, :rental_place).where(stocker_place_id: stocker_place_id)
                            end
 
     if @assign_rental_items.none?

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::OutputCsvController < ApplicationController
   end
 
   def output_assign_rental_items_csv
-    assign_rental_items_scope = AssignRentalItem.includes(:rental_item, :stocker_place, group: :group_category)
+    assign_rental_items_scope = AssignRentalItem.includes(:rental_item, :stocker_place, :rental_place, group: :group_category)
 
     if params[:fes_year_id].to_i == 0
       # 全件選択
@@ -63,7 +63,7 @@ class Api::V1::OutputCsvController < ApplicationController
           assign_rental_item.group.place,
           assign_rental_item.group.sum_power_orders,
           assign_rental_item.rental_item.name,
-          assign_rental_item.stocker_place.name,
+          assign_rental_item.pickup_place_name,
           assign_rental_item.num
           # assign_rental_item.group.fes_year.fes_dates.where(days_num: 0).nil? ? nil : assign_rental_item.group.fes_year.fes_dates.where(days_num: 0).first.date,
           # assign_rental_item.group.fes_year.fes_dates.where(days_num: 3).nil? ? nil : assign_rental_item.group.fes_year.fes_dates.where(days_num: 3).first.date,

--- a/api/app/controllers/assign_rental_items_controller.rb
+++ b/api/app/controllers/assign_rental_items_controller.rb
@@ -19,17 +19,23 @@ class AssignRentalItemsController < ApplicationController
   # POST /assign_rental_items
   # POST /assign_rental_items.json
   def create
-    ActiveRecord::Base.transaction do
-      @assign_rental_items = assign_rental_items_params[:items].map do |item_params|
-        AssignRentalItem.create!(
-          group_id: item_params[:group_id],
-          rental_item_id: assign_rental_items_params[:rentalItemId],
-          num: item_params[:num],
-          stocker_place_id: assign_rental_items_params[:stockerPlaceId]
-        )
+    if assign_rental_items_params[:items].present?
+      ActiveRecord::Base.transaction do
+        @assign_rental_items = assign_rental_items_params[:items].map do |item_params|
+          AssignRentalItem.create!(
+            group_id: item_params[:group_id],
+            rental_item_id: assign_rental_item_params[:rental_item_id],
+            num: item_params[:num],
+            stocker_place_id: assign_rental_item_params[:stocker_place_id],
+            rental_place_id: assign_rental_item_params[:rental_place_id]
+          )
+        end
       end
+      render json: fmt(created, @assign_rental_items)
+    else
+      @assign_rental_item = AssignRentalItem.create!(assign_rental_item_params)
+      render json: fmt(created, @assign_rental_item)
     end
-    render json: fmt(created, @assign_rental_items)
   rescue ActiveRecord::RecordInvalid => e
     render json: fmt(internal_server_error, [], e.message)
   end
@@ -61,6 +67,15 @@ class AssignRentalItemsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def assign_rental_items_params
-    params.permit(:rentalItemId, :stockerPlaceId, items: %i[group_id num])
+    params.permit(:rentalItemId, :stockerPlaceId, :rentalPlaceId, items: %i[group_id num])
+  end
+
+  def assign_rental_item_params
+    source = params[:assign_rental_item].present? ? params.require(:assign_rental_item) : params
+    permitted = source.permit(:group_id, :rental_item_id, :num, :stocker_place_id, :rental_place_id)
+    permitted[:rental_item_id] ||= source[:rentalItemId]
+    permitted[:stocker_place_id] ||= source[:stockerPlaceId]
+    permitted[:rental_place_id] ||= source[:rentalPlaceId]
+    permitted
   end
 end

--- a/api/app/models/assign_rental_item.rb
+++ b/api/app/models/assign_rental_item.rb
@@ -4,24 +4,31 @@ class AssignRentalItem < ApplicationRecord
   belongs_to :group
   belongs_to :rental_item
   belongs_to :stocker_place
+  belongs_to :rental_place, class_name: 'StockerPlace', optional: true
 
   def self.with_groups_and_rental_item
-    @record = AssignRentalItem.preload(:group)
-                              .map do |assign_rental_item|
-      {
-        assign_rental_item: assign_rental_item,
-        rental_item: assign_rental_item.rental_item,
-        group: assign_rental_item.group
-      }
-    end
+    AssignRentalItem.includes(:group, :rental_item, :stocker_place, :rental_place)
+                    .map { |assign_rental_item| build_with_relations(assign_rental_item) }
   end
 
   def self.with_rental_item(assign_rental_item_id)
-    assign_rental_item = AssignRentalItem.find(assign_rental_item_id)
-    return {
+    assign_rental_item = AssignRentalItem.includes(
+      :group,
+      :rental_item,
+      :stocker_place,
+      :rental_place
+    ).find(assign_rental_item_id)
+    build_with_relations(assign_rental_item)
+  end
+
+  def self.build_with_relations(assign_rental_item)
+    {
       assign_rental_item: assign_rental_item,
       rental_item: assign_rental_item.rental_item,
-      group: assign_rental_item.group
+      group: assign_rental_item.group,
+      stocker_place: assign_rental_item.stocker_place&.name,
+      rental_place: assign_rental_item.rental_place&.name,
+      pickup_place: assign_rental_item.pickup_place_name
     }
   end
 
@@ -34,5 +41,17 @@ class AssignRentalItem < ApplicationRecord
       is_stage_rentable: rental_item.is_stage_rentable,
       num: num
     }
+  end
+
+  def pickup_place
+    rental_place || stocker_place
+  end
+
+  def pickup_place_name
+    pickup_place&.name
+  end
+
+  def pickup_place_name_en
+    pickup_place&.name_en
   end
 end

--- a/api/app/models/stocker_place.rb
+++ b/api/app/models/stocker_place.rb
@@ -4,4 +4,5 @@ class StockerPlace < ApplicationRecord
   has_many :stocker_items, dependent: :destroy
   has_many :rentable_items, dependent: :destroy
   has_many :assign_rental_items, dependent: :destroy
+  has_many :pickup_assign_rental_items, class_name: 'AssignRentalItem', foreign_key: :rental_place_id, inverse_of: :rental_place, dependent: :nullify
 end

--- a/api/app/views/assign_rental_items/_assign_rental_item.json.jbuilder
+++ b/api/app/views/assign_rental_items/_assign_rental_item.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! assign_rental_item, :id, :rental_order_id, :rentable_item_id, :num, :created_at, :updated_at
+json.extract! assign_rental_item, :id, :group_id, :rental_item_id, :num, :stocker_place_id, :rental_place_id, :created_at, :updated_at
 json.url assign_rental_item_url(assign_rental_item, format: :json)

--- a/api/app/views/print_pdf/output_all_groups_info.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_info.pdf.erb
@@ -106,7 +106,7 @@
   <% group.assign_rental_items.each do |item| %>
   <tr>
     <td><%= item.rental_item.name %></td>
-    <td><%= item.stocker_place.name %></td>
+    <td><%= item.pickup_place_name %></td>
     <td><%= item.num %></td>
   </tr>
   <% end %>

--- a/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_all_groups_rental_items.pdf.erb
@@ -59,7 +59,7 @@
     <% group.assign_rental_items.each do |assign_rental_item| %>
     <tr>
       <td><%= @use_english_name_for_pdf && assign_rental_item.rental_item.name_en.present? ? assign_rental_item.rental_item.name_en : assign_rental_item.rental_item.name %></td>
-      <td><%= @use_english_name_for_pdf && assign_rental_item.stocker_place.name_en.present? ? assign_rental_item.stocker_place.name_en : assign_rental_item.stocker_place.name %></td>
+      <td><%= @use_english_name_for_pdf && assign_rental_item.pickup_place_name_en.present? ? assign_rental_item.pickup_place_name_en : assign_rental_item.pickup_place_name %></td>
       <td><%= assign_rental_item.num %></td>
       <td><%= pickup_date %><%= t('print_pdf.output_all_groups_rental_items.items_table.pickup_day_label') %></td>
       <td><%= return_date %><%= t('print_pdf.output_all_groups_rental_items.items_table.return_day_label') %></td>

--- a/api/app/views/print_pdf/output_group_info.pdf.erb
+++ b/api/app/views/print_pdf/output_group_info.pdf.erb
@@ -104,7 +104,7 @@
   <% @group.assign_rental_items.each do |item| %>
   <tr>
     <td><%= item.rental_item.name %></td>
-    <td><%= item.stocker_place.name %></td>
+    <td><%= item.pickup_place_name %></td>
     <td><%= item.num %></td>
   </tr>
   <% end %>

--- a/api/app/views/print_pdf/output_rental_items.pdf.erb
+++ b/api/app/views/print_pdf/output_rental_items.pdf.erb
@@ -56,7 +56,7 @@
     <% @group.assign_rental_items.each do |assign_rental_item| %>
     <tr>
       <td><%= assign_rental_item.rental_item.name %></td>
-      <td><%= assign_rental_item.stocker_place.name %></td>
+      <td><%= assign_rental_item.pickup_place_name %></td>
       <td><%= assign_rental_item.num %></td>
       <td><%= pickup_date %>(準備日)</td>
       <td><%= return_date %>(片付け日)</td>

--- a/api/app/views/print_pdf/output_rental_items_list.pdf.erb
+++ b/api/app/views/print_pdf/output_rental_items_list.pdf.erb
@@ -37,7 +37,7 @@
           <% group.assign_rental_items.each_with_index do |assign_rental_item, index| %>
             <% if index > 0 %><tr><% end %>
             <td><%= assign_rental_item.rental_item.name %></td>
-            <td><%= assign_rental_item.stocker_place.name %></td>
+            <td><%= assign_rental_item.pickup_place_name %></td>
             <td><%= assign_rental_item.num %></td>
             <td></td>
             </tr>

--- a/api/db/migrate/20260420000001_add_rental_place_id_to_assign_rental_items.rb
+++ b/api/db/migrate/20260420000001_add_rental_place_id_to_assign_rental_items.rb
@@ -1,0 +1,5 @@
+class AddRentalPlaceIdToAssignRentalItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :assign_rental_items, :rental_place_id, :integer
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -9,7 +9,8 @@
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 2026_03_24_000002) do
+
+ActiveRecord::Schema.define(version: 2026_04_20_000001) do
 
   create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "group_id"
@@ -33,6 +34,7 @@ ActiveRecord::Schema.define(version: 2026_03_24_000002) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "stocker_place_id"
+    t.integer "rental_place_id"
   end
 
   create_table "assign_stages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/api/oas_docs/dist/oas_doc.yml
+++ b/api/oas_docs/dist/oas_doc.yml
@@ -11260,6 +11260,22 @@ components:
         id:
           type: integer
           format: int64
+        group_id:
+          type: integer
+          format: int64
+        rental_item_id:
+          type: integer
+          format: int64
+        num:
+          type: integer
+          format: int64
+        stocker_place_id:
+          type: integer
+          format: int64
+        rental_place_id:
+          type: integer
+          format: int64
+          nullable: true
     AssignStage:
       type: object
       properties:

--- a/api/oas_docs/src/components/schemas/assign_rental_item.yml
+++ b/api/oas_docs/src/components/schemas/assign_rental_item.yml
@@ -7,3 +7,19 @@ components:
         id:
           type: integer
           format: int64
+        group_id:
+          type: integer
+          format: int64
+        rental_item_id:
+          type: integer
+          format: int64
+        num:
+          type: integer
+          format: int64
+        stocker_place_id:
+          type: integer
+          format: int64
+        rental_place_id:
+          type: integer
+          format: int64
+          nullable: true

--- a/api/test/controllers/assign_rental_items_controller_test.rb
+++ b/api/test/controllers/assign_rental_items_controller_test.rb
@@ -14,7 +14,13 @@ class AssignRentalItemsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should create assign_rental_item' do
     assert_difference('AssignRentalItem.count') do
-      post assign_rental_items_url, params: { assign_rental_item: { num: @assign_rental_item.num, rentable_item_id: @assign_rental_item.rentable_item_id, rental_order_id: @assign_rental_item.rental_order_id } }, as: :json
+      post assign_rental_items_url, params: {
+        group_id: @assign_rental_item.group_id,
+        rental_item_id: @assign_rental_item.rental_item_id,
+        num: @assign_rental_item.num,
+        stocker_place_id: @assign_rental_item.stocker_place_id,
+        rental_place_id: @assign_rental_item.rental_place_id
+      }, as: :json
     end
 
     assert_response :created
@@ -26,8 +32,16 @@ class AssignRentalItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update assign_rental_item' do
-    patch assign_rental_item_url(@assign_rental_item), params: { assign_rental_item: { num: @assign_rental_item.num, rentable_item_id: @assign_rental_item.rentable_item_id, rental_order_id: @assign_rental_item.rental_order_id } }, as: :json
-    assert_response :ok
+    patch assign_rental_item_url(@assign_rental_item), params: {
+      assign_rental_item: {
+        num: @assign_rental_item.num,
+        rental_item_id: @assign_rental_item.rental_item_id,
+        group_id: @assign_rental_item.group_id,
+        stocker_place_id: @assign_rental_item.stocker_place_id,
+        rental_place_id: @assign_rental_item.rental_place_id
+      }
+    }, as: :json
+    assert_response :created
   end
 
   test 'should destroy assign_rental_item' do
@@ -35,6 +49,6 @@ class AssignRentalItemsControllerTest < ActionDispatch::IntegrationTest
       delete assign_rental_item_url(@assign_rental_item), as: :json
     end
 
-    assert_response :no_content
+    assert_response :success
   end
 end

--- a/api/test/fixtures/assign_rental_items.yml
+++ b/api/test/fixtures/assign_rental_items.yml
@@ -1,11 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  rental_order_id: 1
-  rentable_item_id: 1
+  group_id: 1
+  rental_item_id: 1
   num: 1
+  stocker_place_id: 1
+  rental_place_id: 2
 
 two:
-  rental_order_id: 1
-  rentable_item_id: 1
+  group_id: 1
+  rental_item_id: 1
   num: 1
+  stocker_place_id: 1
+  rental_place_id: 1

--- a/api/test/models/assign_rental_item_test.rb
+++ b/api/test/models/assign_rental_item_test.rb
@@ -3,7 +3,16 @@
 require 'test_helper'
 
 class AssignRentalItemTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'pickup_place prefers rental_place when present' do
+    assign_rental_item = assign_rental_items(:one)
+
+    assert_equal stocker_places(:two), assign_rental_item.pickup_place
+  end
+
+  test 'pickup_place falls back to stocker_place when rental_place is absent' do
+    assign_rental_item = assign_rental_items(:one)
+    assign_rental_item.rental_place = nil
+
+    assert_equal stocker_places(:one), assign_rental_item.pickup_place
+  end
 end


### PR DESCRIPTION
## 課題と解決策
- assign_rental_items に元の在庫場所しかなく、物品を集約して受け渡す貸出場所を保持できなかった
- assign_rental_items に rental_place_id を追加し、stocker_places を参照する形で貸出場所を保持するようにした
- 物品割当 API、CSV/PDF、旧管理画面の一覧・詳細・編集を貸出場所に対応させた

## 検証結果
- docker compose run --rm api rails db:migrate
- docker compose run --rm api rails db:migrate RAILS_ENV=test
- docker compose run --rm --no-deps api ruby -c app/models/assign_rental_item.rb app/models/stocker_place.rb app/controllers/assign_rental_items_controller.rb app/controllers/api/v1/assign_rental_items_api_controller.rb app/controllers/api/v1/output_csv_controller.rb db/migrate/20260420000001_add_rental_place_id_to_assign_rental_items.rb test/models/assign_rental_item_test.rb test/controllers/assign_rental_items_controller_test.rb
- docker compose run --rm admin_view npm run build
- 手動 API 確認: GET/POST/PUT/DELETE /assign_rental_items, POST /api/v1/get_refinement_assign_rental_item

## 補足
- rails test は既存の employees fixture が現行 schema と不整合なため失敗することを確認済み（今回の変更起因ではない）