### PR TITLE
fix: パスワード作成条件を8文字以上に緩和

### DIFF
--- a/user/public/locales/en/common.json
+++ b/user/public/locales/en/common.json
@@ -128,13 +128,17 @@
       "next": "Next"
     },
     "errors": {
+      "nameRequired": "Name is required.",
       "emailTaken": "This email address is already registered.",
+      "emailInvalid": "Please enter a valid email address.",
       "emailDefault": "There is an issue with the email address.",
       "passwordShort": "Password must be at least 8 characters.",
       "passwordDefault": "There is an issue with the password.",
       "passwordConfirmMismatch": "Passwords do not match.",
       "passwordConfirmDefault": "There is an issue with the password confirmation.",
       "telInvalid": "There is an issue with the phone number.",
+      "telShort": "The phone number is too short.",
+      "telLong": "The phone number is too long.",
       "studentIdInvalid": "There is an issue with the student ID.",
       "gradeInvalid": "There is an issue with the grade selection.",
       "departmentInvalid": "There is an issue with the department selection.",

--- a/user/public/locales/en/common.json
+++ b/user/public/locales/en/common.json
@@ -107,8 +107,8 @@
     },
     "notes": {
       "email": "e.g., s123456@stn.nagaokaut.ac.jp",
-      "password": "At least 8 alphanumeric characters",
-      "passwordConfirm": "At least 8 alphanumeric characters",
+      "password": "At least 8 characters",
+      "passwordConfirm": "At least 8 characters",
       "name": "e.g., Taro Nagaoka",
       "tel": "e.g., 09012345678",
       "studentId": "e.g., 12345678"
@@ -130,7 +130,7 @@
     "errors": {
       "emailTaken": "This email address is already registered.",
       "emailDefault": "There is an issue with the email address.",
-      "passwordShort": "Password must be at least 6 characters.",
+      "passwordShort": "Password must be at least 8 characters.",
       "passwordDefault": "There is an issue with the password.",
       "passwordConfirmMismatch": "Passwords do not match.",
       "passwordConfirmDefault": "There is an issue with the password confirmation.",

--- a/user/public/locales/ja/common.json
+++ b/user/public/locales/ja/common.json
@@ -128,13 +128,17 @@
       "next": "次へ"
     },
     "errors": {
+      "nameRequired": "名前は必須です。",
       "emailTaken": "このメールアドレスは既に登録されています。",
+      "emailInvalid": "有効なメールアドレスを入力してください。",
       "emailDefault": "メールアドレスに誤りがあります。",
       "passwordShort": "パスワードは8文字以上である必要があります。",
       "passwordDefault": "パスワードに誤りがあります。",
       "passwordConfirmMismatch": "パスワードが一致しません。",
       "passwordConfirmDefault": "パスワード確認に誤りがあります。",
       "telInvalid": "電話番号に誤りがあります。",
+      "telShort": "電話番号が短すぎます。",
+      "telLong": "電話番号が長すぎます。",
       "studentIdInvalid": "学籍番号に誤りがあります。",
       "gradeInvalid": "学年に誤りがあります。",
       "departmentInvalid": "学科に誤りがあります。",

--- a/user/public/locales/ja/common.json
+++ b/user/public/locales/ja/common.json
@@ -107,8 +107,8 @@
     },
     "notes": {
       "email": "例：s123456@stn.nagaokaut.ac.jp",
-      "password": "英数字8文字以上",
-      "passwordConfirm": "英数字8文字以上",
+      "password": "8文字以上",
+      "passwordConfirm": "8文字以上",
       "name": "例：長岡 太郎",
       "tel": "例：09012345678",
       "studentId": "例：12345678"
@@ -130,7 +130,7 @@
     "errors": {
       "emailTaken": "このメールアドレスは既に登録されています。",
       "emailDefault": "メールアドレスに誤りがあります。",
-      "passwordShort": "パスワードは6文字以上である必要があります。",
+      "passwordShort": "パスワードは8文字以上である必要があります。",
       "passwordDefault": "パスワードに誤りがあります。",
       "passwordConfirmMismatch": "パスワードが一致しません。",
       "passwordConfirmDefault": "パスワード確認に誤りがあります。",

--- a/user/src/components/RegisterCarousel/RegisterCarousel.tsx
+++ b/user/src/components/RegisterCarousel/RegisterCarousel.tsx
@@ -1,4 +1,5 @@
 import { FC, useRef } from 'react';
+import { useTranslation } from 'next-i18next';
 import Button from '@/components/Button';
 import Selector from '@/components/Form/Selector';
 import TextBox from '@/components/Form/TextBox';
@@ -82,6 +83,7 @@ const FormStep: FC<FormStepProps> = ({ step, steps }) => {
 };
 
 const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation('common');
   const registerCarouselTexts = useRegisterCarouselTexts();
   const {
     steps,
@@ -122,6 +124,9 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
 
   // フォーム参照の作成
   const formRef = useRef<HTMLFormElement>(null);
+
+  const getErrorMessage = (message?: string) =>
+    message ? t(message) : undefined;
 
   // 登録ボタンのクリックハンドラ
   const handleRegisterClick = async (e?: React.MouseEvent) => {
@@ -178,7 +183,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     value={values.mail}
                     note={notes.email}
                     required
-                    error={errors.mail?.message}
+                    error={getErrorMessage(errors.mail?.message)}
                     onChange={(value: string) => setValue('mail', value)}
                     onBlur={() => trigger('mail')}
                   />
@@ -188,7 +193,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     value={values.password}
                     note={notes.password}
                     required
-                    error={errors.password?.message}
+                    error={getErrorMessage(errors.password?.message)}
                     onChange={(value: string) => setValue('password', value)}
                     onBlur={() => trigger('password')}
                   />
@@ -198,7 +203,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     value={values.passwordConfirm}
                     note={notes.passwordConfirm}
                     required
-                    error={errors.passwordConfirm?.message}
+                    error={getErrorMessage(errors.passwordConfirm?.message)}
                     onChange={(value: string) =>
                       setValue('passwordConfirm', value)
                     }
@@ -213,7 +218,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     value={values.name}
                     note={notes.name}
                     required
-                    error={errors.name?.message}
+                    error={getErrorMessage(errors.name?.message)}
                     onChange={(value: string) => setValue('name', value)}
                     onBlur={() => trigger('name')}
                   />
@@ -222,7 +227,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     value={values.tel}
                     note={notes.tel}
                     required
-                    error={errors.tel?.message}
+                    error={getErrorMessage(errors.tel?.message)}
                     onChange={(value: string) => setValue('tel', value)}
                     onBlur={() => trigger('tel')}
                   />
@@ -231,7 +236,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     value={values.studentId}
                     note={notes.studentId}
                     required
-                    error={errors.studentId?.message}
+                    error={getErrorMessage(errors.studentId?.message)}
                     onChange={(value: string) => setValue('studentId', value)}
                     onBlur={() => trigger('studentId')}
                   />
@@ -243,7 +248,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     }
                     options={gradeOptions}
                     value={values.gradeId}
-                    error={errors.gradeId?.message}
+                    error={getErrorMessage(errors.gradeId?.message)}
                   />
                   <Selector
                     label={labels.department}
@@ -253,7 +258,7 @@ const Carousel: FC<RegisterCarouselProps> = ({ isOpen, onClose }) => {
                     }
                     options={departmentOptions}
                     value={values.departmentId}
-                    error={errors.departmentId?.message}
+                    error={getErrorMessage(errors.departmentId?.message)}
                   />
                 </div>
               </div>

--- a/user/src/components/RegisterCarousel/schema.ts
+++ b/user/src/components/RegisterCarousel/schema.ts
@@ -15,13 +15,7 @@ export const RegisterSchema = z
     mail: z.string().email('有効なメールアドレスを入力してください'),
     departmentId: z.number().min(1, '学科を選択してください'),
     gradeId: z.number().min(1, '学年を選択してください'),
-    password: z
-      .string()
-      .min(8, '8文字以上で入力してください')
-      .regex(/[A-Z]/, '大文字を含めてください')
-      .regex(/[a-z]/, '小文字を含めてください')
-      .regex(/\d/, '数字を含めてください')
-      .regex(/[\W_]/, '記号を含めてください'),
+    password: z.string().min(8, '8文字以上で入力してください'),
     passwordConfirm: z.string(),
   })
   .refine((data) => data.password === data.passwordConfirm, {

--- a/user/src/components/RegisterCarousel/schema.ts
+++ b/user/src/components/RegisterCarousel/schema.ts
@@ -2,24 +2,25 @@ import { z } from 'zod';
 
 export const RegisterSchema = z
   .object({
-    name: z.string().min(1, '名前は必須です'),
-    studentId: z.string().regex(/^\d{8}$/, '8桁の学籍番号を入力してください'),
+    name: z.string().min(1, 'registerCarousel.errors.nameRequired'),
+    studentId: z
+      .string()
+      .regex(/^\d{8}$/, 'registerCarousel.errors.studentIdInvalid'),
     tel: z
       .string()
-      .regex(
-        /^0\d{9,10}$/,
-        '有効な電話番号を入力してください（例: 09012345678）'
-      )
-      .min(10, '電話番号が短すぎます')
-      .max(11, '電話番号が長すぎます'),
-    mail: z.string().email('有効なメールアドレスを入力してください'),
-    departmentId: z.number().min(1, '学科を選択してください'),
-    gradeId: z.number().min(1, '学年を選択してください'),
-    password: z.string().min(8, '8文字以上で入力してください'),
+      .regex(/^0\d{9,10}$/, 'registerCarousel.errors.telInvalid')
+      .min(10, 'registerCarousel.errors.telShort')
+      .max(11, 'registerCarousel.errors.telLong'),
+    mail: z.string().email('registerCarousel.errors.emailInvalid'),
+    departmentId: z
+      .number()
+      .min(1, 'registerCarousel.errors.departmentInvalid'),
+    gradeId: z.number().min(1, 'registerCarousel.errors.gradeInvalid'),
+    password: z.string().min(8, 'registerCarousel.errors.passwordShort'),
     passwordConfirm: z.string(),
   })
   .refine((data) => data.password === data.passwordConfirm, {
-    message: 'パスワードが一致しません',
+    message: 'registerCarousel.errors.passwordConfirmMismatch',
     path: ['passwordConfirm'],
   });
 


### PR DESCRIPTION
## 課題と解決策
- user 側の新規登録フォームで、パスワード作成時に大文字・小文字・数字・記号を必須にしていた条件を削除しました。
- パスワード作成条件を 8 文字以上のみに変更しました。
- 登録フォーム schema のバリデーションメッセージを i18n キー化し、日本語・英語の文言を locale 側に寄せました。

## 影響範囲
- user の新規登録カルーセル内バリデーション
- パスワード入力欄・確認欄の注記文言
- 登録フォームのクライアントサイドエラー表示

## 検証結果
- `docker compose run --rm --no-deps user pnpm run lint`
- `docker compose run --rm --no-deps user pnpm run type-check`
- `docker compose up --no-deps user` で `http://localhost:8003` を起動し、トップページの `GET / 200` を確認

## データ・設定変更
- なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation error messages for missing name and invalid email formats.
  * Added phone number length validation with minimum and maximum character constraints.
  * Simplified password requirements to a minimum of 8 characters.

* **Documentation**
  * Updated localization strings for registration form validation messages in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->