### PR TITLE
 fix: userPageSettingsによる申請フォーム可否制御を修正

### DIFF
--- a/.github/workflows/user-e2e.yml
+++ b/.github/workflows/user-e2e.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Create CI env files
+        run: touch webhook.env
+
       - name: Build Docker images
         run: docker compose build api user
 

--- a/.github/workflows/user-e2e.yml
+++ b/.github/workflows/user-e2e.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create CI env files
-        run: touch webhook.env
+        run: touch webhook.env api/.env
 
       - name: Build Docker images
         run: docker compose build api user

--- a/.github/workflows/user-e2e.yml
+++ b/.github/workflows/user-e2e.yml
@@ -16,7 +16,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create CI env files
-        run: touch webhook.env api/.env
+        run: |
+          touch webhook.env
+          cat > api/.env <<'EOF'
+          DEEPL_API_KEY=dummy-ci-key
+          DEEPL_API_URL=https://api-free.deepl.com/v2/translate
+          EOF
 
       - name: Build Docker images
         run: docker compose build api user

--- a/.github/workflows/user-e2e.yml
+++ b/.github/workflows/user-e2e.yml
@@ -39,9 +39,33 @@ jobs:
           done
 
       - name: Prepare Rails database
+        run: docker compose run --rm api rails db:prepare
+
+      - name: Prepare E2E database records
         run: |
-          docker compose run --rm api rails db:prepare
-          docker compose run --rm api rails db:seed_fu FIXTURE_PATH=db/fixtures/develop
+          docker compose run --rm api rails runner '
+            Role.find_or_create_by!(id: 1) { |role| role.name = "管理者" }
+            FesYear.find_or_create_by!(id: 1) { |fes_year| fes_year.year_num = 2026 }
+            GroupCategory.find_or_create_by!(id: 1) do |category|
+              category.name = "食品販売"
+              category.name_en = "Food sales"
+            end
+            User.find_or_create_by!(id: 1) do |user|
+              user.name = "E2E User"
+              user.email = "e2e@example.com"
+              user.password = "password"
+              user.password_confirmation = "password"
+              user.role_id = 1
+            end
+            Group.find_or_create_by!(id: 1) do |group|
+              group.name = "E2E group"
+              group.project_name = "E2E project"
+              group.activity = "E2E activity"
+              group.user_id = 1
+              group.group_category_id = 1
+              group.fes_year_id = 1
+            end
+          '
 
       - name: Install user dependencies
         run: docker compose run --rm user pnpm install --frozen-lockfile

--- a/.github/workflows/user-e2e.yml
+++ b/.github/workflows/user-e2e.yml
@@ -1,0 +1,69 @@
+name: User E2E
+
+on:
+  pull_request:
+    branches: ["gm3/develop"]
+
+concurrency:
+  group: user-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Playwright:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker images
+        run: docker compose build api user
+
+      - name: Start database
+        run: docker compose up -d db
+
+      - name: Wait for database
+        run: |
+          i=0
+          until docker compose exec -T db mysqladmin ping -h 127.0.0.1 -uroot -ppassword --silent; do
+            i=$((i + 1))
+            test "$i" -ge 60 && exit 1
+            sleep 1
+          done
+
+      - name: Prepare Rails database
+        run: |
+          docker compose run --rm api rails db:prepare
+          docker compose run --rm api rails db:seed_fu FIXTURE_PATH=db/fixtures/develop
+
+      - name: Install user dependencies
+        run: docker compose run --rm user pnpm install --frozen-lockfile
+
+      - name: Start Rails API
+        run: docker compose up -d api
+
+      - name: Run Playwright E2E
+        run: |
+          docker compose run --rm user sh -lc '
+            i=0
+            until node -e "require(\"http\").get(\"http://api:3000\", () => process.exit(0)).on(\"error\", () => process.exit(1))"; do
+              i=$((i + 1))
+              test "$i" -ge 60 && exit 1
+              sleep 1
+            done
+            pnpm exec playwright install chromium >/dev/null
+            PLAYWRIGHT_API_BASE_URL=http://api:3000 pnpm run test:e2e
+          '
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            user/playwright-report
+            user/test-results
+          if-no-files-found: ignore
+
+      - name: Tear down Docker Compose
+        if: always()
+        run: docker compose down -v

--- a/user/e2e/applications-user-page-settings.spec.ts
+++ b/user/e2e/applications-user-page-settings.spec.ts
@@ -67,10 +67,10 @@ const applicationButton = (page: Page, title: string) =>
   page.getByRole('button').filter({ hasText: title });
 
 test.describe('home applications user page setting behavior', () => {
-  test('treats the registration toggle as correct for applications that are not registered yet', async ({
-    page,
-  }) => {
-    for (const row of applicationsUsingRegistrationAndEditSettings) {
+  for (const row of applicationsUsingRegistrationAndEditSettings) {
+    test(`${row.title}: 未登録時は登録フラグが開いていれば受付中`, async ({
+      page,
+    }) => {
       await setupHomeApiMocks({
         page,
         userPageSettings: settingWithOnly(row.registrationSettingKey),
@@ -82,13 +82,11 @@ test.describe('home applications user page setting behavior', () => {
       await page.goto('/home');
 
       await expect(applicationButton(page, row.title)).toContainText('受付中');
-    }
-  });
+    });
 
-  test('does not use edit toggles to open applications that are not registered yet', async ({
-    page,
-  }) => {
-    for (const row of applicationsUsingRegistrationAndEditSettings) {
+    test(`${row.title}: 未登録時は編集フラグだけでは受付中にならない`, async ({
+      page,
+    }) => {
       await setupHomeApiMocks({
         page,
         userPageSettings: settingWithOnly(row.editSettingKey),
@@ -102,13 +100,11 @@ test.describe('home applications user page setting behavior', () => {
       await expect(applicationButton(page, row.title)).toContainText(
         '受付終了'
       );
-    }
-  });
+    });
 
-  test('treats the edit toggle as correct for applications that are already registered', async ({
-    page,
-  }) => {
-    for (const row of applicationsUsingRegistrationAndEditSettings) {
+    test(`${row.title}: 登録済み時は編集フラグが開いていれば受付中`, async ({
+      page,
+    }) => {
       await setupHomeApiMocks({
         page,
         userPageSettings: settingWithOnly(row.editSettingKey),
@@ -120,13 +116,11 @@ test.describe('home applications user page setting behavior', () => {
       await page.goto('/home');
 
       await expect(applicationButton(page, row.title)).toContainText('受付中');
-    }
-  });
+    });
 
-  test('does not use registration toggles to reopen applications that are already registered', async ({
-    page,
-  }) => {
-    for (const row of applicationsUsingRegistrationAndEditSettings) {
+    test(`${row.title}: 登録済み時は登録フラグだけでは受付中にならない`, async ({
+      page,
+    }) => {
       await setupHomeApiMocks({
         page,
         userPageSettings: settingWithOnly(row.registrationSettingKey),
@@ -140,10 +134,10 @@ test.describe('home applications user page setting behavior', () => {
       await expect(applicationButton(page, row.title)).toContainText(
         '受付終了'
       );
-    }
-  });
+    });
+  }
 
-  test('uses the group registration toggle before group registration and the group edit toggle after group registration', async ({
+  test('団体申請: 団体登録前は isRegistGroup、登録後は isEditGroup を参照する', async ({
     page,
   }) => {
     await setupHomeApiMocks({

--- a/user/e2e/applications-user-page-settings.spec.ts
+++ b/user/e2e/applications-user-page-settings.spec.ts
@@ -149,6 +149,7 @@ test.describe('home applications user page setting behavior', () => {
     await setupHomeApiMocks({
       page,
       userPageSettings: settingWithOnly('isRegistGroup'),
+      groupRegistered: false,
       registrationStatus: { ...unregisteredStatus, group: false },
     });
     await page.goto('/home');

--- a/user/e2e/applications-user-page-settings.spec.ts
+++ b/user/e2e/applications-user-page-settings.spec.ts
@@ -8,55 +8,58 @@ import {
   unregisteredStatus,
 } from './support/homeMocks';
 
-const applicationRows = [
+const applicationsUsingRegistrationAndEditSettings = [
   {
     title: '物品申請',
-    registrationFlag: 'addRentalOrder',
-    editFlag: 'isEditRentalOrder',
+    registrationStatusKey: 'rentalItem',
+    registrationSettingKey: 'addRentalOrder',
+    editSettingKey: 'isEditRentalOrder',
   },
   {
     title: '電力申請',
-    registrationFlag: 'addPowerOrder',
-    editFlag: 'isEditPowerOrder',
+    registrationStatusKey: 'powerOrder',
+    registrationSettingKey: 'addPowerOrder',
+    editSettingKey: 'isEditPowerOrder',
   },
   {
     title: '従業員申請',
-    registrationFlag: 'addEmployee',
-    editFlag: 'isEditEmployee',
+    registrationStatusKey: 'employee',
+    registrationSettingKey: 'addEmployee',
+    editSettingKey: 'isEditEmployee',
   },
   {
     title: '販売品申請',
-    registrationFlag: 'addFoodProduct',
-    editFlag: 'isEditFoodProduct',
+    registrationStatusKey: 'foodProduct',
+    registrationSettingKey: 'addFoodProduct',
+    editSettingKey: 'isEditFoodProduct',
   },
   {
     title: '購入品申請',
-    registrationFlag: 'addPurchaseList',
-    editFlag: 'isEditPurchaseList',
+    registrationStatusKey: 'purchaseList',
+    registrationSettingKey: 'addPurchaseList',
+    editSettingKey: 'isEditPurchaseList',
   },
   {
     title: '火気使用申請',
-    registrationFlag: 'addFireEquipmentOrder',
-    editFlag: 'isEditFireEquipmentOrder',
+    registrationStatusKey: 'fireEquipmentOrder',
+    registrationSettingKey: 'addFireEquipmentOrder',
+    editSettingKey: 'isEditFireEquipmentOrder',
   },
 ] as const;
+
+const userPageSettingKeysUnderTest =
+  applicationsUsingRegistrationAndEditSettings.flatMap((row) => [
+    row.registrationSettingKey,
+    row.editSettingKey,
+  ]);
 
 const settingWithOnly = (enabledFlag: string): UserPageSettings => ({
   ...baseSettings,
   isRegistGroup: false,
   isEditGroup: false,
-  addRentalOrder: false,
-  isEditRentalOrder: false,
-  addPowerOrder: false,
-  isEditPowerOrder: false,
-  addEmployee: false,
-  isEditEmployee: false,
-  addFoodProduct: false,
-  isEditFoodProduct: false,
-  addPurchaseList: false,
-  isEditPurchaseList: false,
-  addFireEquipmentOrder: false,
-  isEditFireEquipmentOrder: false,
+  ...Object.fromEntries(
+    userPageSettingKeysUnderTest.map((key) => [key, false])
+  ),
   [enabledFlag]: true,
 });
 
@@ -67,11 +70,14 @@ test.describe('home applications user page setting behavior', () => {
   test('treats the registration toggle as correct for applications that are not registered yet', async ({
     page,
   }) => {
-    for (const row of applicationRows) {
+    for (const row of applicationsUsingRegistrationAndEditSettings) {
       await setupHomeApiMocks({
         page,
-        userPageSettings: settingWithOnly(row.registrationFlag),
-        registrationStatus: unregisteredStatus,
+        userPageSettings: settingWithOnly(row.registrationSettingKey),
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: false,
+        },
       });
       await page.goto('/home');
 
@@ -82,11 +88,14 @@ test.describe('home applications user page setting behavior', () => {
   test('does not use edit toggles to open applications that are not registered yet', async ({
     page,
   }) => {
-    for (const row of applicationRows) {
+    for (const row of applicationsUsingRegistrationAndEditSettings) {
       await setupHomeApiMocks({
         page,
-        userPageSettings: settingWithOnly(row.editFlag),
-        registrationStatus: unregisteredStatus,
+        userPageSettings: settingWithOnly(row.editSettingKey),
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: false,
+        },
       });
       await page.goto('/home');
 
@@ -99,11 +108,14 @@ test.describe('home applications user page setting behavior', () => {
   test('treats the edit toggle as correct for applications that are already registered', async ({
     page,
   }) => {
-    for (const row of applicationRows) {
+    for (const row of applicationsUsingRegistrationAndEditSettings) {
       await setupHomeApiMocks({
         page,
-        userPageSettings: settingWithOnly(row.editFlag),
-        registrationStatus: registeredStatus,
+        userPageSettings: settingWithOnly(row.editSettingKey),
+        registrationStatus: {
+          ...unregisteredStatus,
+          [row.registrationStatusKey]: true,
+        },
       });
       await page.goto('/home');
 
@@ -114,11 +126,14 @@ test.describe('home applications user page setting behavior', () => {
   test('does not use registration toggles to reopen applications that are already registered', async ({
     page,
   }) => {
-    for (const row of applicationRows) {
+    for (const row of applicationsUsingRegistrationAndEditSettings) {
       await setupHomeApiMocks({
         page,
-        userPageSettings: settingWithOnly(row.registrationFlag),
-        registrationStatus: registeredStatus,
+        userPageSettings: settingWithOnly(row.registrationSettingKey),
+        registrationStatus: {
+          ...unregisteredStatus,
+          [row.registrationStatusKey]: true,
+        },
       });
       await page.goto('/home');
 

--- a/user/e2e/applications-user-page-settings.spec.ts
+++ b/user/e2e/applications-user-page-settings.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import {
+  type UserPageSettings,
+  baseSettings,
+  registeredStatus,
+  setupHomeApiMocks,
+  unregisteredStatus,
+} from './support/homeMocks';
+
+const applicationRows = [
+  {
+    title: '物品申請',
+    registrationFlag: 'addRentalOrder',
+    editFlag: 'isEditRentalOrder',
+  },
+  {
+    title: '電力申請',
+    registrationFlag: 'addPowerOrder',
+    editFlag: 'isEditPowerOrder',
+  },
+  {
+    title: '従業員申請',
+    registrationFlag: 'addEmployee',
+    editFlag: 'isEditEmployee',
+  },
+  {
+    title: '販売品申請',
+    registrationFlag: 'addFoodProduct',
+    editFlag: 'isEditFoodProduct',
+  },
+  {
+    title: '購入品申請',
+    registrationFlag: 'addPurchaseList',
+    editFlag: 'isEditPurchaseList',
+  },
+  {
+    title: '火気使用申請',
+    registrationFlag: 'addFireEquipmentOrder',
+    editFlag: 'isEditFireEquipmentOrder',
+  },
+] as const;
+
+const settingWithOnly = (enabledFlag: string): UserPageSettings => ({
+  ...baseSettings,
+  isRegistGroup: false,
+  isEditGroup: false,
+  addRentalOrder: false,
+  isEditRentalOrder: false,
+  addPowerOrder: false,
+  isEditPowerOrder: false,
+  addEmployee: false,
+  isEditEmployee: false,
+  addFoodProduct: false,
+  isEditFoodProduct: false,
+  addPurchaseList: false,
+  isEditPurchaseList: false,
+  addFireEquipmentOrder: false,
+  isEditFireEquipmentOrder: false,
+  [enabledFlag]: true,
+});
+
+const applicationButton = (page: Page, title: string) =>
+  page.getByRole('button').filter({ hasText: title });
+
+test.describe('home applications user page setting behavior', () => {
+  test('treats the registration toggle as correct for applications that are not registered yet', async ({
+    page,
+  }) => {
+    for (const row of applicationRows) {
+      await setupHomeApiMocks({
+        page,
+        userPageSettings: settingWithOnly(row.registrationFlag),
+        registrationStatus: unregisteredStatus,
+      });
+      await page.goto('/home');
+
+      await expect(applicationButton(page, row.title)).toContainText('受付中');
+    }
+  });
+
+  test('does not use edit toggles to open applications that are not registered yet', async ({
+    page,
+  }) => {
+    for (const row of applicationRows) {
+      await setupHomeApiMocks({
+        page,
+        userPageSettings: settingWithOnly(row.editFlag),
+        registrationStatus: unregisteredStatus,
+      });
+      await page.goto('/home');
+
+      await expect(applicationButton(page, row.title)).toContainText(
+        '受付終了'
+      );
+    }
+  });
+
+  test('treats the edit toggle as correct for applications that are already registered', async ({
+    page,
+  }) => {
+    for (const row of applicationRows) {
+      await setupHomeApiMocks({
+        page,
+        userPageSettings: settingWithOnly(row.editFlag),
+        registrationStatus: registeredStatus,
+      });
+      await page.goto('/home');
+
+      await expect(applicationButton(page, row.title)).toContainText('受付中');
+    }
+  });
+
+  test('does not use registration toggles to reopen applications that are already registered', async ({
+    page,
+  }) => {
+    for (const row of applicationRows) {
+      await setupHomeApiMocks({
+        page,
+        userPageSettings: settingWithOnly(row.registrationFlag),
+        registrationStatus: registeredStatus,
+      });
+      await page.goto('/home');
+
+      await expect(applicationButton(page, row.title)).toContainText(
+        '受付終了'
+      );
+    }
+  });
+
+  test('uses the group registration toggle before group registration and the group edit toggle after group registration', async ({
+    page,
+  }) => {
+    await setupHomeApiMocks({
+      page,
+      userPageSettings: settingWithOnly('isRegistGroup'),
+      registrationStatus: { ...unregisteredStatus, group: false },
+    });
+    await page.goto('/home');
+    await expect(applicationButton(page, '団体申請')).toContainText('受付中');
+
+    await setupHomeApiMocks({
+      page,
+      userPageSettings: settingWithOnly('isEditGroup'),
+      registrationStatus: { ...registeredStatus, group: true },
+    });
+    await page.goto('/home');
+    await expect(applicationButton(page, '団体申請')).toContainText('受付中');
+  });
+});

--- a/user/e2e/home-category-and-form-submission.spec.ts
+++ b/user/e2e/home-category-and-form-submission.spec.ts
@@ -1,0 +1,463 @@
+import { expect, test } from '@playwright/test';
+import type { Page, Request, Route } from '@playwright/test';
+import {
+  GROUP_CATEGORY,
+  apiResponse,
+  baseSettings,
+  fulfillJson,
+  normalizeApiPath,
+  registeredStatus,
+  setupHomeApiMocks,
+  unregisteredStatus,
+} from './support/homeMocks';
+
+const allApplicationTitles = [
+  '団体申請',
+  '副代表申請',
+  '会場申請',
+  '物品申請',
+  '電力申請',
+  'PR文申請',
+  '従業員申請',
+  '模擬店平面図',
+  '販売品申請',
+  '購入品申請',
+  '調理工程申請',
+  '火気使用申請',
+  'ステージ申請',
+  'ステージオプション申請',
+] as const;
+
+const categoryCases = [
+  {
+    name: '食品販売',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    visible: [
+      '団体申請',
+      '副代表申請',
+      '会場申請',
+      '物品申請',
+      '電力申請',
+      'PR文申請',
+      '従業員申請',
+      '模擬店平面図',
+      '販売品申請',
+      '購入品申請',
+      '調理工程申請',
+      '火気使用申請',
+    ],
+  },
+  {
+    name: '物品販売',
+    groupCategoryId: GROUP_CATEGORY.GOODS_SALES,
+    visible: [
+      '団体申請',
+      '副代表申請',
+      '会場申請',
+      '物品申請',
+      '電力申請',
+      'PR文申請',
+      '模擬店平面図',
+      '販売品申請',
+      '火気使用申請',
+    ],
+  },
+  {
+    name: 'ステージ',
+    groupCategoryId: GROUP_CATEGORY.STAGE,
+    visible: [
+      '団体申請',
+      '副代表申請',
+      '物品申請',
+      'ステージ申請',
+      'ステージオプション申請',
+      '電力申請',
+      'PR文申請',
+    ],
+  },
+  {
+    name: '展示・体験',
+    groupCategoryId: GROUP_CATEGORY.EXHIBITION,
+    visible: [
+      '団体申請',
+      '副代表申請',
+      '会場申請',
+      '物品申請',
+      '電力申請',
+      'PR文申請',
+      '模擬店平面図',
+      '火気使用申請',
+    ],
+  },
+  {
+    name: '研究室公開',
+    groupCategoryId: GROUP_CATEGORY.RESEARCH_LAB,
+    visible: [
+      '団体申請',
+      '副代表申請',
+      '会場申請',
+      '物品申請',
+      '電力申請',
+      'PR文申請',
+      '模擬店平面図',
+      '火気使用申請',
+    ],
+  },
+  {
+    name: '実行委員会',
+    groupCategoryId: GROUP_CATEGORY.COMMITTEE,
+    visible: [
+      '団体申請',
+      '副代表申請',
+      '会場申請',
+      '物品申請',
+      '電力申請',
+      'PR文申請',
+      '模擬店平面図',
+    ],
+  },
+] as const;
+
+const applicationButton = (page: Page, title: string) =>
+  page.getByRole('button').filter({ hasText: title });
+
+test.describe('home application category behavior', () => {
+  for (const categoryCase of categoryCases) {
+    test(`shows current application set for ${categoryCase.name}`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: categoryCase.groupCategoryId,
+        registrationStatus: registeredStatus,
+      });
+
+      await page.goto('/home');
+
+      for (const title of categoryCase.visible) {
+        await expect(applicationButton(page, title)).toBeVisible();
+      }
+
+      const hiddenTitles = allApplicationTitles.filter(
+        (title) => !(categoryCase.visible as readonly string[]).includes(title)
+      );
+      for (const title of hiddenTitles) {
+        await expect(applicationButton(page, title)).toHaveCount(0);
+      }
+    });
+  }
+});
+
+test.describe('home application form submissions', () => {
+  test('submits a new group application from the UI', async ({ page }) => {
+    let submittedUrl: URL | undefined;
+
+    await setupHomeApiMocks({
+      page,
+      groupRegistered: false,
+      registrationStatus: { ...unregisteredStatus, group: false },
+    });
+    await routeMutation(page, 'POST', '/groups', async (route, request) => {
+      submittedUrl = new URL(request.url());
+      await fulfillJson(
+        route,
+        apiResponse({
+          id: 1,
+          name: submittedUrl.searchParams.get('name'),
+          project_name: submittedUrl.searchParams.get('project_name'),
+        })
+      );
+    });
+
+    await page.goto('/home');
+    await applicationButton(page, '団体申請').click();
+    await page.getByLabel('団体名').fill('E2E 団体');
+    await page.getByLabel('企画名').fill('E2E 企画');
+    await page
+      .getByRole('radio', {
+        name: 'いいえ、国際団体（留学生団体）ではありません。',
+      })
+      .check();
+    await page.getByRole('radio', { name: 'いいえ、学内の団体です。' }).check();
+    await page.getByLabel('参加形式').selectOption('4');
+    await page.getByLabel('企画内容').fill('E2E の企画内容です。');
+    await page.getByRole('button', { name: '登録', exact: true }).click();
+
+    await expect
+      .poll(() => submittedUrl?.searchParams.get('name'))
+      .toBe('E2E 団体');
+    expect(submittedUrl?.searchParams.get('project_name')).toBe('E2E 企画');
+    expect(submittedUrl?.searchParams.get('group_category_id')).toBe('4');
+    expect(submittedUrl?.searchParams.get('activity')).toBe(
+      'E2E の企画内容です。'
+    );
+  });
+
+  test('submits a venue application from the UI', async ({ page }) => {
+    let submittedUrl: URL | undefined;
+
+    await setupHomeApiMocks({
+      page,
+      groupCategoryId: GROUP_CATEGORY.EXHIBITION,
+      registrationStatus: { ...registeredStatus, placeOrder: false },
+    });
+    await routeMutation(
+      page,
+      'POST',
+      '/place_orders',
+      async (route, request) => {
+        submittedUrl = new URL(request.url());
+        await fulfillJson(route, apiResponse({ id: 10 }));
+      }
+    );
+
+    await page.goto('/home');
+    await applicationButton(page, '会場申請').click();
+    await page.getByLabel('第一希望').selectOption('1');
+    await page.getByLabel('第二希望').selectOption('2');
+    await page.getByLabel('第三希望').selectOption('3');
+    await page.getByLabel('備考').fill('会場申請 E2E 備考');
+    await page.getByRole('button', { name: '登録', exact: true }).click();
+
+    await expect
+      .poll(() => submittedUrl?.searchParams.get('group_id'))
+      .toBe('1');
+    expect(submittedUrl?.searchParams.get('first')).toBe('1');
+    expect(submittedUrl?.searchParams.get('second')).toBe('2');
+    expect(submittedUrl?.searchParams.get('third')).toBe('3');
+    expect(submittedUrl?.searchParams.get('remark')).toBe('会場申請 E2E 備考');
+  });
+
+  test('submits a negative power application from the UI', async ({ page }) => {
+    let submittedBody: unknown;
+
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: { ...registeredStatus, powerOrder: false },
+    });
+    await routeMutation(
+      page,
+      'POST',
+      '/un_registered_groups',
+      async (route, request) => {
+        submittedBody = request.postDataJSON();
+        await fulfillJson(route, { data: { id: 20 } });
+      }
+    );
+
+    await page.goto('/home');
+    await applicationButton(page, '電力申請').click();
+    await page.getByRole('radio', { name: 'いいえ', exact: true }).check();
+    await page.getByRole('button', { name: '登録', exact: true }).click();
+
+    await expect
+      .poll(() => submittedBody)
+      .toEqual({
+        group_id: 1,
+        order_type: 1,
+      });
+  });
+
+  test('submits a fire equipment application from the UI', async ({ page }) => {
+    let submittedBody: Record<string, unknown> | undefined;
+
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: { ...registeredStatus, fireEquipmentOrder: false },
+    });
+    await routeMutation(
+      page,
+      'POST',
+      '/fire_equipment_orders',
+      async (route, request) => {
+        submittedBody = request.postDataJSON();
+        await fulfillJson(route, {
+          success: true,
+          data: { id: 30 },
+        });
+      }
+    );
+
+    await page.goto('/home');
+    await applicationButton(page, '火気使用申請').click();
+    await page.locator('input[name="火気を使用しますか？"][value="1"]').check();
+    await page.getByLabel('火気の名称').fill('E2E コンロ');
+    await page.getByLabel('火気の台数').fill('2');
+    await page.getByLabel('燃料').selectOption('1');
+    await page.getByLabel('使用用途').fill('湯煎に使用します。');
+    await page
+      .locator(
+        'input[name="火気を毎日テントから持ち帰ることができますか？"][value="1"]'
+      )
+      .check();
+    await page.getByLabel('備考').fill('毎日持ち帰ります。');
+    await page.getByRole('button', { name: '登録', exact: true }).click();
+
+    await expect.poll(() => submittedBody?.name).toBe('E2E コンロ');
+    expect(submittedBody?.group_id).toBe(1);
+    expect(submittedBody?.quantity).toBe(2);
+    expect(submittedBody?.fuel).toBe(1);
+    expect(submittedBody?.usage).toBe('湯煎に使用します。');
+    expect(submittedBody?.is_takeaway).toBe(true);
+    expect(submittedBody?.remark).toBe('毎日持ち帰ります。');
+  });
+});
+
+test.describe('home application action availability', () => {
+  test('does not show the group registration form when group registration is closed', async ({
+    page,
+  }) => {
+    await setupHomeApiMocks({
+      page,
+      groupRegistered: false,
+      registrationStatus: { ...unregisteredStatus, group: false },
+      userPageSettings: { ...baseSettings, isRegistGroup: false },
+    });
+
+    await page.goto('/home');
+    await applicationButton(page, '団体申請').click();
+
+    await expect(page.getByLabel('団体名')).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: '登録', exact: true })
+    ).toHaveCount(0);
+  });
+
+  test('shows the group edit form and submits PATCH when group editing is open', async ({
+    page,
+  }) => {
+    let submittedUrl: URL | undefined;
+
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: registeredStatus,
+      userPageSettings: { ...baseSettings, isEditGroup: true },
+    });
+    await routeMutation(page, 'PATCH', '/groups/1', async (route, request) => {
+      submittedUrl = new URL(request.url());
+      await fulfillJson(route, apiResponse({ id: 1 }));
+    });
+
+    await page.goto('/home');
+    await applicationButton(page, '団体申請').click();
+    await page.getByLabel('団体名').fill('E2E edited group');
+    await page.getByRole('button', { name: '修正', exact: true }).click();
+
+    await expect
+      .poll(() => submittedUrl?.searchParams.get('name'))
+      .toBe('E2E edited group');
+  });
+
+  test('does not show the group edit button when group editing is closed', async ({
+    page,
+  }) => {
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: registeredStatus,
+      userPageSettings: { ...baseSettings, isEditGroup: false },
+    });
+
+    await page.goto('/home');
+    await applicationButton(page, '団体申請').click();
+
+    await expect(
+      page.getByRole('button', { name: '修正', exact: true })
+    ).toHaveCount(0);
+  });
+
+  test('does not show fire equipment registration controls when registration is closed', async ({
+    page,
+  }) => {
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: { ...registeredStatus, fireEquipmentOrder: false },
+      userPageSettings: {
+        ...baseSettings,
+        addFireEquipmentOrder: false,
+        isEditFireEquipmentOrder: true,
+      },
+    });
+
+    await page.goto('/home');
+    await applicationButton(page, '火気使用申請').click();
+
+    await expect(page.getByText('火気を使用しますか？')).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: '登録', exact: true })
+    ).toHaveCount(0);
+  });
+
+  test('shows the fire equipment edit form and submits PATCH when editing is open', async ({
+    page,
+  }) => {
+    let submittedBody: Record<string, unknown> | undefined;
+
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: { ...registeredStatus, fireEquipmentOrder: true },
+      userPageSettings: {
+        ...baseSettings,
+        addFireEquipmentOrder: false,
+        isEditFireEquipmentOrder: true,
+      },
+    });
+    await routeMutation(
+      page,
+      'PATCH',
+      '/fire_equipment_orders/1',
+      async (route, request) => {
+        submittedBody = request.postDataJSON();
+        await fulfillJson(route, { success: true, data: { id: 1 } });
+      }
+    );
+
+    await page.goto('/home');
+    await applicationButton(page, '火気使用申請').click();
+    await page.getByRole('button', { name: '修正', exact: true }).click();
+    await page.getByLabel('火気の名称').fill('E2E edited burner');
+    await page.getByRole('button', { name: '修正', exact: true }).click();
+
+    await expect.poll(() => submittedBody?.name).toBe('E2E edited burner');
+    expect(submittedBody?.group_id).toBe(1);
+  });
+
+  test('does not show the fire equipment edit button when editing is closed', async ({
+    page,
+  }) => {
+    await setupHomeApiMocks({
+      page,
+      registrationStatus: { ...registeredStatus, fireEquipmentOrder: true },
+      userPageSettings: {
+        ...baseSettings,
+        addFireEquipmentOrder: true,
+        isEditFireEquipmentOrder: false,
+      },
+    });
+
+    await page.goto('/home');
+    await applicationButton(page, '火気使用申請').click();
+
+    await expect(
+      page.getByRole('button', { name: '修正', exact: true })
+    ).toHaveCount(0);
+  });
+});
+
+const routeMutation = async (
+  page: Page,
+  method: string,
+  expectedPath: string,
+  handler: (route: Route, request: Request) => Promise<void>
+) => {
+  await page.route('**/*', async (route) => {
+    const request = route.request();
+    const path = normalizeApiPath(new URL(request.url()).pathname);
+
+    if (request.method() === method && path === expectedPath) {
+      await handler(route, request);
+      return;
+    }
+
+    await route.fallback();
+  });
+};

--- a/user/e2e/home-category-and-form-submission.spec.ts
+++ b/user/e2e/home-category-and-form-submission.spec.ts
@@ -605,6 +605,80 @@ test.describe('home application action availability', () => {
   });
 });
 
+// 複数項目申請（1団体が複数件保持できる申請）は、登録済みでも
+// add設定とedit設定を独立に判定できなければならない。
+// isEdit=true, add=false のとき、既存項目の編集は可能だが
+// 新規追加はできないことを回帰的に確認する。
+const multiItemAddButtonTexts: Record<string, string> = {
+  物品申請: '物品の追加',
+  電力申請: '物品の追加',
+  従業員申請: '従業員の追加',
+  販売品申請: '販売品の追加',
+  購入品申請: '購入品を追加',
+};
+
+test.describe('home multi-item application add vs edit gating', () => {
+  const multiItemRows = applicationsUsingAddAndEditSettings.filter(
+    (row) => row.title in multiItemAddButtonTexts
+  );
+
+  for (const row of multiItemRows) {
+    const addButtonText = multiItemAddButtonTexts[row.title];
+
+    test(`hides ${row.title} add-new-item control when add is closed even though edit is open and items already exist`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: row.groupCategoryId,
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: true,
+        },
+        userPageSettings: {
+          ...baseSettings,
+          [row.addSettingKey]: false,
+          [row.editSettingKey]: true,
+        },
+      });
+
+      await page.goto('/home');
+      await applicationButton(page, row.title).click();
+      await editButton(page).first().click();
+
+      await expect(
+        page.getByRole('button', { name: addButtonText })
+      ).toHaveCount(0);
+    });
+
+    test(`shows ${row.title} add-new-item control when both add and edit settings are open`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: row.groupCategoryId,
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: true,
+        },
+        userPageSettings: {
+          ...baseSettings,
+          [row.addSettingKey]: true,
+          [row.editSettingKey]: true,
+        },
+      });
+
+      await page.goto('/home');
+      await applicationButton(page, row.title).click();
+      await editButton(page).first().click();
+
+      await expect(
+        page.getByRole('button', { name: addButtonText }).first()
+      ).toBeVisible();
+    });
+  }
+});
+
 const routeMutation = async (
   page: Page,
   method: string,

--- a/user/e2e/home-category-and-form-submission.spec.ts
+++ b/user/e2e/home-category-and-form-submission.spec.ts
@@ -341,6 +341,8 @@ test.describe('home application action availability', () => {
     await page.goto('/home');
     await applicationButton(page, '団体申請').click();
     await page.getByLabel('団体名').fill('E2E edited group');
+    await page.getByLabel('企画名').fill('E2E edited project');
+    await page.getByLabel('企画内容').fill('E2E edited activity');
     await page.getByRole('button', { name: '修正', exact: true }).click();
 
     await expect

--- a/user/e2e/home-category-and-form-submission.spec.ts
+++ b/user/e2e/home-category-and-form-submission.spec.ts
@@ -121,6 +121,68 @@ const categoryCases = [
 const applicationButton = (page: Page, title: string) =>
   page.getByRole('button').filter({ hasText: title });
 
+const applicationsUsingAddAndEditSettings = [
+  {
+    title: '物品申請',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    registrationStatusKey: 'rentalItem',
+    addSettingKey: 'addRentalOrder',
+    editSettingKey: 'isEditRentalOrder',
+  },
+  {
+    title: '電力申請',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    registrationStatusKey: 'powerOrder',
+    addSettingKey: 'addPowerOrder',
+    editSettingKey: 'isEditPowerOrder',
+  },
+  {
+    title: '従業員申請',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    registrationStatusKey: 'employee',
+    addSettingKey: 'addEmployee',
+    editSettingKey: 'isEditEmployee',
+    registrationControlText:
+      '「代表」と「副代表」以外の従業員申請を行いますか？',
+  },
+  {
+    title: '販売品申請',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    registrationStatusKey: 'foodProduct',
+    addSettingKey: 'addFoodProduct',
+    editSettingKey: 'isEditFoodProduct',
+    registrationControlText: '販売品名',
+  },
+  {
+    title: '購入品申請',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    registrationStatusKey: 'purchaseList',
+    addSettingKey: 'addPurchaseList',
+    editSettingKey: 'isEditPurchaseList',
+  },
+  {
+    title: 'ステージ申請',
+    groupCategoryId: GROUP_CATEGORY.STAGE,
+    registrationStatusKey: 'stageOrder',
+    addSettingKey: 'addStageOrder',
+    editSettingKey: 'isEditStageOrder',
+    registrationControlText: '開催日',
+  },
+  {
+    title: '火気使用申請',
+    groupCategoryId: GROUP_CATEGORY.FOOD_SALES,
+    registrationStatusKey: 'fireEquipmentOrder',
+    addSettingKey: 'addFireEquipmentOrder',
+    editSettingKey: 'isEditFireEquipmentOrder',
+  },
+] as const;
+
+const registrationButton = (page: Page) =>
+  page.getByRole('button', { name: '登録', exact: true });
+
+const editButton = (page: Page) =>
+  page.getByRole('button', { name: /修正|編集/ });
+
 test.describe('home application category behavior', () => {
   for (const categoryCase of categoryCases) {
     test(`shows current application set for ${categoryCase.name}`, async ({
@@ -304,6 +366,104 @@ test.describe('home application form submissions', () => {
 });
 
 test.describe('home application action availability', () => {
+  for (const row of applicationsUsingAddAndEditSettings) {
+    test(`does not show ${row.title} registration controls when add setting is closed`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: row.groupCategoryId,
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: false,
+        },
+        userPageSettings: {
+          ...baseSettings,
+          [row.addSettingKey]: false,
+          [row.editSettingKey]: true,
+        },
+      });
+
+      await page.goto('/home');
+      await applicationButton(page, row.title).click();
+
+      await expect(registrationButton(page)).toHaveCount(0);
+    });
+
+    test(`shows ${row.title} registration controls when add setting is open`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: row.groupCategoryId,
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: false,
+        },
+        userPageSettings: {
+          ...baseSettings,
+          [row.addSettingKey]: true,
+          [row.editSettingKey]: false,
+        },
+      });
+
+      await page.goto('/home');
+      await applicationButton(page, row.title).click();
+
+      const registrationControl =
+        'registrationControlText' in row
+          ? page.getByText(row.registrationControlText).first()
+          : registrationButton(page).first();
+      await expect(registrationControl).toBeVisible();
+    });
+
+    test(`does not show ${row.title} edit controls when edit setting is closed`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: row.groupCategoryId,
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: true,
+        },
+        userPageSettings: {
+          ...baseSettings,
+          [row.addSettingKey]: true,
+          [row.editSettingKey]: false,
+        },
+      });
+
+      await page.goto('/home');
+      await applicationButton(page, row.title).click();
+
+      await expect(editButton(page)).toHaveCount(0);
+    });
+
+    test(`shows ${row.title} edit controls when edit setting is open`, async ({
+      page,
+    }) => {
+      await setupHomeApiMocks({
+        page,
+        groupCategoryId: row.groupCategoryId,
+        registrationStatus: {
+          ...registeredStatus,
+          [row.registrationStatusKey]: true,
+        },
+        userPageSettings: {
+          ...baseSettings,
+          [row.addSettingKey]: false,
+          [row.editSettingKey]: true,
+        },
+      });
+
+      await page.goto('/home');
+      await applicationButton(page, row.title).click();
+
+      await expect(editButton(page).first()).toBeVisible();
+    });
+  }
+
   test('does not show the group registration form when group registration is closed', async ({
     page,
   }) => {

--- a/user/e2e/home-category-and-form-submission.spec.ts
+++ b/user/e2e/home-category-and-form-submission.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { Page, Request, Route } from '@playwright/test';
+import type { Locator, Page, Request, Route } from '@playwright/test';
 import {
   GROUP_CATEGORY,
   apiResponse,
@@ -128,6 +128,11 @@ const applicationsUsingAddAndEditSettings = [
     registrationStatusKey: 'rentalItem',
     addSettingKey: 'addRentalOrder',
     editSettingKey: 'isEditRentalOrder',
+    addButtonText: '物品の追加',
+    // RentItemsForm は1行ごとに <h3>物品 N</h3> を描画する。level指定のみだと
+    // 将来他の見出しが増えた際に壊れやすいため、名前を正規表現で絞り込む。
+    repeatingFieldLocator: (page: Page) =>
+      page.getByRole('heading', { name: /^物品 \d+$/ }),
   },
   {
     title: '電力申請',
@@ -135,6 +140,8 @@ const applicationsUsingAddAndEditSettings = [
     registrationStatusKey: 'powerOrder',
     addSettingKey: 'addPowerOrder',
     editSettingKey: 'isEditPowerOrder',
+    addButtonText: '物品の追加',
+    repeatingFieldLocator: (page: Page) => page.getByLabel('機器の名称'),
   },
   {
     title: '従業員申請',
@@ -144,6 +151,8 @@ const applicationsUsingAddAndEditSettings = [
     editSettingKey: 'isEditEmployee',
     registrationControlText:
       '「代表」と「副代表」以外の従業員申請を行いますか？',
+    addButtonText: '従業員の追加',
+    repeatingFieldLocator: (page: Page) => page.getByLabel('従業員名'),
   },
   {
     title: '販売品申請',
@@ -152,6 +161,8 @@ const applicationsUsingAddAndEditSettings = [
     addSettingKey: 'addFoodProduct',
     editSettingKey: 'isEditFoodProduct',
     registrationControlText: '販売品名',
+    addButtonText: '販売品の追加',
+    repeatingFieldLocator: (page: Page) => page.getByLabel('販売品名'),
   },
   {
     title: '購入品申請',
@@ -159,6 +170,10 @@ const applicationsUsingAddAndEditSettings = [
     registrationStatusKey: 'purchaseList',
     addSettingKey: 'addPurchaseList',
     editSettingKey: 'isEditPurchaseList',
+    addButtonText: '購入品を追加',
+    // PurchaseListsFormには行見出しが無いため、Selectorのラベル
+    // (FoodProductと同じ文言だが別画面なので衝突しない)で判定する。
+    repeatingFieldLocator: (page: Page) => page.getByLabel('販売品名'),
   },
   {
     title: 'ステージ申請',
@@ -176,6 +191,15 @@ const applicationsUsingAddAndEditSettings = [
     editSettingKey: 'isEditFireEquipmentOrder',
   },
 ] as const;
+
+type ApplicationRow = (typeof applicationsUsingAddAndEditSettings)[number];
+type MultiItemApplicationRow = Extract<
+  ApplicationRow,
+  { addButtonText: string }
+>;
+
+const isMultiItemRow = (row: ApplicationRow): row is MultiItemApplicationRow =>
+  'addButtonText' in row;
 
 const registrationButton = (page: Page) =>
   page.getByRole('button', { name: '登録', exact: true });
@@ -609,22 +633,12 @@ test.describe('home application action availability', () => {
 // add設定とedit設定を独立に判定できなければならない。
 // isEdit=true, add=false のとき、既存項目の編集は可能だが
 // 新規追加はできないことを回帰的に確認する。
-const multiItemAddButtonTexts: Record<string, string> = {
-  物品申請: '物品の追加',
-  電力申請: '物品の追加',
-  従業員申請: '従業員の追加',
-  販売品申請: '販売品の追加',
-  購入品申請: '購入品を追加',
-};
 
 test.describe('home multi-item application add vs edit gating', () => {
-  const multiItemRows = applicationsUsingAddAndEditSettings.filter(
-    (row) => row.title in multiItemAddButtonTexts
-  );
+  const multiItemRows =
+    applicationsUsingAddAndEditSettings.filter(isMultiItemRow);
 
   for (const row of multiItemRows) {
-    const addButtonText = multiItemAddButtonTexts[row.title];
-
     test(`hides ${row.title} add-new-item control when add is closed even though edit is open and items already exist`, async ({
       page,
     }) => {
@@ -647,11 +661,11 @@ test.describe('home multi-item application add vs edit gating', () => {
       await editButton(page).first().click();
 
       await expect(
-        page.getByRole('button', { name: addButtonText })
+        page.getByRole('button', { name: row.addButtonText })
       ).toHaveCount(0);
     });
 
-    test(`shows ${row.title} add-new-item control when both add and edit settings are open`, async ({
+    test(`shows ${row.title} add-new-item control when both add and edit settings are open, and clicking it adds a new item row`, async ({
       page,
     }) => {
       await setupHomeApiMocks({
@@ -672,9 +686,17 @@ test.describe('home multi-item application add vs edit gating', () => {
       await applicationButton(page, row.title).click();
       await editButton(page).first().click();
 
-      await expect(
-        page.getByRole('button', { name: addButtonText }).first()
-      ).toBeVisible();
+      const addButton = page
+        .getByRole('button', { name: row.addButtonText })
+        .first();
+      await expect(addButton).toBeVisible();
+
+      const repeatingField: Locator = row.repeatingFieldLocator(page);
+      const priorCount = await repeatingField.count();
+
+      await addButton.click();
+
+      await expect(repeatingField).toHaveCount(priorCount + 1);
     });
   }
 });

--- a/user/e2e/support/homeMocks.ts
+++ b/user/e2e/support/homeMocks.ts
@@ -1,0 +1,295 @@
+import type { Page, Route } from '@playwright/test';
+
+export const GROUP_ID = 1;
+export const USER_ID = 1;
+
+export const GROUP_CATEGORY = {
+  FOOD_SALES: 1,
+  GOODS_SALES: 2,
+  STAGE: 3,
+  EXHIBITION: 4,
+  RESEARCH_LAB: 5,
+  COMMITTEE: 6,
+} as const;
+
+export type UserPageSettings = Record<string, boolean | number>;
+export type RegistrationStatus = Record<string, boolean>;
+
+export const baseSettings: UserPageSettings = {
+  id: 1,
+  isRegistGroup: true,
+  isRegistFoodProduct: true,
+  isEditGroup: true,
+  isEditSubRep: true,
+  isEditPlace: true,
+  isEditPowerOrder: true,
+  isEditRentalOrder: true,
+  isEditStageOrder: true,
+  isEditEmployee: true,
+  isEditFoodProduct: true,
+  isEditPurchaseList: true,
+  addPowerOrder: true,
+  addRentalOrder: true,
+  addEmployee: true,
+  addFoodProduct: true,
+  addPurchaseList: true,
+  fesYearId: 1,
+  isEditAnnouncement: true,
+  addAnnouncement: true,
+  isEditUser: true,
+  isEditStageCommonOption: true,
+  isEditPublicRelation: true,
+  isEditVenueMap: true,
+  isEditCookingProcess: true,
+  addStageOrder: true,
+  addFireEquipmentOrder: true,
+  isEditFireEquipmentOrder: true,
+};
+
+export const unregisteredStatus: RegistrationStatus = {
+  group: true,
+  subRep: false,
+  rentalItem: false,
+  placeOrder: false,
+  stageOrder: false,
+  stageOption: false,
+  powerOrder: false,
+  employee: false,
+  venueMap: false,
+  foodProduct: false,
+  purchaseList: false,
+  cookingProcessOrder: false,
+  fireEquipmentOrder: false,
+  publicRelation: false,
+};
+
+export const registeredStatus: RegistrationStatus = Object.fromEntries(
+  Object.keys(unregisteredStatus).map((key) => [key, true])
+);
+
+export const groupCategories = [
+  { id: GROUP_CATEGORY.FOOD_SALES, name: '食品販売', nameEn: 'Food sales' },
+  { id: GROUP_CATEGORY.GOODS_SALES, name: '物品販売', nameEn: 'Goods sales' },
+  { id: GROUP_CATEGORY.STAGE, name: 'ステージ', nameEn: 'Stage' },
+  { id: GROUP_CATEGORY.EXHIBITION, name: '展示・体験', nameEn: 'Exhibition' },
+  {
+    id: GROUP_CATEGORY.RESEARCH_LAB,
+    name: '研究室公開',
+    nameEn: 'Research lab',
+  },
+  { id: GROUP_CATEGORY.COMMITTEE, name: '実行委員会', nameEn: 'Committee' },
+];
+
+export const apiResponse = (data: unknown, code = 200) => ({
+  status: { code, message: code === 200 ? 'OK' : 'Error' },
+  data,
+});
+
+type HomeApiMockOptions = {
+  page: Page;
+  userPageSettings?: UserPageSettings;
+  registrationStatus?: RegistrationStatus;
+  groupCategoryId?: number;
+  groupRegistered?: boolean;
+};
+
+export const setupHomeApiMocks = async ({
+  page,
+  userPageSettings = baseSettings,
+  registrationStatus = registeredStatus,
+  groupCategoryId = GROUP_CATEGORY.FOOD_SALES,
+  groupRegistered = true,
+}: HomeApiMockOptions) => {
+  await page.unroute('**/*');
+
+  const effectiveRegistrationStatus: RegistrationStatus = {
+    ...registrationStatus,
+    group: groupRegistered,
+  };
+
+  await page.route('**/*', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = normalizeApiPath(url.pathname);
+
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    if (path === '/api/auth/session') {
+      await fulfillJson(route, {
+        user: { name: 'E2E User', email: 'e2e@example.com' },
+        expires: '2999-12-31T00:00:00.000Z',
+        accessToken: 'token',
+        client: 'client',
+        uid: 'e2e@example.com',
+      });
+      return;
+    }
+
+    if (path === '/api/getUser') {
+      await fulfillJson(route, {
+        id: String(USER_ID),
+        name: 'E2E User',
+        email: 'e2e@example.com',
+      });
+      return;
+    }
+
+    if (path === '/news') {
+      await fulfillJson(route, []);
+      return;
+    }
+
+    if (path === '/user_page_settings') {
+      await fulfillJson(route, apiResponse(userPageSettings));
+      return;
+    }
+
+    if (path === `/groups/user/${USER_ID}`) {
+      if (!groupRegistered) {
+        await fulfillJson(route, apiResponse(null, 404));
+        return;
+      }
+
+      await fulfillJson(
+        route,
+        apiResponse({
+          id: GROUP_ID,
+          userId: USER_ID,
+          groupCategoryId,
+        })
+      );
+      return;
+    }
+
+    if (path === `/check_all_registered/${GROUP_ID}`) {
+      await fulfillJson(route, apiResponse(effectiveRegistrationStatus));
+      return;
+    }
+
+    if (path === `/groups/${GROUP_ID}`) {
+      await fulfillJson(route, apiResponse(groupResponse(groupCategoryId)));
+      return;
+    }
+
+    if (path === '/group_categories') {
+      await fulfillJson(route, apiResponse(groupCategories));
+      return;
+    }
+
+    if (path === '/api/v1/get_current_fes_dates') {
+      await fulfillJson(route, apiResponse([]));
+      return;
+    }
+
+    if (path === '/sunny/stages' || path === '/rainy/stages') {
+      await fulfillJson(route, apiResponse([]));
+      return;
+    }
+
+    if (path === '/places') {
+      await fulfillJson(route, {
+        data: [
+          place(1, '第1体育館'),
+          place(2, '講義棟前'),
+          place(3, '学生食堂前'),
+        ],
+      });
+      return;
+    }
+
+    if (path.startsWith('/place_orders/group/')) {
+      await fulfillJson(route, apiResponse(null));
+      return;
+    }
+
+    if (path.startsWith('/fire_equipment_orders/group/')) {
+      await fulfillJson(
+        route,
+        apiResponse(
+          effectiveRegistrationStatus.fireEquipmentOrder
+            ? {
+                id: 1,
+                group_id: GROUP_ID,
+                name: 'E2E コンロ',
+                quantity: 1,
+                fuel: 'gas_bottle',
+                usage: '湯煎',
+                is_takeaway: true,
+                remark: '',
+              }
+            : null
+        )
+      );
+      return;
+    }
+
+    if (path.startsWith('/un_registered_groups/group')) {
+      await fulfillJson(route, { data: [] });
+      return;
+    }
+
+    if (path.startsWith('/api/v1/get_')) {
+      await fulfillJson(route, apiResponse([]));
+      return;
+    }
+
+    if (isApplicationDataEndpoint(path)) {
+      await fulfillJson(route, apiResponse([]));
+      return;
+    }
+
+    await route.fallback();
+  });
+};
+
+export const normalizeApiPath = (pathname: string) =>
+  pathname.startsWith('/undefined/')
+    ? pathname.replace('/undefined', '')
+    : pathname;
+
+export const fulfillJson = async (route: Route, body: unknown) => {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+};
+
+const isApplicationDataEndpoint = (path: string) =>
+  [
+    '/rental_orders',
+    '/power_orders',
+    '/public_relations',
+    '/employees',
+    '/venue_maps',
+    '/food_products',
+    '/purchase_lists',
+    '/cooking_process_orders',
+    '/stage_orders',
+    '/stage_common_options',
+  ].some((endpoint) => path === endpoint || path.startsWith(`${endpoint}/`));
+
+const groupResponse = (groupCategoryId: number) => ({
+  id: GROUP_ID,
+  name: 'E2E group',
+  projectName: 'E2E project',
+  activity: 'E2E activity',
+  userId: USER_ID,
+  groupCategoryId,
+  fesYearId: 1,
+  isInternational: false,
+  committee: groupCategoryId === GROUP_CATEGORY.COMMITTEE,
+  isExternal: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const place = (id: number, name: string) => ({
+  id,
+  name,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+});

--- a/user/e2e/support/homeMocks.ts
+++ b/user/e2e/support/homeMocks.ts
@@ -309,10 +309,7 @@ export const setupHomeApiMocks = async ({
   });
 };
 
-export const normalizeApiPath = (pathname: string) =>
-  pathname.startsWith('/undefined/')
-    ? pathname.replace('/undefined', '')
-    : pathname;
+export const normalizeApiPath = (pathname: string) => pathname;
 
 export const fulfillJson = async (route: Route, body: unknown) => {
   await route.fulfill({

--- a/user/e2e/support/homeMocks.ts
+++ b/user/e2e/support/homeMocks.ts
@@ -180,12 +180,17 @@ export const setupHomeApiMocks = async ({
     }
 
     if (path === '/api/v1/get_current_fes_dates') {
-      await fulfillJson(route, apiResponse([]));
+      await fulfillJson(route, apiResponse([fesDate()]));
       return;
     }
 
     if (path === '/sunny/stages' || path === '/rainy/stages') {
-      await fulfillJson(route, apiResponse([]));
+      await fulfillJson(route, apiResponse([stageOption(path)]));
+      return;
+    }
+
+    if (path === '/shops') {
+      await fulfillJson(route, apiResponse([shop()]));
       return;
     }
 
@@ -197,6 +202,65 @@ export const setupHomeApiMocks = async ({
           place(3, '学生食堂前'),
         ],
       });
+      return;
+    }
+
+    if (path === `/rental_orders/group/${GROUP_ID}`) {
+      await fulfillJson(
+        route,
+        apiResponse(
+          effectiveRegistrationStatus.rentalItem ? [rentalOrder()] : []
+        )
+      );
+      return;
+    }
+
+    if (path === `/power_orders/group/${GROUP_ID}`) {
+      await fulfillJson(
+        route,
+        apiResponse(
+          effectiveRegistrationStatus.powerOrder ? [powerOrder()] : []
+        )
+      );
+      return;
+    }
+
+    if (path === `/employees/group/${GROUP_ID}`) {
+      await fulfillJson(
+        route,
+        apiResponse(effectiveRegistrationStatus.employee ? [employee()] : [])
+      );
+      return;
+    }
+
+    if (path === `/food_products/group/${GROUP_ID}`) {
+      await fulfillJson(
+        route,
+        apiResponse(
+          effectiveRegistrationStatus.foodProduct ||
+            effectiveRegistrationStatus.purchaseList
+            ? [foodProduct()]
+            : []
+        )
+      );
+      return;
+    }
+
+    if (path === '/purchase_lists/food_product') {
+      await fulfillJson(
+        route,
+        apiResponse(
+          effectiveRegistrationStatus.purchaseList ? [purchaseList()] : []
+        )
+      );
+      return;
+    }
+
+    if (path === '/stage_orders') {
+      await fulfillJson(
+        route,
+        apiResponse(effectiveRegistrationStatus.stageOrder ? stageOrders() : [])
+      );
       return;
     }
 
@@ -293,3 +357,116 @@ const place = (id: number, name: string) => ({
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z',
 });
+
+const rentalOrder = () => ({
+  id: 1,
+  groupId: GROUP_ID,
+  rentalItemId: 1,
+  num: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const powerOrder = () => ({
+  id: 1,
+  groupId: GROUP_ID,
+  item: 'E2E IHヒーター',
+  power: 1000,
+  manufacturer: 'E2E maker',
+  model: 'E2E model',
+  itemUrl: 'https://example.com/power',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const employee = () => ({
+  id: 1,
+  groupId: GROUP_ID,
+  name: 'E2E employee',
+  studentId: '12345678',
+  stoolTestId: '1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const foodProduct = () => ({
+  id: 1,
+  groupId: GROUP_ID,
+  name: 'E2E food',
+  isCooking: true,
+  firstDayNum: 10,
+  secondDayNum: 10,
+  isAlcohol: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const purchaseList = () => ({
+  id: 1,
+  foodProductId: 1,
+  shopId: 1,
+  fesDateId: 1,
+  items: 'E2E ingredient',
+  isFresh: false,
+  purchaseDate: '2026-06-01',
+  url: null,
+  remark: 'E2E remark',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const shop = () => ({
+  id: 1,
+  name: 'E2E shop',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const fesDate = () => ({
+  id: 1,
+  daysNum: 1,
+  date: '2026-06-01',
+  day: '月',
+});
+
+const stageOption = (path: string) => ({
+  id: path === '/sunny/stages' ? 1 : 2,
+  name: path === '/sunny/stages' ? 'E2E 晴れステージ' : 'E2E 雨ステージ',
+});
+
+const stageOrders = () => [
+  {
+    id: 1,
+    groupId: GROUP_ID,
+    fesDateId: 1,
+    isSunny: true,
+    stageFirst: 1,
+    stageSecond: 1,
+    useTimeInterval: '30',
+    prepareTimeInterval: '10',
+    cleanupTimeInterval: '10',
+    prepareStartTime: null,
+    performanceStartTime: null,
+    performanceEndTime: null,
+    cleanupEndTime: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 2,
+    groupId: GROUP_ID,
+    fesDateId: 1,
+    isSunny: false,
+    stageFirst: 2,
+    stageSecond: 2,
+    useTimeInterval: '30',
+    prepareTimeInterval: '10',
+    cleanupTimeInterval: '10',
+    prepareStartTime: null,
+    performanceStartTime: null,
+    performanceEndTime: null,
+    cleanupEndTime: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+];

--- a/user/public/locales/en/common.json
+++ b/user/public/locales/en/common.json
@@ -293,6 +293,10 @@
         "fetchTitle": "Error:",
         "fetchDescription": "Failed to load data. Please reload the page."
       },
+      "deadline": {
+        "title": "The application period has ended",
+        "description": "New equipment rental applications are not available outside the application period."
+      },
       "radio": {
         "question": "Will you submit a rental request?",
         "options": {

--- a/user/public/locales/ja/common.json
+++ b/user/public/locales/ja/common.json
@@ -293,6 +293,10 @@
         "fetchTitle": "エラー：",
         "fetchDescription": "データの取得に失敗しました。ページを再読込してください。"
       },
+      "deadline": {
+        "title": "申請期限が過ぎています",
+        "description": "物品申請の受付期間外のため、新規申請はできません。"
+      },
       "radio": {
         "question": "物品申請を行いますか？",
         "options": {

--- a/user/src/api/api.ts
+++ b/user/src/api/api.ts
@@ -17,7 +17,7 @@ export type ApiError = Error & {
   status?: number;
 };
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
 
 type FetchOptions = {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';

--- a/user/src/components/Applications/Employees/Employees.stories.tsx
+++ b/user/src/components/Applications/Employees/Employees.stories.tsx
@@ -87,7 +87,8 @@ const EmployeesWrapper: React.FC<EmployeesWrapperProps> = ({
 
       <Employees
         groupId={groupId}
-        isDeadline={isDeadline}
+        canAdd={!isDeadline}
+        canEdit={!isDeadline}
         isRegistered={isRegistered}
         mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
       />

--- a/user/src/components/Applications/Employees/Employees.tsx
+++ b/user/src/components/Applications/Employees/Employees.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { NEED_APPLICATION, RADIO_VALUE } from '@/utils/constants';
 import { FormProvider } from 'react-hook-form';
 import AccordionMenu from '@/components/AccordionMenu';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 import Button from '@/components/Button';
 import Radio from '@/components/Form/Radio';
 import FormList from '@/components/FormList';
@@ -9,7 +10,8 @@ import { EmployeeForm } from './EmployeesFrom/EmployeesForm';
 import { useEmployeesApplicationHooks } from './hooks';
 
 type EmployeesProps = {
-  isDeadline?: boolean; // 申請期限が過ぎているかどうか（true: 期限外、false: 期限内）
+  canAdd?: boolean; // 新規追加可否
+  canEdit?: boolean; // 編集可否
   isRegistered?: boolean; // 既に登録済みかどうか
   groupId: number; // 対象のグループID
   mutateCheckAllRegisteredGroups: () => void;
@@ -19,11 +21,18 @@ type EmployeesProps = {
  * 従業員申請のメインコンポーネント
  */
 export const Employees: FC<EmployeesProps> = ({
-  isDeadline,
+  canAdd,
+  canEdit,
   isRegistered,
   groupId,
   mutateCheckAllRegisteredGroups,
 }) => {
+  const { canSubmit } = resolveApplicationAccess({
+    isRegistered,
+    canAdd,
+    canEdit,
+  });
+  const isDeadline = !canSubmit;
   const employeesApplicationHook = useEmployeesApplicationHooks(
     groupId,
     isDeadline,
@@ -32,13 +41,14 @@ export const Employees: FC<EmployeesProps> = ({
   return (
     <AccordionMenu
       title={employeesApplicationHook.texts.title}
-      isEdit={!isDeadline} // 期限内（isDeadline=false）の場合のみ編集可能
+      isEdit={canSubmit} // 申請可能な場合のみ編集可能
       isExist={isRegistered} // 登録済みの場合に表示
       required={true} // 必須項目として表示
     >
       <Content
         employeesApplicationHook={employeesApplicationHook}
         isDeadline={isDeadline}
+        canAdd={!!canAdd}
       />
     </AccordionMenu>
   );
@@ -47,6 +57,7 @@ export const Employees: FC<EmployeesProps> = ({
 type ContentProps = {
   employeesApplicationHook: ReturnType<typeof useEmployeesApplicationHooks>;
   isDeadline?: boolean; // 申請期限が過ぎているかどうか（true: 期限外、false: 期限内）
+  canAdd: boolean; // 新規追加可否
 };
 /**
  * 従業員申請のコンテンツ部分
@@ -54,6 +65,7 @@ type ContentProps = {
 const Content: FC<ContentProps> = ({
   employeesApplicationHook,
   isDeadline,
+  canAdd,
 }) => {
   const { texts } = employeesApplicationHook;
 
@@ -166,16 +178,18 @@ const Content: FC<ContentProps> = ({
                 )
               )}
               <div className="flex justify-center gap-4">
-                <Button
-                  type="button"
-                  size="pc"
-                  color="main"
-                  icon="plus"
-                  variant
-                  onClick={employeesApplicationHook.form.appendEmpty}
-                >
-                  {texts.buttons.addEmployee}
-                </Button>
+                {canAdd && (
+                  <Button
+                    type="button"
+                    size="pc"
+                    color="main"
+                    icon="plus"
+                    variant
+                    onClick={employeesApplicationHook.form.appendEmpty}
+                  >
+                    {texts.buttons.addEmployee}
+                  </Button>
+                )}
                 <Button
                   size="pc"
                   color="main"

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import AccordionMenu from '@/components/AccordionMenu';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 import FormList from '@/components/FormList';
 import { FireEquipmentFormView } from './components';
 import { useFireEquipmentTexts } from './constant';
@@ -97,7 +98,11 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   const hasFireEquipmentOrder =
     fireEquipmentHooks.fireEquipment !== undefined ||
     fireEquipmentHooks.hasUnregistered;
-  const canSubmit = hasFireEquipmentOrder ? !!canEdit : !!canAdd;
+  const canSubmit = resolveApplicationAccess({
+    isRegistered,
+    canAdd,
+    canEdit,
+  }).canSubmit;
   const isExist = fireEquipmentHooks.isLoading
     ? isRegistered
     : hasFireEquipmentOrder;

--- a/user/src/components/Applications/FoodProduct/FoodProduct.stories.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProduct.stories.tsx
@@ -22,7 +22,8 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     groupId: 1,
-    isDeadline: false,
+    canAdd: true,
+    canEdit: true,
     isRegistered: false,
   },
 };

--- a/user/src/components/Applications/FoodProduct/FoodProduct.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProduct.tsx
@@ -6,12 +6,14 @@ import {
   RegisteredProduct,
 } from '@/components/Applications/FoodProduct/FoodProductForm/schema';
 import { useFoodProductHooks } from '@/components/Applications/FoodProduct/hooks';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 import FormList from '@/components/FormList/FormList';
 import { FormItem } from '@/components/FormList/type';
 
 type FoodProductProps = {
   groupId: number;
-  isDeadline: boolean | undefined;
+  canAdd: boolean | undefined;
+  canEdit: boolean | undefined;
   isRegistered: boolean | undefined;
 };
 
@@ -19,6 +21,7 @@ type ContentProps = {
   isLoading: boolean;
   hasError: boolean;
   isDeadline: boolean | undefined;
+  canAdd: boolean;
   isEditing: boolean | null;
   toEdit: () => void;
   foodProducts: RegisteredProduct[] | null;
@@ -36,6 +39,7 @@ const Content: FC<ContentProps> = ({
   isLoading,
   hasError,
   isDeadline,
+  canAdd,
   isEditing,
   toEdit,
   foodProducts,
@@ -117,6 +121,7 @@ const Content: FC<ContentProps> = ({
         addFoodProducts={addFoodProducts}
         removeFoodProduct={removeFoodProduct}
         setFoodProductsData={setFoodProductsData}
+        canAdd={canAdd}
       />
     );
   }
@@ -130,15 +135,23 @@ const Content: FC<ContentProps> = ({
       removeFoodProduct={removeFoodProduct}
       setFoodProductsData={setFoodProductsData}
       isViewMode={true}
+      canAdd={canAdd}
     />
   );
 };
 
 const FoodProduct: FC<FoodProductProps> = ({
   groupId,
-  isDeadline,
+  canAdd,
+  canEdit,
   isRegistered,
 }) => {
+  const { canSubmit } = resolveApplicationAccess({
+    isRegistered,
+    canAdd,
+    canEdit,
+  });
+  const isDeadline = !canSubmit;
   const {
     formItem,
     isEditing,
@@ -155,7 +168,7 @@ const FoodProduct: FC<FoodProductProps> = ({
   return (
     <AccordionMenu
       title={foodProductViewTexts.title}
-      isEdit={!isDeadline}
+      isEdit={canSubmit}
       isExist={isRegistered}
       required
     >
@@ -163,6 +176,7 @@ const FoodProduct: FC<FoodProductProps> = ({
         isLoading={isLoading}
         hasError={hasError}
         isDeadline={isDeadline}
+        canAdd={!!canAdd}
         isEditing={isEditing}
         toEdit={toEdit}
         foodProducts={foodProducts}

--- a/user/src/components/Applications/FoodProduct/FoodProductForm/FoodProductForm.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProductForm/FoodProductForm.tsx
@@ -31,6 +31,7 @@ type FoodProductFormProps = {
   removeFoodProduct?: (id: string) => Promise<void>;
   setFoodProductsData?: (products: ProductInput[]) => Promise<void>;
   isViewMode?: boolean;
+  canAdd?: boolean;
   mutateCheckAllRegisteredGroups?: KeyedMutator<
     ApiResponse<RegistrationStatus>
   >;
@@ -44,6 +45,7 @@ const FoodProductForm: FC<FoodProductFormProps> = ({
   removeFoodProduct,
   setFoodProductsData,
   isViewMode = false,
+  canAdd = false,
   mutateCheckAllRegisteredGroups,
 }) => {
   const {
@@ -74,15 +76,17 @@ const FoodProductForm: FC<FoodProductFormProps> = ({
       return (
         <div className="flex flex-col items-center gap-4">
           <p className="text-gray-500">{foodProductFormTexts.view.empty}</p>
-          <Button
-            type="button"
-            size="pc"
-            color="main"
-            onClick={toEdit}
-            icon="plus"
-          >
-            {foodProductFormTexts.view.addButton}
-          </Button>
+          {canAdd && (
+            <Button
+              type="button"
+              size="pc"
+              color="main"
+              onClick={toEdit}
+              icon="plus"
+            >
+              {foodProductFormTexts.view.addButton}
+            </Button>
+          )}
         </div>
       );
     }
@@ -258,18 +262,20 @@ const FoodProductForm: FC<FoodProductFormProps> = ({
               </FormContainer>
             ))}
             <div className="mx-auto flex justify-center gap-4">
-              <div className="flex w-full justify-center">
-                <Button
-                  size="pc"
-                  color="main"
-                  variant
-                  type="button"
-                  onClick={addProduct}
-                  icon="plus"
-                >
-                  {foodProductFormTexts.buttons.add}
-                </Button>
-              </div>
+              {canAdd && (
+                <div className="flex w-full justify-center">
+                  <Button
+                    size="pc"
+                    color="main"
+                    variant
+                    type="button"
+                    onClick={addProduct}
+                    icon="plus"
+                  >
+                    {foodProductFormTexts.buttons.add}
+                  </Button>
+                </div>
+              )}
               <div className="flex w-full items-center justify-center">
                 <Button
                   size="pc"

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItems.stories.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItems.stories.tsx
@@ -20,7 +20,8 @@ type Story = StoryObj<typeof RentItems>;
 
 export const Default: Story = {
   args: {
-    isDeadline: false,
+    canAdd: true,
+    canEdit: true,
     isRegistered: false,
     groupId: 1,
   },
@@ -28,7 +29,8 @@ export const Default: Story = {
 
 export const Existing: Story = {
   args: {
-    isDeadline: false,
+    canAdd: true,
+    canEdit: true,
     isRegistered: true,
     groupId: 1,
   },
@@ -36,7 +38,8 @@ export const Existing: Story = {
 
 export const Closed: Story = {
   args: {
-    isDeadline: true,
+    canAdd: false,
+    canEdit: false,
     isRegistered: false,
     groupId: 1,
   },

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
@@ -2,32 +2,41 @@ import { FC } from 'react';
 import AccordionMenu from '@/components/AccordionMenu';
 import RentItemsForm from '@/components/Applications/MultiItemForms/RentItems/RentItemsForm';
 import { useRentItemsAccordionHooks } from '@/components/Applications/MultiItemForms/RentItems/hooks';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 
 type RentItemsProps = {
-  isDeadline: boolean | undefined;
+  canAdd?: boolean;
+  canEdit?: boolean;
   isRegistered: boolean | undefined;
   groupId: number;
   groupCategoryId?: number; // 追加：団体カテゴリID
 };
 
 const RentItems: FC<RentItemsProps> = ({
-  isDeadline,
+  canAdd,
+  canEdit,
   isRegistered,
   groupId,
   groupCategoryId,
 }) => {
   const { rentItemsAccordionTexts } = useRentItemsAccordionHooks();
+  const { canSubmit } = resolveApplicationAccess({
+    isRegistered,
+    canAdd,
+    canEdit,
+  });
   return (
     <AccordionMenu
       title={rentItemsAccordionTexts.title}
-      isEdit={!isDeadline}
+      isEdit={canSubmit}
       isExist={isRegistered}
       required={true}
     >
       <RentItemsForm
         groupId={groupId}
         groupCategoryId={groupCategoryId}
-        isDeadline={!!isDeadline}
+        isDeadline={!canSubmit}
+        canAdd={!!canAdd}
       />
     </AccordionMenu>
   );

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
@@ -27,7 +27,7 @@ const RentItems: FC<RentItemsProps> = ({
       <RentItemsForm
         groupId={groupId}
         groupCategoryId={groupCategoryId}
-        isDeadline={!isDeadline}
+        isDeadline={!!isDeadline}
       />
     </AccordionMenu>
   );

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -14,12 +14,14 @@ type RentItemsFormProps = {
   groupId: number;
   groupCategoryId?: number; // 団体カテゴリID
   isDeadline: boolean;
+  canAdd: boolean;
 };
 
 const RentItemsForm: FC<RentItemsFormProps> = ({
   groupId,
   groupCategoryId,
   isDeadline,
+  canAdd,
 }) => {
   const {
     form,
@@ -428,19 +430,21 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
           )}
 
           <div className="mb-2 mt-4 flex justify-center gap-4">
-            <MultiItemFormButton
-              type="button"
-              size="pc"
-              color="add"
-              onClick={() => {
-                addItem();
-              }}
-            >
-              <div className="flex items-center">
-                <span className="mr-1 text-lg">+</span>{' '}
-                {rentItemsFormTexts.buttons.addItem}
-              </div>
-            </MultiItemFormButton>
+            {canAdd && (
+              <MultiItemFormButton
+                type="button"
+                size="pc"
+                color="add"
+                onClick={() => {
+                  addItem();
+                }}
+              >
+                <div className="flex items-center">
+                  <span className="mr-1 text-lg">+</span>{' '}
+                  {rentItemsFormTexts.buttons.addItem}
+                </div>
+              </MultiItemFormButton>
+            )}
             <Button type="submit" size="pc" color="main" isDisable={!isValid}>
               {hasExisting
                 ? rentItemsFormTexts.buttons.edit

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -79,7 +79,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
             </p>
             <p>{rentItemsFormTexts.summary.noApplication.description}</p>
           </div>
-          {isDeadline && (
+          {!isDeadline && (
             <div className="mt-4 flex w-full items-center justify-center gap-4">
               <Button
                 size="pc"
@@ -145,7 +145,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
           ))}
         </div>
 
-        {isDeadline && (
+        {!isDeadline && (
           <div className="mt-4 flex w-full items-center justify-center gap-4">
             <Button
               size="pc"
@@ -158,6 +158,21 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
             </Button>
           </div>
         )}
+      </div>
+    );
+  }
+
+  if (isDeadline) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <div className="rounded-lg border border-gray-300 bg-gray-50 p-6">
+          <h3 className="mb-2 text-lg font-semibold text-gray-800">
+            {rentItemsFormTexts.deadline.title}
+          </h3>
+          <p className="text-sm text-gray-600">
+            {rentItemsFormTexts.deadline.description}
+          </p>
+        </div>
       </div>
     );
   }

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
@@ -775,6 +775,10 @@ export const useRentItemsFormHooks = (
       contactLimit: t('applications.rentItems.notes.contactLimit'),
       contactEmail: t('applications.rentItems.notes.contactEmail'),
     },
+    deadline: {
+      title: t('applications.rentItems.deadline.title'),
+      description: t('applications.rentItems.deadline.description'),
+    },
     buttons: {
       edit: t('form.actions.edit'),
       register: t('form.actions.register'),

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import AccordionMenu from '@/components/AccordionMenu';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 import { PowerNegativeView, PowerSummaryView } from './components';
 import { PowerFormView } from './components/PowerFormView';
 import { RADIO_OPTIONS } from './constants';
@@ -8,13 +9,20 @@ import { usePowerApplication } from './hooks/usePowerApplication';
 import { usePowerDisplay } from './hooks/usePowerDisplay';
 
 type PowerProps = {
-  isDeadline?: boolean;
+  canAdd?: boolean;
+  canEdit?: boolean;
   isRegistered?: boolean | undefined;
   groupId: number;
 };
 
-const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
+const Power: FC<PowerProps> = ({ canAdd, canEdit, isRegistered, groupId }) => {
   const powerAccordionHooks = usePowerAccordionHooks();
+  const { canSubmit } = resolveApplicationAccess({
+    isRegistered,
+    canAdd,
+    canEdit,
+  });
+  const isDeadline = !canSubmit;
 
   // 電力申請のカスタムフックから状態とロジックの取得
   const {
@@ -120,7 +128,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           devices={devices}
           onEdit={prepareFormForEditing}
           onDeleteDevice={handleDeleteDevice}
-          isDeadline={!isDeadline}
+          canEdit={!!canEdit}
         />
       );
       break;
@@ -139,6 +147,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
           radioOptions={RADIO_OPTIONS}
           showForm={applyPower === 'yes'}
           onSubmit={handleFormSubmit}
+          canAdd={!!canAdd}
         />
       );
   }
@@ -146,7 +155,7 @@ const Power: FC<PowerProps> = ({ isDeadline, isRegistered, groupId }) => {
   return (
     <AccordionMenu
       title={powerAccordionHooks.powerAccordionTexts.title}
-      isEdit={!isDeadline}
+      isEdit={canSubmit}
       isExist={isRegistered}
       required={true}
     >

--- a/user/src/components/Applications/Power/components/PowerFormView.tsx
+++ b/user/src/components/Applications/Power/components/PowerFormView.tsx
@@ -18,6 +18,7 @@ export const PowerFormView: FC<PowerFormViewProps> = ({
   radioOptions,
   showForm,
   onSubmit,
+  canAdd = false,
 }) => {
   const { handleSubmit } = formMethods;
   const { powerFormViewTexts } = usePowerFormViewHooks(radioOptions);
@@ -61,16 +62,18 @@ export const PowerFormView: FC<PowerFormViewProps> = ({
             )}
             {/* 操作ボタン */}
             <div className="flex justify-center gap-4">
-              <Button
-                type="button"
-                size="pc"
-                color="main"
-                icon="plus"
-                variant
-                onClick={onAddDevice}
-              >
-                {powerFormViewTexts.actions.addDevice}
-              </Button>
+              {canAdd && (
+                <Button
+                  type="button"
+                  size="pc"
+                  color="main"
+                  icon="plus"
+                  variant
+                  onClick={onAddDevice}
+                >
+                  {powerFormViewTexts.actions.addDevice}
+                </Button>
+              )}
               <Button
                 type="submit"
                 size="pc"

--- a/user/src/components/Applications/Power/components/PowerSummaryView.tsx
+++ b/user/src/components/Applications/Power/components/PowerSummaryView.tsx
@@ -8,7 +8,7 @@ export const PowerSummaryView: FC<PowerSummaryViewProps> = ({
   devices,
   onEdit,
   onDeleteDevice,
-  isDeadline,
+  canEdit,
 }) => {
   const { createSummaryItemsForDevice, powerSummaryViewTexts } =
     usePowerSummaryViewHooks();
@@ -19,14 +19,14 @@ export const PowerSummaryView: FC<PowerSummaryViewProps> = ({
         <div key={`device-${index}`} className="mb-4">
           <FormList
             items={createSummaryItemsForDevice(device)}
-            onEdit={isDeadline ? undefined : onEdit}
-            isDelete={isDeadline}
+            onEdit={canEdit ? undefined : onEdit}
+            isDelete={canEdit}
             onDelete={device.id ? () => onDeleteDevice(device.id!) : undefined}
           />
         </div>
       ))}
 
-      {isDeadline && (
+      {canEdit && (
         <div className="flex w-full items-center justify-center gap-4">
           <Button
             size="pc"

--- a/user/src/components/Applications/Power/types.ts
+++ b/user/src/components/Applications/Power/types.ts
@@ -35,6 +35,7 @@ export interface PowerFormViewProps {
   radioOptions: RadioOption[];
   showForm: boolean;
   onSubmit: (data: PowerApplicationFormData) => Promise<void>;
+  canAdd?: boolean;
 }
 
 export interface PowerFormProps {
@@ -72,5 +73,5 @@ export interface PowerSummaryViewProps {
   devices: Device[];
   onEdit: () => void;
   onDeleteDevice: (id: number) => void;
-  isDeadline: boolean;
+  canEdit: boolean;
 }

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.stories.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.stories.tsx
@@ -42,12 +42,18 @@ export default {
         defaultValue: { summary: '1' },
       },
     },
-    isDeadline: {
+    canAdd: {
       control: 'boolean',
-      description:
-        '申請期限が過ぎているかどうかのフラグ。trueの場合、編集や新規作成が制限されます。',
+      description: '新規追加が可能かどうかのフラグ。',
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+    canEdit: {
+      control: 'boolean',
+      description: '編集・削除が可能かどうかのフラグ。',
+      table: {
+        defaultValue: { summary: 'true' },
       },
     },
     isRegistered: {
@@ -72,7 +78,8 @@ type Story = StoryObj<typeof PurchaseLists>;
 export const NewApplication: Story = {
   args: {
     groupId: 100,
-    isDeadline: false,
+    canAdd: true,
+    canEdit: true,
     isRegistered: false,
   },
   decorators: [
@@ -91,7 +98,8 @@ export const NewApplication: Story = {
 export const WithExistingData: Story = {
   args: {
     groupId: 202,
-    isDeadline: false,
+    canAdd: true,
+    canEdit: true,
     isRegistered: true,
   },
   decorators: [
@@ -137,7 +145,8 @@ export const WithExistingData: Story = {
 export const AfterDeadlineWithData: Story = {
   args: {
     groupId: 203,
-    isDeadline: true,
+    canAdd: false,
+    canEdit: false,
     isRegistered: true,
   },
   decorators: [
@@ -171,7 +180,8 @@ export const AfterDeadlineWithData: Story = {
 export const AfterDeadlineNoData: Story = {
   args: {
     groupId: 204,
-    isDeadline: true,
+    canAdd: false,
+    canEdit: false,
     isRegistered: false,
   },
   decorators: [
@@ -190,7 +200,8 @@ export const AfterDeadlineNoData: Story = {
 export const ForOtherShopValidation: Story = {
   args: {
     groupId: 205,
-    isDeadline: false,
+    canAdd: true,
+    canEdit: true,
     isRegistered: false,
   },
   decorators: [

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import AccordionMenu from '@/components/AccordionMenu/AccordionMenu';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 import Button from '@/components/Button';
 import FormList from '@/components/FormList/FormList';
 import PurchaseListsForm from './PurchaseListsForm';
@@ -13,16 +14,24 @@ import {
 import { PurchaseItem } from './schema';
 
 export type PurchaseListsProps = {
-  isDeadline: boolean;
+  canAdd: boolean | undefined;
+  canEdit: boolean | undefined;
   isRegistered?: boolean | undefined;
   groupId: number;
 };
 
 const PurchaseLists: FC<PurchaseListsProps> = ({
   groupId,
-  isDeadline,
+  canAdd,
+  canEdit,
   isRegistered: initialIsRegistered,
 }) => {
+  const { canSubmit } = resolveApplicationAccess({
+    isRegistered: initialIsRegistered,
+    canAdd,
+    canEdit,
+  });
+  const isDeadline = !canSubmit;
   const purchaseListsViewTexts = usePurchaseListsViewTexts();
   const title = purchaseListsViewTexts.title;
 
@@ -155,6 +164,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
           foodProductOptions={foodProductOptions}
           shopOptions={shopOptions}
           onFoodProductChange={handleFoodProductChange}
+          canAdd={canAdd}
         />
       </AccordionMenu>
     );

--- a/user/src/components/Applications/PurchaseLists/PurchaseListsForm/PurchaseListsForm.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseListsForm/PurchaseListsForm.tsx
@@ -33,6 +33,7 @@ export type PurchaseListsFormProps = {
   foodProductOptions: FoodProductOption[];
   shopOptions: { id: number; name: string }[];
   onFoodProductChange?: (foodProductId: number, index: number) => void;
+  canAdd?: boolean;
 };
 
 const PurchaseListsForm: FC<PurchaseListsFormProps> = ({
@@ -45,6 +46,7 @@ const PurchaseListsForm: FC<PurchaseListsFormProps> = ({
   foodProductOptions,
   shopOptions,
   onFoodProductChange,
+  canAdd = false,
 }) => {
   const purchaseListsFormTexts = usePurchaseListsFormTexts();
   // フォーム全体の値を監視
@@ -222,16 +224,18 @@ const PurchaseListsForm: FC<PurchaseListsFormProps> = ({
           );
         })}
         <div className="flex justify-center gap-3">
-          <Button
-            type="button"
-            size="pc"
-            color="main"
-            variant
-            icon="plus"
-            onClick={() => append(DEFAULT_PURCHASE_ITEM as PurchaseItem)}
-          >
-            {purchaseListsFormTexts.buttons.addItem}
-          </Button>
+          {canAdd && (
+            <Button
+              type="button"
+              size="pc"
+              color="main"
+              variant
+              icon="plus"
+              onClick={() => append(DEFAULT_PURCHASE_ITEM as PurchaseItem)}
+            >
+              {purchaseListsFormTexts.buttons.addItem}
+            </Button>
+          )}
           <Button size="pc" color="main" type="submit">
             {purchaseListsFormTexts.buttons.register}
           </Button>

--- a/user/src/components/Applications/accessControl.ts
+++ b/user/src/components/Applications/accessControl.ts
@@ -1,0 +1,23 @@
+export type ApplicationAccessInput = {
+  isRegistered?: boolean;
+  canAdd?: boolean;
+  canEdit?: boolean;
+};
+
+export type ApplicationAccess = {
+  canSubmit: boolean;
+  isDeadline: boolean;
+};
+
+export const resolveApplicationAccess = ({
+  isRegistered,
+  canAdd,
+  canEdit,
+}: ApplicationAccessInput): ApplicationAccess => {
+  const canSubmit = isRegistered ? !!canEdit : !!canAdd;
+
+  return {
+    canSubmit,
+    isDeadline: !canSubmit,
+  };
+};

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -21,6 +21,7 @@ import StageOptions from '@/components/Applications/StageOptions';
 import VenueApplications from '@/components/Applications/VenueApplication';
 import VenueMap from '@/components/Applications/VenueMap';
 import ViceRepresentative from '@/components/Applications/ViceRepresentative';
+import { resolveApplicationAccess } from '@/components/Applications/accessControl';
 import NewsList from '@/components/NewsList';
 import { useUser } from '@/hooks/useUser';
 
@@ -40,6 +41,12 @@ type CheckAllRegisteredGroups = {
   subRep?: boolean;
   fireEquipmentOrder?: boolean;
 };
+
+const isApplicationDeadline = (
+  isRegistered: boolean | undefined,
+  canAdd: boolean | undefined,
+  canEdit: boolean | undefined
+) => resolveApplicationAccess({ isRegistered, canAdd, canEdit }).isDeadline;
 
 type GroupCategoryContentProps = {
   groupCategoryId: number | undefined;
@@ -66,13 +73,21 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={!userPageSettings?.isEditRentalOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.rentalItem,
+            userPageSettings?.addRentalOrder,
+            userPageSettings?.isEditRentalOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={!userPageSettings?.isEditPowerOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.powerOrder,
+            userPageSettings?.addPowerOrder,
+            userPageSettings?.isEditPowerOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -82,7 +97,11 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <Employees
-          isDeadline={!userPageSettings?.isEditEmployee}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.employee,
+            userPageSettings?.addEmployee,
+            userPageSettings?.isEditEmployee
+          )}
           isRegistered={checkAllRegisteredGroups?.employee}
           mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           groupId={groupId}
@@ -94,11 +113,19 @@ const GroupCategoryContent = ({
         />
         <FoodProduct
           groupId={groupId}
-          isDeadline={!userPageSettings?.isEditFoodProduct}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.foodProduct,
+            userPageSettings?.addFoodProduct,
+            userPageSettings?.isEditFoodProduct
+          )}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
         />
         <PurchaseLists
-          isDeadline={!userPageSettings?.isEditPurchaseList}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.purchaseList,
+            userPageSettings?.addPurchaseList,
+            userPageSettings?.isEditPurchaseList
+          )}
           isRegistered={checkAllRegisteredGroups?.purchaseList}
           groupId={groupId}
         />
@@ -125,13 +152,21 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={!userPageSettings?.isEditRentalOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.rentalItem,
+            userPageSettings?.addRentalOrder,
+            userPageSettings?.isEditRentalOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={!userPageSettings?.isEditPowerOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.powerOrder,
+            userPageSettings?.addPowerOrder,
+            userPageSettings?.isEditPowerOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -147,7 +182,11 @@ const GroupCategoryContent = ({
         />
         <FoodProduct
           groupId={groupId}
-          isDeadline={!userPageSettings?.isEditFoodProduct}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.foodProduct,
+            userPageSettings?.addFoodProduct,
+            userPageSettings?.isEditFoodProduct
+          )}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
         />
         <FireEquipment
@@ -163,13 +202,21 @@ const GroupCategoryContent = ({
     return (
       <>
         <RentItems
-          isDeadline={!userPageSettings?.isEditRentalOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.rentalItem,
+            userPageSettings?.addRentalOrder,
+            userPageSettings?.isEditRentalOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Stage
-          isDeadline={!userPageSettings?.isEditStageOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.stageOrder,
+            userPageSettings?.addStageOrder,
+            userPageSettings?.isEditStageOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.stageOrder}
           groupId={groupId}
         />
@@ -179,7 +226,11 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <Power
-          isDeadline={!userPageSettings?.isEditPowerOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.powerOrder,
+            userPageSettings?.addPowerOrder,
+            userPageSettings?.isEditPowerOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -200,13 +251,21 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={!userPageSettings?.isEditRentalOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.rentalItem,
+            userPageSettings?.addRentalOrder,
+            userPageSettings?.isEditRentalOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={!userPageSettings?.isEditPowerOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.powerOrder,
+            userPageSettings?.addPowerOrder,
+            userPageSettings?.isEditPowerOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -238,13 +297,21 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={!userPageSettings?.isEditRentalOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.rentalItem,
+            userPageSettings?.addRentalOrder,
+            userPageSettings?.isEditRentalOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={!userPageSettings?.isEditPowerOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.powerOrder,
+            userPageSettings?.addPowerOrder,
+            userPageSettings?.isEditPowerOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -276,13 +343,21 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={!userPageSettings?.isEditRentalOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.rentalItem,
+            userPageSettings?.addRentalOrder,
+            userPageSettings?.isEditRentalOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={!userPageSettings?.isEditPowerOrder}
+          isDeadline={isApplicationDeadline(
+            checkAllRegisteredGroups?.powerOrder,
+            userPageSettings?.addPowerOrder,
+            userPageSettings?.isEditPowerOrder
+          )}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -326,7 +401,11 @@ export default function HomePage() {
       <div className="order-2 flex flex-1 flex-col lg:order-1">
         {/* Group申請がまだの場合はGroup申請のみ表示 */}
         <Group
-          isDeadline={!userPageSettings?.isRegistGroup}
+          isDeadline={isApplicationDeadline(
+            isGroupRegistered,
+            userPageSettings?.isRegistGroup,
+            userPageSettings?.isEditGroup
+          )}
           isRegistered={isGroupRegistered}
           groupId={displayGroupId}
           userId={userId || 0}

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -73,21 +73,15 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.rentalItem,
-            userPageSettings?.addRentalOrder,
-            userPageSettings?.isEditRentalOrder
-          )}
+          canAdd={userPageSettings?.addRentalOrder}
+          canEdit={userPageSettings?.isEditRentalOrder}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.powerOrder,
-            userPageSettings?.addPowerOrder,
-            userPageSettings?.isEditPowerOrder
-          )}
+          canAdd={userPageSettings?.addPowerOrder}
+          canEdit={userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -97,11 +91,8 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <Employees
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.employee,
-            userPageSettings?.addEmployee,
-            userPageSettings?.isEditEmployee
-          )}
+          canAdd={userPageSettings?.addEmployee}
+          canEdit={userPageSettings?.isEditEmployee}
           isRegistered={checkAllRegisteredGroups?.employee}
           mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           groupId={groupId}
@@ -113,19 +104,13 @@ const GroupCategoryContent = ({
         />
         <FoodProduct
           groupId={groupId}
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.foodProduct,
-            userPageSettings?.addFoodProduct,
-            userPageSettings?.isEditFoodProduct
-          )}
+          canAdd={userPageSettings?.addFoodProduct}
+          canEdit={userPageSettings?.isEditFoodProduct}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
         />
         <PurchaseLists
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.purchaseList,
-            userPageSettings?.addPurchaseList,
-            userPageSettings?.isEditPurchaseList
-          )}
+          canAdd={userPageSettings?.addPurchaseList}
+          canEdit={userPageSettings?.isEditPurchaseList}
           isRegistered={checkAllRegisteredGroups?.purchaseList}
           groupId={groupId}
         />
@@ -152,21 +137,15 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.rentalItem,
-            userPageSettings?.addRentalOrder,
-            userPageSettings?.isEditRentalOrder
-          )}
+          canAdd={userPageSettings?.addRentalOrder}
+          canEdit={userPageSettings?.isEditRentalOrder}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.powerOrder,
-            userPageSettings?.addPowerOrder,
-            userPageSettings?.isEditPowerOrder
-          )}
+          canAdd={userPageSettings?.addPowerOrder}
+          canEdit={userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -182,11 +161,8 @@ const GroupCategoryContent = ({
         />
         <FoodProduct
           groupId={groupId}
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.foodProduct,
-            userPageSettings?.addFoodProduct,
-            userPageSettings?.isEditFoodProduct
-          )}
+          canAdd={userPageSettings?.addFoodProduct}
+          canEdit={userPageSettings?.isEditFoodProduct}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
         />
         <FireEquipment
@@ -202,11 +178,8 @@ const GroupCategoryContent = ({
     return (
       <>
         <RentItems
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.rentalItem,
-            userPageSettings?.addRentalOrder,
-            userPageSettings?.isEditRentalOrder
-          )}
+          canAdd={userPageSettings?.addRentalOrder}
+          canEdit={userPageSettings?.isEditRentalOrder}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
@@ -226,11 +199,8 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <Power
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.powerOrder,
-            userPageSettings?.addPowerOrder,
-            userPageSettings?.isEditPowerOrder
-          )}
+          canAdd={userPageSettings?.addPowerOrder}
+          canEdit={userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -251,21 +221,15 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.rentalItem,
-            userPageSettings?.addRentalOrder,
-            userPageSettings?.isEditRentalOrder
-          )}
+          canAdd={userPageSettings?.addRentalOrder}
+          canEdit={userPageSettings?.isEditRentalOrder}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.powerOrder,
-            userPageSettings?.addPowerOrder,
-            userPageSettings?.isEditPowerOrder
-          )}
+          canAdd={userPageSettings?.addPowerOrder}
+          canEdit={userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -297,21 +261,15 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.rentalItem,
-            userPageSettings?.addRentalOrder,
-            userPageSettings?.isEditRentalOrder
-          )}
+          canAdd={userPageSettings?.addRentalOrder}
+          canEdit={userPageSettings?.isEditRentalOrder}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.powerOrder,
-            userPageSettings?.addPowerOrder,
-            userPageSettings?.isEditPowerOrder
-          )}
+          canAdd={userPageSettings?.addPowerOrder}
+          canEdit={userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />
@@ -343,21 +301,15 @@ const GroupCategoryContent = ({
           groupId={groupId}
         />
         <RentItems
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.rentalItem,
-            userPageSettings?.addRentalOrder,
-            userPageSettings?.isEditRentalOrder
-          )}
+          canAdd={userPageSettings?.addRentalOrder}
+          canEdit={userPageSettings?.isEditRentalOrder}
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
         />
         <Power
-          isDeadline={isApplicationDeadline(
-            checkAllRegisteredGroups?.powerOrder,
-            userPageSettings?.addPowerOrder,
-            userPageSettings?.isEditPowerOrder
-          )}
+          canAdd={userPageSettings?.addPowerOrder}
+          canEdit={userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
         />


### PR DESCRIPTION
## 対応Issue

resolve #0

## 概要

`userPageSettings` の登録系フラグと編集系フラグに応じて、申請フォームの登録・編集可否が正しく切り替わるよう修正しました。

未登録時は `add*` / `isRegistGroup`、登録済み時は `isEdit*` を参照する挙動を E2E で固定しています。

## 実装詳細

- `/home` の申請フォーム可否 E2E を追加
  - 物品申請
  - 電力申請
  - 従業員申請
  - 販売品申請
  - 購入品申請
  - ステージ申請
  - 火気使用申請
- E2E モックに登録済み申請データを追加
- 火気使用申請の可否判定を `resolveApplicationAccess` に統一
- 物品申請で受付終了時にも登録フォームが表示される問題を修正
- 物品申請の受付終了メッセージを ja/en locale に追加

## 追加修正（複数項目申請の add/edit 独立化）

上記の `resolveApplicationAccess` は `canSubmit = isRegistered ? canEdit : canAdd` という判定のため、1団体につき最大1件しか持たない申請（火気使用申請・団体申請等）では正しく機能する一方、**電力・物品(レンタル)・従業員・販売品・購入品の5申請のように1団体が複数件を保持できる申請**では、登録済みになった時点で `canAdd` が完全に無視され、`isEdit=true, add=false` でも新規追加ができてしまう不具合があった。

この5コンポーネントについて、単一の `isDeadline` propを廃止し、`canAdd` / `canEdit` を独立したpropとして末端の「+新規追加」ボタンまで配線し直した。既存項目の編集・削除は従来通り `canEdit` ベースで、変更なし。

- 対象コンポーネント: `RentItems` / `Power` / `Employees` / `FoodProduct` / `PurchaseLists`（および関連する `*Form` コンポーネント、`Power/types.ts`）
- `home/index.tsx` の呼び出し箇所を `isDeadline={isApplicationDeadline(...)}` から `canAdd={...} canEdit={...}` に変更
- `home-category-and-form-submission.spec.ts` に、上記5ドメインについて「登録済み・add=false・edit=true」で新規追加ボタンが表示されないこと、「add=true・edit=true」で表示されることを確認する回帰E2Eを追加

## 追加修正2（E2Eテストの強化）

上記の回帰E2Eは追加ボタンの表示/非表示のみを確認しており、実際にクリックして新規行が増えることまでは検証していなかった。以下を対応:

- 「add=true・edit=true」ケースを拡張し、追加ボタンを実際にクリックして、各ドメインの繰り返し要素（物品申請は行見出し、他4ドメインはフィールドのラベル）の件数が1件増えることまでassertするよう強化
- テストデータの重複を解消: 同じ日本語タイトルで二重にキーイングされていた `applicationsUsingAddAndEditSettings` と `multiItemAddButtonTexts` を統合し、`addButtonText` / `repeatingFieldLocator` を前者に直接持たせる形に整理

## 画面スクリーンショット等

なし

## テスト項目

- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec playwright test applications-user-page-settings.spec.ts home-category-and-form-submission.spec.ts --reporter=list`
  - `79 passed`（既存69件 + 複数項目申請の回帰テスト10件、うち5件は追加ボタンのクリックによる行数増加まで検証）

## 備考

マイグレーションや追加の環境変数設定はありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 申請期限切れ時に新しい期限切れメッセージを表示するようになりました。

* **Bug Fixes**
  * アプリケーション申請のアクセス制御ロジックを一元化し、各申請機能でのアクセス判定の一貫性を向上させました。
  * 物品申請の期限判定表示を改善しました。
  * 複数項目申請（電力・物品・従業員・販売品・購入品）で、編集は許可されているが新規追加が禁止されている場合に、新規追加ができてしまう不具合を修正しました。

* **Tests**
  * ホームページと各種申請機能のエンドツーエンドテストスイートを追加しました。
  * 複数項目申請の追加ボタンについて、クリックして新規行が増えることまで検証するE2Eを追加しました。

* **Chores**
  * E2Eテスト実行用のCI/CDワークフローを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
