### PR TITLE
[codex] ユーザー画面の未翻訳箇所をi18n対応

### DIFF
--- a/user/public/locales/en/common.json
+++ b/user/public/locales/en/common.json
@@ -84,6 +84,10 @@
     "toasts": {
       "loginFailed": "Failed to sign in",
       "loginSuccess": "Signed in successfully"
+    },
+    "validation": {
+      "required": "Enter this field.",
+      "email": "Enter a valid email address."
     }
   },
   "registerCarousel": {
@@ -881,10 +885,69 @@
         "fileType": "Only png or jpeg files are supported.",
         "checklist": "Confirm every item."
       }
+    },
+    "fireEquipment": {
+      "title": "Fire Use Application",
+      "fields": {
+        "name": "Fire equipment name",
+        "quantity": "Number of units",
+        "fuel": "Fuel",
+        "usage": "Purpose of use",
+        "isTakeaway": "Can you take the fire equipment out of the tent every day?",
+        "remark": "Remarks"
+      },
+      "fuel": {
+        "gasBottle": "Cassette gas",
+        "lpGas": "LP gas",
+        "charcoal": "Charcoal"
+      },
+      "radio": {
+        "question": "Will you use fire equipment?",
+        "options": {
+          "yes": "Yes",
+          "no": "No"
+        }
+      },
+      "notes": {
+        "quantity": "Half-width numbers only",
+        "takeaway": "In principle, take fire equipment back with you every day unless you cannot do so.\nLeaving fire equipment inside the tent may cause a fire.",
+        "remark": "If you select No, write the reason in the remarks field.",
+        "remarkRequired": "Required if you select No",
+        "excludedItems": "Electric hot plates and IH cookers are not included."
+      },
+      "summary": {
+        "noApplication": {
+          "label": "Fire use application not required (saved)",
+          "description": "We will not use fire equipment."
+        }
+      },
+      "messages": {
+        "deleteSuccess": "Deleted the fire use application.",
+        "deleteFailed": "Failed to delete. Please try again.",
+        "noApplicationSuccess": "Saved that no fire use application is needed.",
+        "registerSuccess": "Fire use application submitted.",
+        "updateSuccess": "Fire use application updated.",
+        "submitFailed": "Submission failed: {{message}}"
+      },
+      "validation": {
+        "required": "Enter this field.",
+        "quantity": "Enter a number of 1 or more.",
+        "fuel": "Select a fuel.",
+        "remarkRequired": "Remarks are required when you cannot take the equipment back every day.",
+        "group": "Select a group."
+      }
     }
   },
   "auth": {
     "logout": "Log out"
+  },
+  "userModal": {
+    "guest": "Guest",
+    "noEmail": "No email address",
+    "toasts": {
+      "logoutSuccess": "Logged out.",
+      "logoutFailed": "Failed to log out."
+    }
   },
   "footer": {
     "copyright": "Copyright © {{year}} NUTMEG. All Rights Reserved."

--- a/user/public/locales/ja/common.json
+++ b/user/public/locales/ja/common.json
@@ -84,6 +84,10 @@
     "toasts": {
       "loginFailed": "ログインに失敗しました",
       "loginSuccess": "ログインに成功しました"
+    },
+    "validation": {
+      "required": "入力してください",
+      "email": "有効なメールアドレスを入力してください"
     }
   },
   "registerCarousel": {
@@ -881,10 +885,69 @@
         "fileType": "ファイル形式はpngまたはjpegにしてください",
         "checklist": "すべての項目を確認してください。"
       }
+    },
+    "fireEquipment": {
+      "title": "火気使用申請",
+      "fields": {
+        "name": "火気の名称",
+        "quantity": "火気の台数",
+        "fuel": "燃料",
+        "usage": "使用用途",
+        "isTakeaway": "火気を毎日テントから持ち帰ることができますか？",
+        "remark": "備考"
+      },
+      "fuel": {
+        "gasBottle": "カセットガス",
+        "lpGas": "LPガス",
+        "charcoal": "炭"
+      },
+      "radio": {
+        "question": "火気を使用しますか？",
+        "options": {
+          "yes": "はい",
+          "no": "いいえ"
+        }
+      },
+      "notes": {
+        "quantity": "半角数字のみ",
+        "takeaway": "火気は毎日持って帰ることができない場合を除き、基本的に持ち帰ってください。\n火気はテント内に残す行為は火事の原因になります。",
+        "remark": "いいえを押した場合は火気の備考欄に理由を記載して下さい。",
+        "remarkRequired": "いいえを押した場合必須",
+        "excludedItems": "電気ホットプレートとIHは含まれません。"
+      },
+      "summary": {
+        "noApplication": {
+          "label": "火気申請は不要（登録済み）",
+          "description": "火気は使用しません。"
+        }
+      },
+      "messages": {
+        "deleteSuccess": "火気申請を削除しました",
+        "deleteFailed": "削除に失敗しました。もう一度お試しください。",
+        "noApplicationSuccess": "火気申請を行わない登録が完了しました",
+        "registerSuccess": "火気申請が完了しました。",
+        "updateSuccess": "火気申請を更新しました。",
+        "submitFailed": "送信に失敗しました: {{message}}"
+      },
+      "validation": {
+        "required": "入力してください",
+        "quantity": "1以上の数字を入力してください",
+        "fuel": "燃料を選択してください",
+        "remarkRequired": "持ち帰りが「いいえ」の場合、備考欄は必須です",
+        "group": "グループを選択してください"
+      }
     }
   },
   "auth": {
     "logout": "ログアウト"
+  },
+  "userModal": {
+    "guest": "ゲスト",
+    "noEmail": "メールアドレスなし",
+    "toasts": {
+      "logoutSuccess": "ログアウトしました",
+      "logoutFailed": "ログアウトに失敗しました"
+    }
   },
   "footer": {
     "copyright": "Copyright © {{year}} NUTMEG. All Rights Reserved."

--- a/user/src/api/groupApi.ts
+++ b/user/src/api/groupApi.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from 'next-i18next';
 import useSWRMutation from 'swr/mutation';
 import { useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
@@ -34,6 +35,7 @@ export type GroupResponse = {
 export type GroupCategoryResponse = {
   id: number;
   name: string;
+  nameEn?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -65,13 +67,23 @@ export const useGetGroups = (groupId: number | null) => {
 
 // 既存の参加形式を取得するフック
 export const useGetGroupCategories = () => {
+  const { i18n } = useTranslation('common');
   const endpoint = `${API_ENDPOINTS.GROUP_CATEGORIES}`;
 
   const { data, error, isLoading } =
     useAuthenticatedGet<ApiResponse<GroupCategoryResponse[]>>(endpoint);
 
   return {
-    groupCategories: data?.status.code === 200 ? data?.data : undefined,
+    groupCategories:
+      data?.status.code === 200
+        ? data.data.map((category) => ({
+            ...category,
+            name:
+              i18n.language.startsWith('en') && category.nameEn
+                ? category.nameEn
+                : category.name,
+          }))
+        : undefined,
     isLoading,
     hasError: !!error,
   };

--- a/user/src/api/rentItemsApi.ts
+++ b/user/src/api/rentItemsApi.ts
@@ -1,4 +1,5 @@
 // src/api/rentItemsApi.ts
+import { useTranslation } from 'next-i18next';
 import { useApiMutations, useAuthenticatedGet } from '@/hooks/useApi';
 import { legacyPatchFetcher, legacyPostFetcher } from './api';
 
@@ -21,6 +22,7 @@ const API_ENDPOINTS = {
 export type RentalItem = {
   id: number;
   name: string;
+  nameEn?: string;
   is_inside_shop_rentable: boolean;
   is_outside_shop_rentable: boolean;
   is_stage_rentable: boolean;
@@ -63,6 +65,7 @@ type ApiResponse<T> = {
 
 // 団体タイプに応じた物品一覧を取得するフック (API実装不要)
 export const useRentableItemsByType = (locationType: string) => {
+  const { i18n } = useTranslation('common');
   // 会場タイプに応じてエンドポイントを選択
   const endpoint =
     locationType === '1'
@@ -76,7 +79,14 @@ export const useRentableItemsByType = (locationType: string) => {
   } = useAuthenticatedGet<ApiResponse<RentalItem[]>>(endpoint);
 
   return {
-    items: response?.data || [],
+    items:
+      response?.data.map((item) => ({
+        ...item,
+        name:
+          i18n.language.startsWith('en') && item.nameEn
+            ? item.nameEn
+            : item.name,
+      })) || [],
     itemsError: error,
     itemsLoading: isLoading,
   };
@@ -84,6 +94,7 @@ export const useRentableItemsByType = (locationType: string) => {
 
 // 全ての貸出物品を取得するフック (実行委員会用を含む)
 export const useAllRentableItems = () => {
+  const { i18n } = useTranslation('common');
   const {
     data: response,
     error,
@@ -93,7 +104,14 @@ export const useAllRentableItems = () => {
   );
 
   return {
-    items: response?.data || [],
+    items:
+      response?.data.map((item) => ({
+        ...item,
+        name:
+          i18n.language.startsWith('en') && item.nameEn
+            ? item.nameEn
+            : item.name,
+      })) || [],
     itemsError: error,
     itemsLoading: isLoading,
   };

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import AccordionMenu from '@/components/AccordionMenu';
 import FormList from '@/components/FormList';
 import { FireEquipmentFormView } from './components';
+import { useFireEquipmentTexts } from './constant';
 import { useFireEquipmentHooks } from './hooks';
 
 type FireEquipmentProps = {
@@ -11,6 +12,7 @@ type FireEquipmentProps = {
 };
 
 const Content: FC<FireEquipmentProps> = ({ groupId, isDeadline }) => {
+  const fireEquipmentTexts = useFireEquipmentTexts();
   const {
     isEditing,
     handleEditClick,
@@ -22,7 +24,9 @@ const Content: FC<FireEquipmentProps> = ({ groupId, isDeadline }) => {
   } = useFireEquipmentHooks(groupId);
 
   if (isLoading) {
-    return <p className="text-sm text-gray-400">読み込み中...</p>;
+    return (
+      <p className="text-sm text-gray-400">{fireEquipmentTexts.loading}</p>
+    );
   }
 
   // 締め切り後
@@ -37,7 +41,7 @@ const Content: FC<FireEquipmentProps> = ({ groupId, isDeadline }) => {
         groupId={groupId}
         fireEquipmentData={fireEquipment}
         handleEditCancel={handleEditClick}
-        submitLabel="更新"
+        submitLabel={fireEquipmentTexts.buttons.update}
         disableValidate
       />
     );
@@ -79,9 +83,10 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   isDeadline,
   isRegistered,
 }) => {
+  const fireEquipmentTexts = useFireEquipmentTexts();
   return (
     <AccordionMenu
-      title={'火気使用申請'}
+      title={fireEquipmentTexts.title}
       isEdit={!isDeadline}
       isExist={isRegistered}
       required={true}

--- a/user/src/components/Applications/FireEquipment/components/FireEquipmentForm.tsx
+++ b/user/src/components/Applications/FireEquipment/components/FireEquipmentForm.tsx
@@ -7,11 +7,7 @@ import Selector from '@/components/Form/Selector/Selector';
 import TextArea from '@/components/Form/TextArea/TextArea';
 import TextBox from '@/components/Form/TextBox/TextBox';
 import FormContainer from '@/components/FormContainer';
-import {
-  FIRE_EQUIPMENT_FUEL_PLACEHOLDER_ID,
-  FIRE_EQUIPMENT_INSTRUCTIONS,
-  fireEquipmentFormFields,
-} from '../constant';
+import { useFireEquipmentTexts } from '../constant';
 import { convertToBoolToString } from './hooks';
 import { FireEquipmentFormValues } from './schema';
 
@@ -34,51 +30,32 @@ const FireEquipmentForm: FC<FireEquipmentFormProps> = ({
   validate,
   submitLabel,
 }) => {
+  const fireEquipmentTexts = useFireEquipmentTexts();
+
   return (
     <FormContainer>
       <div className="flex flex-col">
         <div className="flex flex-col gap-10 text-[#484848]">
           <TextBox
-            label={fireEquipmentFormFields.NAME}
+            label={fireEquipmentTexts.fields.name}
             required
             value={values.name}
             onChange={(value) => setValue('name', value)}
             error={errors.name?.message}
           />
           <TextBox
-            label={fireEquipmentFormFields.QUANTITY}
+            label={fireEquipmentTexts.fields.quantity}
             required
             type="number"
             value={values.quantity.toString()}
-            note="半角数字のみ"
+            note={fireEquipmentTexts.notes.quantity}
             onChange={(value) => setValue('quantity', Number(value))}
             error={errors.quantity?.message}
           />
           <Selector
-            label={fireEquipmentFormFields.FUEL}
+            label={fireEquipmentTexts.fields.fuel}
             required
-            options={[
-              {
-                id: FIRE_EQUIPMENT_FUEL_PLACEHOLDER_ID,
-                name: '選択してください',
-                disabled: true,
-              },
-              {
-                id: Number(FireEquipmentFuel.GAS_BOTTLE),
-                name: 'カセットガス',
-                disabled: false,
-              },
-              {
-                id: Number(FireEquipmentFuel.LP_GAS),
-                name: 'LPガス',
-                disabled: false,
-              },
-              {
-                id: Number(FireEquipmentFuel.CHARCOAL),
-                name: '炭',
-                disabled: false,
-              },
-            ]}
+            options={fireEquipmentTexts.fuelOptions}
             value={values.fuel}
             onChange={(value) =>
               setValue('fuel', Number(value) as FireEquipmentFuel)
@@ -86,17 +63,17 @@ const FireEquipmentForm: FC<FireEquipmentFormProps> = ({
             error={errors.fuel?.message}
           />
           <TextArea
-            label={fireEquipmentFormFields.USAGE}
+            label={fireEquipmentTexts.fields.usage}
             required
             value={values.usage}
             onChange={(value) => setValue('usage', value)}
             error={errors.usage?.message}
           />
           <Radio
-            label={fireEquipmentFormFields.IS_TAKEAWAY}
+            label={fireEquipmentTexts.fields.isTakeaway}
             options={[
-              { id: 1, name: 'はい' },
-              { id: 2, name: 'いいえ' },
+              { id: 1, name: fireEquipmentTexts.radio.options.yes },
+              { id: 2, name: fireEquipmentTexts.radio.options.no },
             ]}
             value={convertToBoolToString(values.isTakeaway)}
             onChange={(value) => {
@@ -106,23 +83,23 @@ const FireEquipmentForm: FC<FireEquipmentFormProps> = ({
             error={errors.isTakeaway?.message}
           />
           <p className="-mt-10 max-w-[400px] break-words text-xs text-[#484848]">
-            {FIRE_EQUIPMENT_INSTRUCTIONS.TAKEAWAY_NOTICE.split('\n').map(
-              (line, index) => (
+            {fireEquipmentTexts.notes.takeaway
+              .split('\n')
+              .map((line, index) => (
                 <span key={index}>
                   {line}
                   {index === 0 && <br />}
                 </span>
-              )
-            )}
+              ))}
           </p>
           <p className="max-w-[400px] break-words text-xs text-[#484848]">
-            {FIRE_EQUIPMENT_INSTRUCTIONS.REMARK_NOTICE}
+            {fireEquipmentTexts.notes.remark}
           </p>
           <TextArea
-            label={fireEquipmentFormFields.REMARK}
+            label={fireEquipmentTexts.fields.remark}
             // 「火気を毎日テントから持ち帰ることができますか？」の質問で必須にするかしないか判定する
             required
-            requireMessage="いいえを押した場合必須"
+            requireMessage={fireEquipmentTexts.notes.remarkRequired}
             value={values.remarks || ''}
             onChange={(value) => setValue('remarks', value)}
             error={errors.remarks?.message}
@@ -138,7 +115,7 @@ const FireEquipmentForm: FC<FireEquipmentFormProps> = ({
                 type="button"
                 onClick={handleEditCancel}
               >
-                キャンセル
+                {fireEquipmentTexts.buttons.cancel}
               </Button>
             </div>
           )}
@@ -148,7 +125,9 @@ const FireEquipmentForm: FC<FireEquipmentFormProps> = ({
             type="submit"
             isDisable={validate && validate()}
           >
-            {isEditing ? '修正' : (submitLabel ?? '登録')}
+            {isEditing
+              ? fireEquipmentTexts.buttons.edit
+              : (submitLabel ?? fireEquipmentTexts.buttons.register)}
           </Button>
         </div>
       </div>

--- a/user/src/components/Applications/FireEquipment/components/FireEquipmentFormView.tsx
+++ b/user/src/components/Applications/FireEquipment/components/FireEquipmentFormView.tsx
@@ -3,6 +3,7 @@ import { FireEquipmentResponse } from '@/api/fireEquipmentApi';
 import { NO_ID_STRING, RADIO_OPTIONS, YES_ID_STRING } from '@/utils/constant';
 import Button from '@/components/Button/Button';
 import Radio from '@/components/Form/Radio/Radio';
+import { useFireEquipmentTexts } from '../constant';
 import FireEquipmentForm from './FireEquipmentForm';
 import { useFireEquipmentOrder } from './hooks';
 
@@ -21,6 +22,7 @@ export const FireEquipmentFormView: FC<FireEquipmentFormViewProps> = ({
   submitLabel,
   disableValidate = false,
 }) => {
+  const fireEquipmentTexts = useFireEquipmentTexts();
   const {
     isRegister,
     submitUnregisteredHandler,
@@ -40,7 +42,7 @@ export const FireEquipmentFormView: FC<FireEquipmentFormViewProps> = ({
       {/* 火気使用有無の選択 */}
       <div>
         <Radio
-          label="火気申請を使用しますか？"
+          label={fireEquipmentTexts.radio.question}
           value={isRegisterValue}
           onChange={(value) => {
             setIsRegisterValue(
@@ -48,11 +50,17 @@ export const FireEquipmentFormView: FC<FireEquipmentFormViewProps> = ({
             );
           }}
           required
-          options={RADIO_OPTIONS}
+          options={RADIO_OPTIONS.map((option) => ({
+            ...option,
+            name:
+              option.id.toString() === YES_ID_STRING
+                ? fireEquipmentTexts.radio.options.yes
+                : fireEquipmentTexts.radio.options.no,
+          }))}
           error={errorsUnregistered.isRegister?.message}
         />
         <p className="max-w-[400px] break-words text-xs text-[#484848]">
-          電気ホットプレートとIHは含まれません。
+          {fireEquipmentTexts.notes.excludedItems}
         </p>
       </div>
 
@@ -61,7 +69,7 @@ export const FireEquipmentFormView: FC<FireEquipmentFormViewProps> = ({
         <form onSubmit={submitUnregisteredHandler}>
           <div className="mt-8 flex flex-col items-center gap-4">
             <Button type="submit" size="pc" color="main">
-              登録
+              {fireEquipmentTexts.buttons.register}
             </Button>
           </div>
         </form>

--- a/user/src/components/Applications/FireEquipment/components/hooks.ts
+++ b/user/src/components/Applications/FireEquipment/components/hooks.ts
@@ -8,6 +8,7 @@ import { NO_ID_STRING, YES_ID_STRING } from '@/utils/constant';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
+import { useFireEquipmentTexts } from '../constant';
 import {
   FireEquipmentFormValues,
   FireEquipmentSchema,
@@ -20,6 +21,7 @@ export const useFireEquipmentOrder = (
   fireEquipmentData?: FireEquipmentResponse,
   handleEditCancel?: () => void
 ) => {
+  const fireEquipmentTexts = useFireEquipmentTexts();
   const { mutateFireEquipmentOrder } =
     useGetFireEquipmentOrderByGroupId(groupId);
 
@@ -103,12 +105,12 @@ export const useFireEquipmentOrder = (
         });
       }
       await mutateFireEquipmentOrder();
-      toast.success('火気申請を行わない登録が完了しました');
+      toast.success(fireEquipmentTexts.messages.noApplicationSuccess);
       handleEditCancel?.();
     } catch (error) {
       console.error('火気不使用登録エラー:', error);
       const message = error instanceof Error ? error.message : String(error);
-      toast.error(`登録に失敗しました: ${message}`);
+      toast.error(fireEquipmentTexts.messages.submitFailed(message));
     }
   };
   const submitUnregisteredHandler =
@@ -146,10 +148,10 @@ export const useFireEquipmentOrder = (
     try {
       if (isEditing && fireEquipmentData?.id !== undefined) {
         await patchFireEquipmentOrder(fireEquipmentData.id, payload);
-        toast.success('火気申請を更新しました！');
+        toast.success(fireEquipmentTexts.messages.updateSuccess);
       } else {
         await postFireEquipmentOrder(payload);
-        toast.success('火気申請が完了しました！');
+        toast.success(fireEquipmentTexts.messages.registerSuccess);
       }
       await mutateFireEquipmentOrder();
       // 成功後に編集モードを終了
@@ -157,7 +159,7 @@ export const useFireEquipmentOrder = (
     } catch (error) {
       console.error('火気申請送信エラー:', error);
       const message = error instanceof Error ? error.message : String(error);
-      toast.error(`送信に失敗しました: ${message}`);
+      toast.error(fireEquipmentTexts.messages.submitFailed(message));
     }
   };
 

--- a/user/src/components/Applications/FireEquipment/components/schema.ts
+++ b/user/src/components/Applications/FireEquipment/components/schema.ts
@@ -9,12 +9,14 @@ const fireEquipmentFuelArray = Object.values(FireEquipmentFuel).filter(
 export const FireEquipmentSchema = z
   .object({
     id: z.number().optional(),
-    name: z.string().min(1, '入力してください'),
-    quantity: z.number().min(1, '1以上の数字を入力してください'),
+    name: z.string().min(1, 'applications.fireEquipment.validation.required'),
+    quantity: z
+      .number()
+      .min(1, 'applications.fireEquipment.validation.quantity'),
     fuel: z.number().refine((value) => fireEquipmentFuelArray.includes(value), {
-      message: '燃料を選択してください',
+      message: 'applications.fireEquipment.validation.fuel',
     }),
-    usage: z.string().min(1, '入力してください'),
+    usage: z.string().min(1, 'applications.fireEquipment.validation.required'),
     isTakeaway: z.boolean(),
     remarks: z.string().optional(),
   })
@@ -23,7 +25,7 @@ export const FireEquipmentSchema = z
     if (!data.isTakeaway && data.remarks == '') {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: '持ち帰りが「いいえ」の場合、備考欄は必須です',
+        message: 'applications.fireEquipment.validation.remarkRequired',
         path: ['remarks'],
       });
     }
@@ -32,7 +34,7 @@ export const FireEquipmentSchema = z
 export type FireEquipmentFormValues = z.infer<typeof FireEquipmentSchema>;
 
 export const UnregisteredFireEquipmentSchema = z.object({
-  groupId: z.number().min(1, 'グループを選択してください'),
+  groupId: z.number().min(1, 'applications.fireEquipment.validation.group'),
   isRegister: z.boolean().default(true),
 });
 

--- a/user/src/components/Applications/FireEquipment/constant.ts
+++ b/user/src/components/Applications/FireEquipment/constant.ts
@@ -1,16 +1,93 @@
-export enum fireEquipmentFormFields {
-  NAME = '火気の名称',
-  QUANTITY = '火気の台数',
-  FUEL = '燃料',
-  USAGE = '使用用途',
-  IS_TAKEAWAY = '火気を毎日テントから持ち帰ることができますか？',
-  REMARK = '備考',
-}
-
-export const FIRE_EQUIPMENT_INSTRUCTIONS = {
-  TAKEAWAY_NOTICE:
-    '火気は毎日持って帰ることができない場合を除き、基本的に持ち帰ってください。\n火気はテント内に残す行為は火事の原因になります。',
-  REMARK_NOTICE: 'いいえを押した場合は火気の備考欄に理由を記載して下さい。',
-};
+import { FireEquipmentFuel } from '@/api/fireEquipmentApi';
+import { useTranslation } from 'next-i18next';
 
 export const FIRE_EQUIPMENT_FUEL_PLACEHOLDER_ID = 0;
+
+export const useFireEquipmentTexts = () => {
+  const { t } = useTranslation('common');
+
+  return {
+    title: t('applications.fireEquipment.title'),
+    loading: t('general.loading'),
+    fields: {
+      name: t('applications.fireEquipment.fields.name'),
+      quantity: t('applications.fireEquipment.fields.quantity'),
+      fuel: t('applications.fireEquipment.fields.fuel'),
+      usage: t('applications.fireEquipment.fields.usage'),
+      isTakeaway: t('applications.fireEquipment.fields.isTakeaway'),
+      remark: t('applications.fireEquipment.fields.remark'),
+    },
+    notes: {
+      quantity: t('applications.fireEquipment.notes.quantity'),
+      takeaway: t('applications.fireEquipment.notes.takeaway'),
+      remark: t('applications.fireEquipment.notes.remark'),
+      remarkRequired: t('applications.fireEquipment.notes.remarkRequired'),
+      excludedItems: t('applications.fireEquipment.notes.excludedItems'),
+    },
+    radio: {
+      question: t('applications.fireEquipment.radio.question'),
+      options: {
+        yes: t('applications.fireEquipment.radio.options.yes'),
+        no: t('applications.fireEquipment.radio.options.no'),
+      },
+    },
+    fuelOptions: [
+      {
+        id: FIRE_EQUIPMENT_FUEL_PLACEHOLDER_ID,
+        name: t('form.validation.select'),
+        disabled: true,
+      },
+      {
+        id: Number(FireEquipmentFuel.GAS_BOTTLE),
+        name: t('applications.fireEquipment.fuel.gasBottle'),
+        disabled: false,
+      },
+      {
+        id: Number(FireEquipmentFuel.LP_GAS),
+        name: t('applications.fireEquipment.fuel.lpGas'),
+        disabled: false,
+      },
+      {
+        id: Number(FireEquipmentFuel.CHARCOAL),
+        name: t('applications.fireEquipment.fuel.charcoal'),
+        disabled: false,
+      },
+    ],
+    fuelLabel: (fuel: FireEquipmentFuel) => {
+      switch (fuel) {
+        case FireEquipmentFuel.LP_GAS:
+          return t('applications.fireEquipment.fuel.lpGas');
+        case FireEquipmentFuel.CHARCOAL:
+          return t('applications.fireEquipment.fuel.charcoal');
+        case FireEquipmentFuel.GAS_BOTTLE:
+        default:
+          return t('applications.fireEquipment.fuel.gasBottle');
+      }
+    },
+    buttons: {
+      register: t('form.actions.register'),
+      edit: t('form.actions.edit'),
+      update: t('form.actions.save'),
+      cancel: t('form.actions.cancel'),
+    },
+    summary: {
+      noApplicationLabel: t(
+        'applications.fireEquipment.summary.noApplication.label'
+      ),
+      noApplicationDescription: t(
+        'applications.fireEquipment.summary.noApplication.description'
+      ),
+    },
+    messages: {
+      deleteSuccess: t('applications.fireEquipment.messages.deleteSuccess'),
+      deleteFailed: t('applications.fireEquipment.messages.deleteFailed'),
+      noApplicationSuccess: t(
+        'applications.fireEquipment.messages.noApplicationSuccess'
+      ),
+      registerSuccess: t('applications.fireEquipment.messages.registerSuccess'),
+      updateSuccess: t('applications.fireEquipment.messages.updateSuccess'),
+      submitFailed: (message: string) =>
+        t('applications.fireEquipment.messages.submitFailed', { message }),
+    },
+  };
+};

--- a/user/src/components/Applications/FireEquipment/hooks.ts
+++ b/user/src/components/Applications/FireEquipment/hooks.ts
@@ -5,9 +5,10 @@ import {
 } from '@/api/fireEquipmentApi';
 import { toast } from 'react-toastify';
 import { FormItem } from '@/components/FormList/type';
-import { fireEquipmentFormFields } from './constant';
+import { useFireEquipmentTexts } from './constant';
 
 export const useFireEquipmentHooks = (groupId: number) => {
+  const fireEquipmentTexts = useFireEquipmentTexts();
   const { fireEquipmentOrder, isLoading, mutateFireEquipmentOrder } =
     useGetFireEquipmentOrderByGroupId(groupId);
 
@@ -22,27 +23,29 @@ export const useFireEquipmentHooks = (groupId: number) => {
     fireEquipment && !hasUnregistered
       ? [
           {
-            label: fireEquipmentFormFields.NAME,
+            label: fireEquipmentTexts.fields.name,
             content: fireEquipment.name,
           },
           {
-            label: fireEquipmentFormFields.QUANTITY,
+            label: fireEquipmentTexts.fields.quantity,
             content: String(fireEquipment.quantity),
           },
           {
-            label: fireEquipmentFormFields.FUEL,
-            content: String(fireEquipment.fuel),
+            label: fireEquipmentTexts.fields.fuel,
+            content: fireEquipmentTexts.fuelLabel(fireEquipment.fuel),
           },
           {
-            label: fireEquipmentFormFields.USAGE,
+            label: fireEquipmentTexts.fields.usage,
             content: fireEquipment.usage,
           },
           {
-            label: fireEquipmentFormFields.IS_TAKEAWAY,
-            content: fireEquipment.is_takeaway ? 'はい' : 'いいえ',
+            label: fireEquipmentTexts.fields.isTakeaway,
+            content: fireEquipment.is_takeaway
+              ? fireEquipmentTexts.radio.options.yes
+              : fireEquipmentTexts.radio.options.no,
           },
           {
-            label: fireEquipmentFormFields.REMARK,
+            label: fireEquipmentTexts.fields.remark,
             content: fireEquipment.remark || '',
           },
         ]
@@ -58,17 +61,17 @@ export const useFireEquipmentHooks = (groupId: number) => {
     try {
       await deleteFireEquipmentOrder(fireEquipment.id);
       await mutateFireEquipmentOrder();
-      toast.success('火気申請を削除しました');
+      toast.success(fireEquipmentTexts.messages.deleteSuccess);
     } catch (error) {
       console.error('火気申請削除エラー:', error);
-      toast.error('削除に失敗しました。もう一度お試しください。');
+      toast.error(fireEquipmentTexts.messages.deleteFailed);
     }
   };
 
   const noApplicationItems: FormItem[] = [
     {
-      label: '火気申請は不要（登録済み）',
-      content: '火気は使用しません。',
+      label: fireEquipmentTexts.summary.noApplicationLabel,
+      content: fireEquipmentTexts.summary.noApplicationDescription,
     },
   ];
 

--- a/user/src/components/Applications/Stage/StageForm/StageForm.tsx
+++ b/user/src/components/Applications/Stage/StageForm/StageForm.tsx
@@ -97,7 +97,7 @@ const StageForm: FC<Props> = ({ isDeadline, groupId }) => {
     <>
       {isFormMode === null ? (
         <div className="w-[400px] py-4 text-center">
-          <p>データを読み込み中です...</p>
+          <p>{stageFormTexts.loading}</p>
         </div>
       ) : isFormMode ? (
         <FormContainer>

--- a/user/src/components/EditButton/EditButton.tsx
+++ b/user/src/components/EditButton/EditButton.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { useTranslation } from 'next-i18next';
 import { MdModeEdit } from 'react-icons/md';
 
 type EditButtonProps = {
@@ -6,10 +7,14 @@ type EditButtonProps = {
 };
 
 const EditButton: FC<EditButtonProps> = ({ OnClick }) => {
+  const { t } = useTranslation('common');
+
   return (
     <button className="flex w-32 gap-3" onClick={OnClick}>
       <MdModeEdit color="#000000" size="24" />
-      <p className="text-base font-medium text-font">編集</p>
+      <p className="text-base font-medium text-font">
+        {t('form.actions.edit')}
+      </p>
     </button>
   );
 };

--- a/user/src/components/Form/TextArea/TextArea.tsx
+++ b/user/src/components/Form/TextArea/TextArea.tsx
@@ -22,11 +22,11 @@ const TextArea: FC<TextAreaProps> = ({
   note,
   error,
 }) => {
-  const { translateError } = useFormFieldCommonTexts();
+  const { required: requiredLabel, translateError } = useFormFieldCommonTexts();
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange(event.target.value);
   };
-  const requiredMessage = requireMessage ? `※${requireMessage}` : '※必須';
+  const requiredMessage = requireMessage ?? requiredLabel;
   return (
     <>
       <label>

--- a/user/src/components/LoginModal/schema.ts
+++ b/user/src/components/LoginModal/schema.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 export const loginModalSchema = z.object({
   email: z
-    .string({ required_error: '入力してください' })
-    .email('有効なメールアドレスを入力してください'),
-  password: z.string({ required_error: '入力してください' }),
+    .string({ required_error: 'loginModal.validation.required' })
+    .email('loginModal.validation.email'),
+  password: z.string({ required_error: 'loginModal.validation.required' }),
 });
 
 export type LoginModalSchema = z.infer<typeof loginModalSchema>;

--- a/user/src/components/UserModal/UserModal.tsx
+++ b/user/src/components/UserModal/UserModal.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { useTranslation } from 'next-i18next';
 import CancelButton from '../CancelButton';
 import EditButton from '../EditButton';
 import LogoutButton from '../LogoutButton';
@@ -11,6 +12,7 @@ type UserModalProps = {
 };
 
 const UserModal: FC<UserModalProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation('common');
   const {
     userInformation,
     handleLogout,
@@ -32,10 +34,10 @@ const UserModal: FC<UserModalProps> = ({ isOpen, onClose }) => {
           <div className="flex flex-col items-center gap-12 rounded-[20px] bg-white p-6 shadow-2xl">
             <div className="flex w-80 flex-col items-center justify-center gap-6 py-4 md:w-[420px]">
               <p className="text-3xl font-bold text-font">
-                {userInformation?.user?.name || 'ゲスト'}
+                {userInformation?.user?.name || t('userModal.guest')}
               </p>
               <p className="text-base font-medium text-font">
-                {userInformation?.user?.email || 'メールアドレスなし'}
+                {userInformation?.user?.email || t('userModal.noEmail')}
               </p>
               <EditButton OnClick={handleEdit} />
               <LogoutButton onClick={handleLogout} />

--- a/user/src/components/UserModal/hooks.ts
+++ b/user/src/components/UserModal/hooks.ts
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useGetCurrentUserInformation } from '@/api/useUserDetailApi';
 import { signOut } from 'next-auth/react';
+import { useTranslation } from 'next-i18next';
 import { toast } from 'react-toastify';
 
 export const useUserModalHooks = (onClose: () => void) => {
+  const { t } = useTranslation('common');
   const { userInformation, mutate } = useGetCurrentUserInformation();
 
   const [isEdit, setIsEdit] = useState(false);
@@ -17,11 +19,11 @@ export const useUserModalHooks = (onClose: () => void) => {
   const handleLogout = async () => {
     try {
       await signOut({ redirect: false });
-      toast.success('ログアウトしました');
+      toast.success(t('userModal.toasts.logoutSuccess'));
       onClose();
     } catch (error) {
       console.error('Logout error:', error);
-      toast.error('ログアウトに失敗しました');
+      toast.error(t('userModal.toasts.logoutFailed'));
     }
   };
 

--- a/user/src/icons/Icons.tsx
+++ b/user/src/icons/Icons.tsx
@@ -1,18 +1,23 @@
 import { FC } from 'react';
+import { useTranslation } from 'next-i18next';
 import { FiPlus } from 'react-icons/fi';
 import { LiaLessThanSolid } from 'react-icons/lia';
 import { RxCross2 } from 'react-icons/rx';
 import { SlPencil } from 'react-icons/sl';
 
-export const Loading: FC<{ colorClass: string }> = ({ colorClass }) => (
-  <div className="flex justify-center" aria-label="読み込み中">
-    <div className={`size-2 animate-ping ${colorClass} rounded-full`}></div>
-    <div
-      className={`size-2 animate-ping ${colorClass} mx-4 rounded-full`}
-    ></div>
-    <div className={`size-2 animate-ping ${colorClass} rounded-full`}></div>
-  </div>
-);
+export const Loading: FC<{ colorClass: string }> = ({ colorClass }) => {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="flex justify-center" aria-label={t('general.loading')}>
+      <div className={`size-2 animate-ping ${colorClass} rounded-full`}></div>
+      <div
+        className={`size-2 animate-ping ${colorClass} mx-4 rounded-full`}
+      ></div>
+      <div className={`size-2 animate-ping ${colorClass} rounded-full`}></div>
+    </div>
+  );
+};
 
 const Icons: { [key: string]: JSX.Element } = {
   pencil: <SlPencil />,

--- a/user/src/utils/constant.ts
+++ b/user/src/utils/constant.ts
@@ -4,11 +4,9 @@ export const YES_ID = 1;
 export const NO_ID = 2;
 export const YES_ID_STRING = '1' as const;
 export const NO_ID_STRING = '2' as const;
-export const YES_NAME = 'はい';
-export const NO_NAME = 'いいえ';
 
 // 登録・未登録の選択肢
 export const RADIO_OPTIONS: Option[] = [
-  { id: YES_ID, name: YES_NAME },
-  { id: NO_ID, name: NO_NAME },
+  { id: YES_ID, name: 'yes' },
+  { id: NO_ID, name: 'no' },
 ];


### PR DESCRIPTION
resolved #2033
## 概要
- `/user` の未翻訳表示を既存の `next-i18next` 構成に合わせて i18n 化
- 参加形式と物品名は英語表示時に API の `name_en` を使うように修正
- 火気使用申請のフォーム、一覧、toast、バリデーションを日英対応
- ユーザーモーダル、編集ボタン、ローディング表示などの直書き文言を翻訳キーへ移行

## 背景
英語表示時にも一部の画面文言やマスタ名称が日本語のまま表示されていました。DB/fixture 側に用意されている英語名を使い、UI 文言は locale ファイルに集約しています。

## 補足
場所名は今年は日本語のままにする方針のため、翻訳対象から外しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive multi-language support with dynamic text rendering for English and Japanese across all application interfaces, including forms, validation messages, and user-facing labels.
  * Enabled language-specific display for fire equipment applications, login modals, and user profile sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->