### PR TITLE
fix: pnpm cache設定を修正

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,25 +18,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # Corepack を有効にして pnpm を使えるようにする
-      - name: Enable Corepack
-        run: corepack enable
+      # pnpm を明示的にセットアップしてから setup-node の cache を使う
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+            version: 10.7.0
       # Node.js v22をセットアップ
       - name: Use Node.js v22
         uses: actions/setup-node@v4
         with:
             node-version: '22'
             cache: 'pnpm'
-            cache-dependency-path: |
-              ./user/package.json
-              ./user/pnpm-lock.yaml
+            cache-dependency-path: ./user/pnpm-lock.yaml
       # pnpmで依存関係をインストール
       - name: pnpm install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./user
-      - name: Install dependencies
-        working-directory: ./user
-        run: pnpm i
       - name: Run Chromatic
         uses: chromaui/action@latest
         with:

--- a/.github/workflows/user-code-quality.yml
+++ b/.github/workflows/user-code-quality.yml
@@ -32,9 +32,11 @@ jobs:
           token: ${{ steps.create.outputs.token }}
           persist-credentials: true
 
-      # Corepack を有効にして pnpm を使えるようにする
-      - name: Enable Corepack
-        run: corepack enable
+      # pnpm を明示的にセットアップしてから setup-node の cache を使う
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
 
       # Node.js v22をセットアップ
       - name: Use Node.js v22
@@ -42,9 +44,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-          cache-dependency-path: |
-            ./user/package.json
-            ./user/pnpm-lock.yaml
+          cache-dependency-path: ./user/pnpm-lock.yaml
 
       # pnpmで依存関係をインストール
       - name: pnpm install dependencies


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
close #2046

# 概要
- Chromatic workflow / User Code Quality workflow が pnpm cache miss 時に `actions/setup-node@v4` の post cache 保存で failure になる問題を修正します
- `pnpm/action-setup@v4` で pnpm を明示的に setup してから `setup-node` の pnpm cache を使うように変更しました
- Chromatic workflow では重複していた `pnpm install --frozen-lockfile` と `pnpm i` のうち、後者を削除しました

# 実装詳細
- `.github/workflows/chromatic.yml`
  - `Enable Corepack` step を `pnpm/action-setup@v4` に置き換え
  - `version: 10.7.0` を明示
  - `cache-dependency-path` を `./user/pnpm-lock.yaml` のみに整理
  - 重複 install step を削除
- `.github/workflows/user-code-quality.yml`
  - 同じ pnpm cache post failure が発生していたため、同様に `pnpm/action-setup@v4` を追加
  - `cache-dependency-path` を `./user/pnpm-lock.yaml` のみに整理

# 原因調査
## 確認できたこと
- `25425286282` では cache miss 後に Chromatic build が成功し、pnpm cache 保存も成功していました
  - `pnpm cache is not found`
  - `Build 401 passed!`
  - `Cache saved with the key: node-cache-Linux-x64-pnpm-eea933...`
- `25435408741` では上記 cache に hit して成功していました
  - `Cache hit for: node-cache-Linux-x64-pnpm-eea933...`
  - `Cache hit occurred on the primary key ..., not saving cache.`
- `25503747613` 以降は cache miss 後、Chromatic build 自体は成功しているが、post cache 保存で失敗していました
  - `pnpm cache is not found`
  - `Build 405 passed!`
  - `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`
- 現在の User Code Quality workflow でも同じ `Post Use Node.js v22` の cache 保存 error が発生していました
- cache 保存成功 run `25425286282` と、最初に保存失敗が確認できた run `25503747613` の間で、以下の hash は変わっていません
  - `.github/workflows/chromatic.yml`
  - `user/package.json`
  - `user/pnpm-lock.yaml`
- `actions/setup-node@v4` の action SHA と runner image release も、確認した成功/失敗 run 間では同じでした

## 推測
- repo 側の dependency 変更や workflow 定義変更が直接原因ではなさそうです
- 現在の workflow では `setup-node` が repo root で `pnpm store path --silent` を実行して cache path を記録します
- 一方、実際の `pnpm install` は `./user` で実行されます
- repo root には `packageManager` がなく、`user/package.json` にだけ `packageManager: pnpm@10.7.0...` があるため、cache path の解決が安定していなかった可能性があります
- 以前は一度 cache 保存に成功した後、cache hit により保存処理を通らなかったため、cache miss 時の不安定さが表面化していなかった可能性があります

## まだ断定できないこと
- 2026-05-07 付近で GitHub 側にこの現象へ直結する仕様変更があったとは、現時点のログからは断定できません
- 5/6 に保存成功し、5/7 以降に保存失敗した直接要因は、`setup-node` が保存対象にした pnpm store path がログに出ていないため完全には特定できません
- ただし、公式 docs 上 GitHub Actions cache は scope / 7日未アクセス削除 / repository cache 容量上限による eviction の影響を受けるため、cache miss 自体は通常発生し得ます

# 画面スクリーンショット等

# テスト項目
- [x] `ruby -e 'require "yaml"; %w[.github/workflows/chromatic.yml .github/workflows/user-code-quality.yml].each { |f| YAML.load_file(f); puts "#{f} OK" }'`\n- [x] `git diff --check`\n- [x] GitHub Actions: `Run Chromatic` が pass すること\n- [x] GitHub Actions: `Code-Check` が post cache 保存で failure にならないこと\n\n# 備考\n- 初回 PR 作成後、Chromatic は pass しました\n- その後 `User Code Quality` でも同じ post cache 保存 error が残っていたため、本 PR 内で同じ修正を追加しています\n