### PR TITLE
fix: 新規登録時の登録状況取得を修正

### DIFF
--- a/user/src/api/checkAllRegisteredApi.ts
+++ b/user/src/api/checkAllRegisteredApi.ts
@@ -33,7 +33,10 @@ const API_ENDPOINTS = {
 };
 
 export const useGetCheckAllRegisteredGroups = (groupId: number | undefined) => {
-  const endpoint = `${API_ENDPOINTS.CHECK_ALL_REGISTERED}/${groupId}`;
+  const endpoint =
+    groupId && groupId > 0
+      ? `${API_ENDPOINTS.CHECK_ALL_REGISTERED}/${groupId}`
+      : null;
 
   const { data, error, isLoading, mutate } =
     useAuthenticatedGet<ApiResponse<RegistrationStatus>>(endpoint);

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -315,12 +315,16 @@ export default function HomePage() {
     mutateGroupByUserId,
     isLoading: isLoadingGroupByUserId,
   } = useGetGroupByUserId(userId);
-  const groupId = groupUserIdAndGroupCategoryId?.id ?? 0;
+  const groupId = groupUserIdAndGroupCategoryId?.id;
+  const displayGroupId = groupId ?? 0;
   const groupCategoryId = groupUserIdAndGroupCategoryId?.groupCategoryId;
   const isGroupResolved = userId !== undefined && !isLoadingGroupByUserId;
   const { userPageSettings } = useGetUserPageSettings();
   const { checkAllRegisteredGroups, mutateCheckAllRegisteredGroups } =
     useGetCheckAllRegisteredGroups(groupId);
+  const registrationStatus: CheckAllRegisteredGroups =
+    checkAllRegisteredGroups ?? {};
+  const isGroupRegistered = groupId ? registrationStatus.group === true : false;
 
   return (
     <div className="m-4 flex flex-col gap-10 lg:mx-10 lg:my-16 lg:flex-row lg:gap-0">
@@ -328,29 +332,29 @@ export default function HomePage() {
         {/* Group申請がまだの場合はGroup申請のみ表示 */}
         <Group
           isDeadline={!userPageSettings?.isRegistGroup}
-          isRegistered={checkAllRegisteredGroups?.group}
-          groupId={groupId}
+          isRegistered={isGroupRegistered}
+          groupId={displayGroupId}
           userId={userId || 0}
           isGroupResolved={isGroupResolved}
           mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           mutateGroupByUserId={mutateGroupByUserId}
         />
 
-        {checkAllRegisteredGroups?.group && (
+        {isGroupRegistered && (
           <ViceRepresentative
             isDeadline={!userPageSettings?.isEditSubRep}
-            isRegistered={checkAllRegisteredGroups?.subRep}
-            groupId={groupId}
+            isRegistered={registrationStatus.subRep}
+            groupId={displayGroupId}
             mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           />
         )}
 
-        {checkAllRegisteredGroups?.group && (
+        {isGroupRegistered && (
           <GroupCategoryContent
             groupCategoryId={groupCategoryId}
             userPageSettings={userPageSettings}
-            checkAllRegisteredGroups={checkAllRegisteredGroups}
-            groupId={groupId}
+            checkAllRegisteredGroups={registrationStatus}
+            groupId={displayGroupId}
             mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           />
         )}


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2049

# 概要
<!-- 開発内容の概要を記載 -->
- 新規登録ユーザーで団体申請が未作成の場合に、団体申請フォームが loading のままになる問題を修正しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `groupId` が未取得または `0` の場合は `/check_all_registered/{groupId}` を呼ばないように修正しました。
- 団体未作成時は `isRegistered=false` として `GroupForm` を表示するように修正しました。
- 登録状況データが未取得の場合でも、団体申請以外の申請表示判定が壊れないように fallback を追加しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 新規登録ユーザーでホーム画面を開いたとき、団体申請フォームが loading のままにならず表示されること
- [x] 団体申請作成後に、正式な `group_id` で登録状況が取得されること
- [x] 既存団体があるユーザーで、従来通り各申請の登録状況が表示されること

# 備考
<!-- 実装していて困った箇所・質問など -->
- `docker compose run --rm user pnpm run type-check` 成功
- `docker compose run --rm user pnpm run lint` 成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or missing group identifiers to prevent unnecessary API requests and enhance performance.
  * Enhanced registration status tracking with more reliable conditional component rendering based on actual group registration state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NUTFes/group-manager-2/pull/2050)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->