### PR TITLE
Fix/inaba/2072 fix users news display

### DIFF
--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -26,7 +26,7 @@ const NewsList: FC<NewsListProps> = () => {
     return (
       <div key={item.id} className="flex flex-col gap-2">
         <span className="w-24 text-base font-medium text-font">{date}</span>
-        <span className="w-full whitespace-pre-line text-base font-medium text-font">
+        <span className="w-full break-words whitespace-pre-line text-base font-medium text-font">
           {item.body}
         </span>
       </div>

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -48,9 +48,9 @@ const NewsList: FC<NewsListProps> = () => {
       formattedDate === 'Invalid date' ? newsListTexts.none : formattedDate;
 
     return (
-      <div key={item.id} className="flex flex-col gap-2">
+      <div key={item.id} className="flex min-w-0 flex-col gap-2">
         <span className="w-24 text-base font-medium text-font">{date}</span>
-        <span className="w-full whitespace-pre-line break-words text-base font-medium text-font">
+        <span className="w-full min-w-0 whitespace-pre-line break-words text-base font-medium text-font">
           {item.body}
         </span>
       </div>
@@ -65,7 +65,12 @@ const NewsList: FC<NewsListProps> = () => {
             {newsListTexts.title}
           </div>
         </div>
-        <div className="flex max-h-96 flex-col gap-4 overflow-y-auto pr-2">
+        <div
+          className="flex max-h-96 w-full min-w-0 flex-col gap-4 overflow-y-auto pr-2"
+          role="region"
+          aria-label={newsListTexts.title}
+          tabIndex={0}
+        >
           {isLoading ? (
             <div className="text-base text-font">{newsListTexts.loading}</div>
           ) : error ? (

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -43,7 +43,7 @@ const NewsList: FC<NewsListProps> = () => {
             {newsListTexts.title}
           </div>
         </div>
-        <div className="flex flex-col gap-4 max-h-96 overflow-y-auto pr-2">
+        <div className="flex max-h-96 flex-col gap-4 overflow-y-auto pr-2">
           {isLoading ? (
             <div className="text-base text-font">{newsListTexts.loading}</div>
           ) : error ? (

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -1,7 +1,7 @@
-import { News, useGetNews } from '@/api/newsApi';
-import FormContainer from '@/components/FormContainer';
-import { format } from 'date-fns';
 import { FC } from 'react';
+import { News, useGetNews } from '@/api/newsApi';
+import { format } from 'date-fns';
+import FormContainer from '@/components/FormContainer';
 import { useNewsListTexts } from './hooks';
 
 type NewsListProps = {
@@ -43,7 +43,7 @@ const NewsList: FC<NewsListProps> = () => {
             {newsListTexts.title}
           </div>
         </div>
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 max-h-96 overflow-y-auto pr-2">
           {isLoading ? (
             <div className="text-base text-font">{newsListTexts.loading}</div>
           ) : error ? (

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -12,10 +12,12 @@ const NewsList: FC<NewsListProps> = () => {
   const { news, error, isLoading } = useGetNews();
   const newsListTexts = useNewsListTexts();
 
-  const sortedNews: News[] = [...(news ?? [])].sort((a, b) => a.id - b.id);
+  const sortedNews: News[] = [...(news ?? [])].sort((a, b) => {
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
 
   const formattedDates = sortedNews.map((item: News) => {
-    const date = new Date(item.createdAt);
+    const date = new Date(item.updatedAt);
     const formattedDate = format(date, 'yyyy/MM/dd');
     return formattedDate;
   });

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -12,9 +12,21 @@ const NewsList: FC<NewsListProps> = () => {
   const { news, error, isLoading } = useGetNews();
   const newsListTexts = useNewsListTexts();
 
-  const sortedNews: News[] = [...(news ?? [])].sort((a, b) => {
-    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-  });
+  const sortedNews: News[] = [...(news ?? [])]
+    .map((item, idx) => {
+      let ts = Date.parse(item.updatedAt);
+      if (Number.isNaN(ts)) {
+        ts = 0;
+      }
+      return { item, ts, idx };
+    })
+    .sort((a, b) => {
+      if (b.ts !== a.ts) {
+        return b.ts - a.ts;
+      }
+      return a.idx - b.idx;
+    })
+    .map(({ item }) => item);
 
   const formattedDates = sortedNews.map((item: News) => {
     const date = new Date(item.updatedAt);

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -28,14 +28,24 @@ const NewsList: FC<NewsListProps> = () => {
     })
     .map(({ item }) => item);
 
-  const formattedDates = sortedNews.map((item: News) => {
-    const date = new Date(item.updatedAt);
-    const formattedDate = format(date, 'yyyy/MM/dd');
-    return formattedDate;
+  const sortedNewsWithMeta = sortedNews.map((item: News) => {
+    let formattedDate = '';
+    try {
+      const ts = Date.parse(item.updatedAt);
+      if (Number.isNaN(ts)) {
+        formattedDate = 'Invalid date';
+      } else {
+        formattedDate = format(new Date(ts), 'yyyy/MM/dd');
+      }
+    } catch {
+      formattedDate = 'Invalid date';
+    }
+    return { item, formattedDate };
   });
 
-  const newsList = sortedNews.map((item: News, index: number) => {
-    const date = formattedDates[index] ?? newsListTexts.none;
+  const newsList = sortedNewsWithMeta.map(({ item, formattedDate }) => {
+    const date =
+      formattedDate === 'Invalid date' ? newsListTexts.none : formattedDate;
 
     return (
       <div key={item.id} className="flex flex-col gap-2">

--- a/user/src/components/NewsList/NewsList.tsx
+++ b/user/src/components/NewsList/NewsList.tsx
@@ -1,7 +1,7 @@
-import { FC } from 'react';
 import { News, useGetNews } from '@/api/newsApi';
-import { format } from 'date-fns';
 import FormContainer from '@/components/FormContainer';
+import { format } from 'date-fns';
+import { FC } from 'react';
 import { useNewsListTexts } from './hooks';
 
 type NewsListProps = {
@@ -26,7 +26,7 @@ const NewsList: FC<NewsListProps> = () => {
     return (
       <div key={item.id} className="flex flex-col gap-2">
         <span className="w-24 text-base font-medium text-font">{date}</span>
-        <span className="w-full break-words whitespace-pre-line text-base font-medium text-font">
+        <span className="w-full whitespace-pre-line break-words text-base font-medium text-font">
           {item.body}
         </span>
       </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2072 

# 概要
<!-- 開発内容の概要を記載 -->
- `user` 側トップページのお知らせ欄（`NewsList`）における、文字の見切れや表示順・表示サイズに関する複数の不具合および使い勝手を改善しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 長いテキスト（URLなど）が枠外に見切れてしまう問題を修正（`break-words` の追加）
- お知らせの表示順を「作成日順」から「最終更新日（`updatedAt`）が新しい順（降順）」に変更
- 各お知らせの表示日付を「作成日」から「最終更新日」に変更
- お知らせの件数が増えても画面全体のレイアウトが崩れないよう、お知らせ欄の高さを固定（最大 `max-h-96`）し、内部で縦スクロールできるように修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/833fe949-8f79-4ee7-b330-81c5433f8c77" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] ローカル環境でお知らせに長いURL等を含むデータを追加し、見切れずに折り返されることを確認する
- [ ] 複数のお知らせを登録・更新し、更新日が新しいものが一番上に表示されること、また表示日付が更新日になっていることを確認する
- [ ] お知らせの件数を増やした際に、枠が無限に伸びず一定の高さでスクロールバーが出現することを確認する

# 備考
<!-- 実装していて困った箇所・質問など -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ニュースを更新日時（最新順）で表示するようにしました
  * 表示日を更新日時から生成し、日付が不正な場合は表示をフォールバックします
  * ニュースリストに高さ制限と縦スクロールを追加しました
  * テキストの折り返し表示を改善し、読みやすさを向上させました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->