### PR TITLE
[fix]deepl APIのURLが.envでは設定されていたが、デフォルトのdeepl apiでは利用していなかったので、その問題を解決

### DIFF
--- a/api/config/initializers/deepl.rb
+++ b/api/config/initializers/deepl.rb
@@ -1,0 +1,4 @@
+DeepL.configure do |config|
+  config.auth_key = ENV['DEEPL_API_KEY']
+  config.host = ENV['DEEPL_API_URL']
+end


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
resolve #0

# 概要
- DeepL翻訳APIがrental_itemsページで動作しない問題を修正

# 実装詳細
- `config.auth_key`に`DEEPL_API_KEY`を設定
- `config.host`に`DEEPL_API_URL`を設定（FreeプランのエンドポイントURL）

# 画面スクリーンショット等

# テスト項目
- [ ] 物品一覧ページで「自動翻訳」ボタンを押すと英語名が自動入力されるか
- [ ] 物品詳細ページで「自動翻訳」ボタンを押すと英語名が自動入力されるか

# 備考
deepl apiはデフォルトの設定だと有料のアカウントを読みにいくので、API_URLを読まずに、APIキーだけで動作する。そのため、freeプランの場合、API_URLを読む設定を追加することで、freeプランでも動作するようになる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured DeepL translation service initialization at application startup with API credentials and endpoint settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NUTFes/group-manager-2/pull/2055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->