### PR TITLE
[fix] 従業員申請のcsv出力を改良

### DIFF
--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -362,23 +362,6 @@ class Api::V1::OutputCsvController < ApplicationController
           next
         end
 
-        skip = false
-        if rep && rep_student.present? && emp_student.present? && rep_student == emp_student
-          skip = true
-          group_dup_student_ids[group.id] << emp_student if emp_student.present?
-        elsif sub_rep && sub_rep_student.present? && emp_student.present? && sub_rep_student == emp_student
-          skip = true
-          group_dup_student_ids[group.id] << emp_student if emp_student.present?
-        elsif rep && rep_norm.present? && emp_norm.present? && rep_norm == emp_norm
-          skip = true
-          group_dup_names[group.id] << emp_norm
-        elsif sub_rep && sub_rep_norm.present? && emp_norm.present? && sub_rep_norm == emp_norm
-          skip = true
-          group_dup_names[group.id] << emp_norm
-        end
-
-        next if skip
-
         # 正常な従業員は persons に追加し、グループ内の既出に追加する
         persons << { group_id: group.id, group: group.name, name: emp_name, student_id: emp_student, roles: [] }
         group_seen_student_ids << emp_student if emp_student.present?

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -351,7 +351,7 @@ class Api::V1::OutputCsvController < ApplicationController
         ]
 
         # 学籍番号による重複チェック対象か（存在し、かつ外部/スタッフなどの特別値ではない）
-        student_id_dup_check_target = emp_student.present? && !common_student_ids.include?(emp_student)
+        student_id_dup_check_target = emp_student.present? && common_student_ids.exclude?(emp_student)
 
         # 重複判定: まず同一団体内で既に見た student_id / name と重複しているか
         if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -458,8 +458,8 @@ class Api::V1::OutputCsvController < ApplicationController
             remark = '同一団体内で2重登録（非表示で対応）'
           end
         else
-          if group_dup_names[current_group_id].include?(p[:normalized_key])
-            remark = '同一団体内で2重登録（非表示で対応）
+          if group_dup_names[current_group_id].include?(p[:normalized_name])
+            remark = '同一団体内で2重登録（非表示で対応）'
           end
         end
 

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -341,6 +341,7 @@ class Api::V1::OutputCsvController < ApplicationController
       # 従業員 — 同一団体内で代表/副代表と学籍番号または正規化氏名が一致する場合はスキップ
       (group.employees || []).each do |employee|
         next if employee.nil?
+
         emp_name = employee.name.to_s
         emp_norm = emp_name.gsub(/[[:space:]\u3000]+/, '')
         emp_student = employee.student_id
@@ -355,16 +356,16 @@ class Api::V1::OutputCsvController < ApplicationController
         end
 
         skip = false
-        if rep && (rep_student.present? && emp_student.present? && rep_student == emp_student)
+        if rep && rep_student.present? && emp_student.present? && rep_student == emp_student
           skip = true
           group_dup_student_ids[group.id] << emp_student if emp_student.present?
-        elsif sub_rep && (sub_rep_student.present? && emp_student.present? && sub_rep_student == emp_student)
+        elsif sub_rep && sub_rep_student.present? && emp_student.present? && sub_rep_student == emp_student
           skip = true
           group_dup_student_ids[group.id] << emp_student if emp_student.present?
-        elsif rep && (rep_norm.present? && emp_norm.present? && rep_norm == emp_norm)
+        elsif rep && rep_norm.present? && emp_norm.present? && rep_norm == emp_norm
           skip = true
           group_dup_names[group.id] << emp_norm
-        elsif sub_rep && (sub_rep_norm.present? && emp_norm.present? && sub_rep_norm == emp_norm)
+        elsif sub_rep && sub_rep_norm.present? && emp_norm.present? && sub_rep_norm == emp_norm
           skip = true
           group_dup_names[group.id] << emp_norm
         end
@@ -383,26 +384,26 @@ class Api::V1::OutputCsvController < ApplicationController
       # 半角スペースと全角スペースを削除して正規化
       p[:normalized_name] = p[:name].gsub(/[[:space:]\u3000]+/, '')
       p[:normalized_key] = p[:normalized_name].downcase
-      if p[:student_id].present?
-        p[:is_student] = (user_category_label(p[:student_id]) == '学生')
-      else
-        p[:is_student] = false
-      end
+      p[:is_student] = if p[:student_id].present?
+                         (user_category_label(p[:student_id]) == '学生')
+                       else
+                         false
+                       end
     end
 
     # 学籍番号で集計（学生のみ）: student_id => [{group_id, group_name}]
     student_map = Hash.new { |h, k| h[k] = [] }
     persons.each do |p|
       next unless p[:is_student] && p[:student_id].present?
+
       student_map[p[:student_id]] << { group_id: p[:group_id], group: p[:group], roles: Array(p[:roles]) }
     end
 
     # 氏名で集計（学籍番号で既にまとめられた人物は除外）: normalized_key => [{group_id, group_name}]
     name_map = Hash.new { |h, k| h[k] = [] }
     persons.each do |p|
-      if p[:is_student] && p[:student_id].present? && student_map[p[:student_id]].any?
-        next
-      end
+      next if p[:is_student] && p[:student_id].present? && student_map[p[:student_id]].any?
+
       key = p[:normalized_key]
       name_map[key] << { group_id: p[:group_id], group: p[:group], student_id: p[:student_id], roles: Array(p[:roles]) }
     end
@@ -431,36 +432,29 @@ class Api::V1::OutputCsvController < ApplicationController
 
         # 重複先を決定
         duplicates = []
-        if p[:is_student] && p[:student_id].present?
-          entries = student_map[p[:student_id]] || []
-          entries.each do |e|
-            next if e[:group_id] == current_group_id
-            duplicates << e[:group]
-          end
-        else
-          entries = name_map[p[:normalized_key]] || []
-          entries.each do |e|
-            next if e[:group_id] == current_group_id
-            duplicates << e[:group]
-          end
+        entries = if p[:is_student] && p[:student_id].present?
+                    student_map[p[:student_id]] || []
+                  else
+                    name_map[p[:normalized_key]] || []
+                  end
+        entries.each do |e|
+          next if e[:group_id] == current_group_id
+
+          duplicates << e[:group]
         end
 
-        duplicates_str = duplicates.sort_by { |gname|
+        duplicates_str = duplicates.sort_by do |gname|
           # sort duplicates by group id: find id from persons (slow but dataset small)
           found = persons.find { |pp| pp[:group] == gname }
           found ? found[:group_id] : 0
-        }.join(',')
+        end.join(',')
 
         # 同一団体内で同一人物が2重登録されているかチェック（スキップされた重複を group_dup_maps で判定）
         remark = ''
         if p[:is_student] && p[:student_id].present?
-          if group_dup_student_ids[current_group_id].include?(p[:student_id])
-            remark = '同一団体内で2重登録（非表示で対応）'
-          end
-        else
-          if group_dup_names[current_group_id].include?(p[:normalized_name])
-            remark = '同一団体内で2重登録（非表示で対応）'
-          end
+          remark = '同一団体内で2重登録（非表示で対応）' if group_dup_student_ids[current_group_id].include?(p[:student_id])
+        elsif group_dup_names[current_group_id].include?(p[:normalized_name])
+          remark = '同一団体内で2重登録（非表示で対応）'
         end
 
         csv << [current_group, name, student_id, roles_str, duplicates_str, remark]

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @groups = Group.where(fes_year_id: params[:fes_year_id])
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -47,7 +47,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @assign_rental_items = assign_rental_items_scope.where(groups: { fes_year_id: params[:fes_year_id] }).references(:groups)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -83,7 +83,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @sub_reps = Group.where(fes_year_id: params[:fes_year_id]).preload(:sub_rep).map(&:sub_rep)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -116,7 +116,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @rental_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:rental_orders).map(&:rental_orders)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -152,7 +152,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @power_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:power_orders).map(&:power_orders)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -190,7 +190,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @place_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:place_order).map(&:place_order)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -222,7 +222,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @stage_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:stage_orders).map(&:stage_orders)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -266,7 +266,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @stage_common_options = Group.where(fes_year_id: params[:fes_year_id]).preload(:stage_common_option).map(&:stage_common_option)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -297,7 +297,7 @@ class Api::V1::OutputCsvController < ApplicationController
     else
       # 開催年かつ食品団体（食販）のみ対象
       groups = Group.where(fes_year_id: params[:fes_year_id], group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
 
     # 全件の人物リストを収集（代表・副代表・従業員）
@@ -460,7 +460,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @food_products = Group.where(fes_year_id: params[:fes_year_id]).preload(:food_products).map(&:food_products)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -494,7 +494,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @purchase_lists = FoodProduct.preload(:purchase_lists).map { |food_product| food_product.purchase_lists if food_product.group.fes_year_id == params[:fes_year_id] }
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -533,7 +533,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @groups = Group.where(fes_year_id: params[:fes_year_id]).preload(:user, :sub_rep, user: :user_detail) # 必要な関連を事前にロード
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
 
     @categories = []
@@ -622,7 +622,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @public_relations = Group.where(fes_year_id: params[:fes_year_id]).preload(:public_relation).map(&:public_relation)
-      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
+      filename_year = FesYear.find(params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -648,7 +648,7 @@ class Api::V1::OutputCsvController < ApplicationController
       @fire_equipment_orders = FireEquipmentOrder.all
       filename_year = '全'
     else
-      fes_year = FesYear.find_by(id: params[:fes_year_id])
+      fes_year = FesYear.find(params[:fes_year_id])
       if fes_year
         @fire_equipment_orders = FireEquipmentOrder.joins(:group).where(groups: { fes_year_id: fes_year.id })
         filename_year = fes_year.year_num

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -2,7 +2,9 @@
 
 class Api::V1::OutputCsvController < ApplicationController
   require 'csv'
+  require 'set'
   before_action :authenticate_api_user!
+  include ApplicationHelper
 
   def output_groups_csv
     if params[:fes_year_id].to_i == 0
@@ -288,8 +290,8 @@ class Api::V1::OutputCsvController < ApplicationController
   end
 
   def output_employees_csv
+    # 対象グループの取得（食品団体のみ）
     if params[:fes_year_id].to_i == 0
-      # 食品団体（食販）のみ対象
       groups = Group.where(group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
       filename_year = '全'
     else
@@ -297,50 +299,174 @@ class Api::V1::OutputCsvController < ApplicationController
       groups = Group.where(fes_year_id: params[:fes_year_id], group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
       filename_year = FesYear.find(params[:fes_year_id]).year_num
     end
-    bom = "\uFEFF"
-    csv_data = CSV.generate(bom.dup) do |csv|
-      column_name = %w[参加団体名 名前 学籍番号]
-      csv << column_name
-      groups.each do |group|
-        next if group.nil?
 
-        # 1団体内で重複（代表・副代表・従業員の重複含む）を排除するためのキー集合
-        used = {}
+    # 全件の人物リストを収集（代表・副代表・従業員）
+    persons = []
+    # 同一団体内重複記録: group_id => Set of student_ids / normalized names
+    group_dup_student_ids = Hash.new { |h, k| h[k] = Set.new }
+    group_dup_names = Hash.new { |h, k| h[k] = Set.new }
 
-        # 代表
-        rep = group.user
-        rep_name = rep&.name
-        rep_student_id = rep&.user_detail&.student_id
-        if rep_name.present?
-          key = "#{rep_name}\t#{rep_student_id}"
-          unless used[key]
-            csv << [group.name, rep_name, rep_student_id]
-            used[key] = true
-          end
+    groups.each do |group|
+      next if group.nil?
+
+      # 代表
+      rep = group.user
+      rep_norm = nil
+      rep_student = nil
+      # グループ内既出チェック用セット
+      group_seen_student_ids = Set.new
+      group_seen_normalized = Set.new
+      if rep
+        rep_norm = rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
+        rep_student = rep.user_detail&.student_id
+        # mark seen
+        group_seen_student_ids << rep_student if rep_student.present?
+        group_seen_normalized << rep_norm if rep_norm.present?
+        persons << { group_id: group.id, group: group.name, name: rep.name.to_s, student_id: rep_student, roles: ['代'] }
+      end
+
+      # 副代表
+      sub_rep = group.sub_rep
+      sub_rep_norm = nil
+      sub_rep_student = nil
+      if sub_rep
+        sub_rep_norm = sub_rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
+        sub_rep_student = sub_rep.student_id
+        # mark seen
+        group_seen_student_ids << sub_rep_student if sub_rep_student.present?
+        group_seen_normalized << sub_rep_norm if sub_rep_norm.present?
+        persons << { group_id: group.id, group: group.name, name: sub_rep.name.to_s, student_id: sub_rep_student, roles: ['副'] }
+      end
+
+      # 従業員 — 同一団体内で代表/副代表と学籍番号または正規化氏名が一致する場合はスキップ
+      (group.employees || []).each do |employee|
+        next if employee.nil?
+        emp_name = employee.name.to_s
+        emp_norm = emp_name.gsub(/[[:space:]\u3000]+/, '')
+        emp_student = employee.student_id
+
+        # 重複判定: まず同一団体内で既に見た student_id / name と重複しているか
+        if emp_student.present? && group_seen_student_ids.include?(emp_student)
+          group_dup_student_ids[group.id] << emp_student
+          next
+        elsif emp_norm.present? && group_seen_normalized.include?(emp_norm)
+          group_dup_names[group.id] << emp_norm
+          next
         end
 
-        # 副代表（存在しない場合はスキップ）
-        sub_rep = group.sub_rep
-        if sub_rep
-          key = "#{sub_rep.name}\t#{sub_rep.student_id}"
-          unless used[key]
-            csv << [group.name, sub_rep.name, sub_rep.student_id]
-            used[key] = true
-          end
+        skip = false
+        if rep && (rep_student.present? && emp_student.present? && rep_student == emp_student)
+          skip = true
+          group_dup_student_ids[group.id] << emp_student if emp_student.present?
+        elsif sub_rep && (sub_rep_student.present? && emp_student.present? && sub_rep_student == emp_student)
+          skip = true
+          group_dup_student_ids[group.id] << emp_student if emp_student.present?
+        elsif rep && (rep_norm.present? && emp_norm.present? && rep_norm == emp_norm)
+          skip = true
+          group_dup_names[group.id] << emp_norm
+        elsif sub_rep && (sub_rep_norm.present? && emp_norm.present? && sub_rep_norm == emp_norm)
+          skip = true
+          group_dup_names[group.id] << emp_norm
         end
 
-        # 従業員
-        (group.employees || []).each do |employee|
-          next if employee.nil?
+        next if skip
 
-          key = "#{employee.name}\t#{employee.student_id}"
-          next if used[key]
-
-          csv << [group.name, employee.name, employee.student_id]
-          used[key] = true
-        end
+        # 正常な従業員は persons に追加し、グループ内の既出に追加する
+        persons << { group_id: group.id, group: group.name, name: emp_name, student_id: emp_student, roles: [] }
+        group_seen_student_ids << emp_student if emp_student.present?
+        group_seen_normalized << emp_norm if emp_norm.present?
       end
     end
+
+    # 正規化: 氏名はスペース削除、比較は小文字化。学籍番号は存在しかつ学生のみで重複判定対象とする
+    persons.each do |p|
+      # 半角スペースと全角スペースを削除して正規化
+      p[:normalized_name] = p[:name].gsub(/[[:space:]\u3000]+/, '')
+      p[:normalized_key] = p[:normalized_name].downcase
+      if p[:student_id].present?
+        p[:is_student] = (user_category_label(p[:student_id]) == '学生')
+      else
+        p[:is_student] = false
+      end
+    end
+
+    # 学籍番号で集計（学生のみ）: student_id => [{group_id, group_name}]
+    student_map = Hash.new { |h, k| h[k] = [] }
+    persons.each do |p|
+      next unless p[:is_student] && p[:student_id].present?
+      student_map[p[:student_id]] << { group_id: p[:group_id], group: p[:group], roles: Array(p[:roles]) }
+    end
+
+    # 氏名で集計（学籍番号で既にまとめられた人物は除外）: normalized_key => [{group_id, group_name}]
+    name_map = Hash.new { |h, k| h[k] = [] }
+    persons.each do |p|
+      if p[:is_student] && p[:student_id].present? && student_map[p[:student_id]].any?
+        next
+      end
+      key = p[:normalized_key]
+      name_map[key] << { group_id: p[:group_id], group: p[:group], student_id: p[:student_id], roles: Array(p[:roles]) }
+    end
+
+    # 行は参加団体ID順で出力する
+    persons_sorted = persons.sort_by { |p| p[:group_id] || 0 }
+
+    # 参加団体ごとのメンバー一覧（グループ内重複チェック用）
+    group_map = Hash.new { |h, k| h[k] = [] }
+    persons.each do |p|
+      group_map[p[:group_id]] << p
+    end
+
+    # CSV生成（列: 参加団体名, 名前, 学籍番号, 役職, 重複, 備考）
+    bom = "\uFEFF"
+    csv_data = CSV.generate(bom.dup) do |csv|
+      column_name = %w[参加団体名 名前 学籍番号 役職 重複 備考]
+      csv << column_name
+
+      persons_sorted.each do |p|
+        current_group = p[:group]
+        current_group_id = p[:group_id]
+        name = p[:normalized_name]
+        student_id = p[:student_id].presence || ''
+        roles_str = Array(p[:roles]).join(',')
+
+        # 重複先を決定
+        duplicates = []
+        if p[:is_student] && p[:student_id].present?
+          entries = student_map[p[:student_id]] || []
+          entries.each do |e|
+            next if e[:group_id] == current_group_id
+            duplicates << e[:group]
+          end
+        else
+          entries = name_map[p[:normalized_key]] || []
+          entries.each do |e|
+            next if e[:group_id] == current_group_id
+            duplicates << e[:group]
+          end
+        end
+
+        duplicates_str = duplicates.sort_by { |gname|
+          # sort duplicates by group id: find id from persons (slow but dataset small)
+          found = persons.find { |pp| pp[:group] == gname }
+          found ? found[:group_id] : 0
+        }.join(',')
+
+        # 同一団体内で同一人物が2重登録されているかチェック（スキップされた重複を group_dup_maps で判定）
+        remark = ''
+        if p[:is_student] && p[:student_id].present?
+          if group_dup_student_ids[current_group_id].include?(p[:student_id])
+            remark = '同一団体内で2重登録（非表示で対応）'
+          end
+        else
+          if group_dup_names[current_group_id].include?(p[:normalized_key])
+            remark = '同一団体内で2重登録（非表示で対応）
+          end
+        end
+
+        csv << [current_group, name, student_id, roles_str, duplicates_str, remark]
+      end
+    end
+
     send_data(csv_data, filename: "従業員申請_#{filename_year}年度.csv")
   end
 

--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @groups = Group.where(fes_year_id: params[:fes_year_id])
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -47,7 +47,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @assign_rental_items = assign_rental_items_scope.where(groups: { fes_year_id: params[:fes_year_id] }).references(:groups)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -78,12 +78,12 @@ class Api::V1::OutputCsvController < ApplicationController
   end
 
   def output_sub_reps_csv
-    if params[:fes_year_id].to_id == 0
+    if params[:fes_year_id].to_i == 0
       @sub_reps = Group.preload(:sub_rep).map(&:sub_rep)
       filename_year = '全'
     else
       @sub_reps = Group.where(fes_year_id: params[:fes_year_id]).preload(:sub_rep).map(&:sub_rep)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -116,7 +116,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @rental_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:rental_orders).map(&:rental_orders)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -152,7 +152,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @power_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:power_orders).map(&:power_orders)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -190,7 +190,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @place_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:place_order).map(&:place_order)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -222,7 +222,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @stage_orders = Group.where(fes_year_id: params[:fes_year_id]).preload(:stage_orders).map(&:stage_orders)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -266,7 +266,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @stage_common_options = Group.where(fes_year_id: params[:fes_year_id]).preload(:stage_common_option).map(&:stage_common_option)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -297,7 +297,7 @@ class Api::V1::OutputCsvController < ApplicationController
     else
       # 開催年かつ食品団体（食販）のみ対象
       groups = Group.where(fes_year_id: params[:fes_year_id], group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
 
     # 全件の人物リストを収集（代表・副代表・従業員）
@@ -345,9 +345,16 @@ class Api::V1::OutputCsvController < ApplicationController
         emp_name = employee.name.to_s
         emp_norm = emp_name.gsub(/[[:space:]\u3000]+/, '')
         emp_student = employee.student_id
+        common_student_ids = [
+          UserDetail::STUDENT_ID_EXTERNAL,
+          UserDetail::STUDENT_ID_STAFF
+        ]
+
+        # 学籍番号による重複チェック対象か（存在し、かつ外部/スタッフなどの特別値ではない）
+        student_id_dup_check_target = emp_student.present? && !common_student_ids.include?(emp_student)
 
         # 重複判定: まず同一団体内で既に見た student_id / name と重複しているか
-        if emp_student.present? && group_seen_student_ids.include?(emp_student)
+        if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
           group_dup_student_ids[group.id] << emp_student
           next
         elsif emp_norm.present? && group_seen_normalized.include?(emp_norm)
@@ -470,7 +477,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @food_products = Group.where(fes_year_id: params[:fes_year_id]).preload(:food_products).map(&:food_products)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -504,7 +511,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @purchase_lists = FoodProduct.preload(:purchase_lists).map { |food_product| food_product.purchase_lists if food_product.group.fes_year_id == params[:fes_year_id] }
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -543,7 +550,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @groups = Group.where(fes_year_id: params[:fes_year_id]).preload(:user, :sub_rep, user: :user_detail) # 必要な関連を事前にロード
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
 
     @categories = []
@@ -632,7 +639,7 @@ class Api::V1::OutputCsvController < ApplicationController
       filename_year = '全'
     else
       @public_relations = Group.where(fes_year_id: params[:fes_year_id]).preload(:public_relation).map(&:public_relation)
-      filename_year = FesYear.find(params[:fes_year_id]).year_num
+      filename_year = FesYear.find_by(id: params[:fes_year_id])&.year_num || params[:fes_year_id].to_s
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom.dup) do |csv|
@@ -658,9 +665,14 @@ class Api::V1::OutputCsvController < ApplicationController
       @fire_equipment_orders = FireEquipmentOrder.all
       filename_year = '全'
     else
-      fes_year = FesYear.find(params[:fes_year_id])
-      @fire_equipment_orders = FireEquipmentOrder.joins(:group).where(groups: { fes_year_id: fes_year.id })
-      filename_year = fes_year.year_num
+      fes_year = FesYear.find_by(id: params[:fes_year_id])
+      if fes_year
+        @fire_equipment_orders = FireEquipmentOrder.joins(:group).where(groups: { fes_year_id: fes_year.id })
+        filename_year = fes_year.year_num
+      else
+        @fire_equipment_orders = []
+        filename_year = params[:fes_year_id].to_s
+      end
     end
     bom = "\uFEFF"
     csv_data = CSV.generate(bom) do |csv|


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2056 

# 概要
<!-- 開発内容の概要を記載 -->
- 従業員申請のcsv出力を改良

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 代表・副代表を示す役職カラムを追加
- 99999999/88888888以外の学籍番号では、学籍番号重複 or 氏名をスペース（半角・全角）を削除して正規化して重複確認。他団体であれば団体名を表記
- 同じ団体内で重複があれば（代表者・副代表者含む）備考欄に警告を表示して、重複を非表示にする  

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1440" height="759" alt="image" src="https://github.com/user-attachments/assets/754967e5-ee40-41da-9d79-33a04dca17e4" />

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 重複者が表示されているか
- [ ] すべての参加団体が重複欄に表示されるか
- [ ] 代表・副代表の役職が正しく表示されるか
- [ ] 団体内重複時に、警告文が表示されて1回しか表示されないか 

# 備考
<!-- 実装していて困った箇所・質問など -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 従業員CSVを大幅強化：氏名の正規化、学籍番号、役職（代表/副代表/その他）、重複先グループ一覧、同一団体内の注記を含めて出力する集計ロジックを追加。重複判定にSetを用い効率化。

* **Bug Fixes**
  * fes_year未取得時でもCSVファイル名をフォールバック生成して安全化。
  * 一部CSV出力の判定（ID変換等）を修正し安定性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->