### PR TITLE
fix: power_orders.item_url カラムを TEXT 型に変更して長いURLを許容する

### DIFF
--- a/api/db/migrate/20260527000001_change_item_url_to_text_in_power_orders.rb
+++ b/api/db/migrate/20260527000001_change_item_url_to_text_in_power_orders.rb
@@ -1,0 +1,9 @@
+class ChangeItemUrlToTextInPowerOrders < ActiveRecord::Migration[6.0]
+  def up
+    change_column :power_orders, :item_url, :text
+  end
+
+  def down
+    change_column :power_orders, :item_url, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -249,7 +249,7 @@ ActiveRecord::Schema.define(version: 2026_05_01_000001) do
     t.string "model"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "item_url"
+    t.text "item_url"
   end
 
   create_table "public_relations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
$(cat <<'EOF'
## 問題

Amazon の長い商品URLを `power_orders.item_url` に登録しようとすると `ActiveRecord::ValueTooLong` で 500 エラーが発生していた。

`item_url` カラムが `:string`（MySQL の VARCHAR 255）で定義されていたため、255文字を超えるURLが入らなかった。

## 対応

`item_url` カラムの型を `string` → `text`（MySQL の TEXT、最大65,535バイト）に変更するマイグレーションを追加。

## 変更ファイル

- `api/db/migrate/20260527000001_change_item_url_to_text_in_power_orders.rb` — マイグレーション追加
- `api/db/schema.rb` — スキーマ反映

## デプロイ時の注意

本番環境で `rails db:migrate` を実行すること。

https://claude.ai/code/session_015T3cWgLEt3FEzHDFZrQhy5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015T3cWgLEt3FEzHDFZrQhy5)_