### PR TITLE
feat: 汎用メール送信機能を追加

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -51,6 +51,8 @@ end
 group :development do
   gem 'listen', '~> 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'letter_opener'
+  gem 'letter_opener_web'
   gem 'r2-oas'
   gem 'rails-erd'
   gem 'spring'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.2.0)
     bcrypt (3.1.16)
@@ -67,6 +69,8 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     choice (0.2.0)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -130,6 +134,17 @@ GEM
     json (2.13.2)
     key_flatten (1.0.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     lint_roller (1.1.0)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -160,6 +175,7 @@ GEM
       racc
     pdfkit (0.8.5)
     prism (1.4.0)
+    public_suffix (6.0.2)
     puma (4.3.7)
       nio4r (~> 2.0)
     r2-oas (0.5.0)
@@ -308,6 +324,8 @@ DEPENDENCIES
   devise_token_auth
   dotenv-rails
   jbuilder (~> 2.7)
+  letter_opener
+  letter_opener_web
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   pdfkit

--- a/api/app/controllers/api/v1/mail_deliveries_controller.rb
+++ b/api/app/controllers/api/v1/mail_deliveries_controller.rb
@@ -11,12 +11,10 @@ class Api::V1::MailDeliveriesController < ApplicationController
     return render json: fmt(unprocessable_entity, errors), status: :unprocessable_entity if errors.present?
 
     mail = GenericMailer.plain_text_email(
-      to: recipient,
+      to: mail_delivery_params[:to],
       subject: mail_delivery_params[:subject],
       body: mail_delivery_params[:body]
     )
-    return render json: fmt(ok, dry_run_response(mail), 'Dry run mail') if dry_run?
-
     mail.deliver_now
 
     render json: fmt(ok, [], 'Delivered mail')
@@ -31,37 +29,17 @@ class Api::V1::MailDeliveriesController < ApplicationController
   end
 
   def mail_delivery_params
-    params.permit(:to, :subject, :body, :dry_run)
+    params.permit(:to, :subject, :body)
   end
 
   def validate_mail_delivery_params
     errors = []
-    errors << 'to is required' if mail_delivery_params[:to].blank? && !dry_run?
+    errors << 'to is required' if mail_delivery_params[:to].blank?
     errors << 'subject is required' if mail_delivery_params[:subject].blank?
     errors << 'body is required' if mail_delivery_params[:body].blank?
-    errors << 'to must be a single email address' if !dry_run? && multiple_recipients?
-    errors << 'to is invalid' if !dry_run? && mail_delivery_params[:to].present? && !valid_email?
+    errors << 'to must be a single email address' if multiple_recipients?
+    errors << 'to is invalid' if mail_delivery_params[:to].present? && !valid_email?
     errors
-  end
-
-  def recipient
-    return ENV.fetch('GMAIL_ADDRESS') if dry_run?
-
-    mail_delivery_params[:to]
-  end
-
-  def dry_run?
-    ActiveModel::Type::Boolean.new.cast(mail_delivery_params[:dry_run])
-  end
-
-  def dry_run_response(mail)
-    {
-      dry_run: true,
-      delivered: false,
-      to: mail.to,
-      from: mail.from,
-      subject: mail.subject
-    }
   end
 
   def multiple_recipients?

--- a/api/app/controllers/api/v1/mail_deliveries_controller.rb
+++ b/api/app/controllers/api/v1/mail_deliveries_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::MailDeliveriesController < ApplicationController
   before_action :require_admin!
 
   EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP
+  MULTIPLE_RECIPIENTS_REGEXP = /[,;]|\S+@\S+\s+\S+@\S+|<[^>]+>.*<[^>]+>/
 
   def create
     errors = validate_mail_delivery_params
@@ -37,13 +38,18 @@ class Api::V1::MailDeliveriesController < ApplicationController
     errors << 'to is required' if mail_delivery_params[:to].blank?
     errors << 'subject is required' if mail_delivery_params[:subject].blank?
     errors << 'body is required' if mail_delivery_params[:body].blank?
-    errors << 'to must be a single email address' if multiple_recipients?
-    errors << 'to is invalid' if mail_delivery_params[:to].present? && !valid_email?
+    if mail_delivery_params[:to].present?
+      if multiple_recipients?
+        errors << 'to must be a single email address'
+      elsif !valid_email?
+        errors << 'to is invalid'
+      end
+    end
     errors
   end
 
   def multiple_recipients?
-    mail_delivery_params[:to].to_s.match?(/[,;]/)
+    mail_delivery_params[:to].to_s.match?(MULTIPLE_RECIPIENTS_REGEXP)
   end
 
   def valid_email?

--- a/api/app/controllers/api/v1/mail_deliveries_controller.rb
+++ b/api/app/controllers/api/v1/mail_deliveries_controller.rb
@@ -11,10 +11,12 @@ class Api::V1::MailDeliveriesController < ApplicationController
     return render json: fmt(unprocessable_entity, errors), status: :unprocessable_entity if errors.present?
 
     mail = GenericMailer.plain_text_email(
-      to: mail_delivery_params[:to],
+      to: recipient,
       subject: mail_delivery_params[:subject],
       body: mail_delivery_params[:body]
     )
+    return render json: fmt(ok, dry_run_response(mail), 'Dry run mail') if dry_run?
+
     mail.deliver_now
 
     render json: fmt(ok, [], 'Delivered mail')
@@ -29,17 +31,37 @@ class Api::V1::MailDeliveriesController < ApplicationController
   end
 
   def mail_delivery_params
-    params.permit(:to, :subject, :body)
+    params.permit(:to, :subject, :body, :dry_run)
   end
 
   def validate_mail_delivery_params
     errors = []
-    errors << 'to is required' if mail_delivery_params[:to].blank?
+    errors << 'to is required' if mail_delivery_params[:to].blank? && !dry_run?
     errors << 'subject is required' if mail_delivery_params[:subject].blank?
     errors << 'body is required' if mail_delivery_params[:body].blank?
-    errors << 'to must be a single email address' if multiple_recipients?
-    errors << 'to is invalid' if mail_delivery_params[:to].present? && !valid_email?
+    errors << 'to must be a single email address' if !dry_run? && multiple_recipients?
+    errors << 'to is invalid' if !dry_run? && mail_delivery_params[:to].present? && !valid_email?
     errors
+  end
+
+  def recipient
+    return ENV.fetch('GMAIL_ADDRESS') if dry_run?
+
+    mail_delivery_params[:to]
+  end
+
+  def dry_run?
+    ActiveModel::Type::Boolean.new.cast(mail_delivery_params[:dry_run])
+  end
+
+  def dry_run_response(mail)
+    {
+      dry_run: true,
+      delivered: false,
+      to: mail.to,
+      from: mail.from,
+      subject: mail.subject
+    }
   end
 
   def multiple_recipients?

--- a/api/app/controllers/api/v1/mail_deliveries_controller.rb
+++ b/api/app/controllers/api/v1/mail_deliveries_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Api::V1::MailDeliveriesController < ApplicationController
+  before_action :authenticate_api_user!
+  before_action :require_admin!
+
+  EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP
+
+  def create
+    errors = validate_mail_delivery_params
+    return render json: fmt(unprocessable_entity, errors), status: :unprocessable_entity if errors.present?
+
+    mail = GenericMailer.plain_text_email(
+      to: mail_delivery_params[:to],
+      subject: mail_delivery_params[:subject],
+      body: mail_delivery_params[:body]
+    )
+    mail.deliver_now
+
+    render json: fmt(ok, [], 'Delivered mail')
+  end
+
+  private
+
+  def require_admin!
+    return if current_api_user&.role_id == 1
+
+    render json: fmt({ code: 403, message: 'Forbidden' }), status: :forbidden
+  end
+
+  def mail_delivery_params
+    params.permit(:to, :subject, :body)
+  end
+
+  def validate_mail_delivery_params
+    errors = []
+    errors << 'to is required' if mail_delivery_params[:to].blank?
+    errors << 'subject is required' if mail_delivery_params[:subject].blank?
+    errors << 'body is required' if mail_delivery_params[:body].blank?
+    errors << 'to must be a single email address' if multiple_recipients?
+    errors << 'to is invalid' if mail_delivery_params[:to].present? && !valid_email?
+    errors
+  end
+
+  def multiple_recipients?
+    mail_delivery_params[:to].to_s.match?(/[,;]/)
+  end
+
+  def valid_email?
+    mail_delivery_params[:to].to_s.match?(EMAIL_REGEXP)
+  end
+end

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: -> { ENV.fetch('GMAIL_ADDRESS') }
+  default from: -> { ENV.fetch('GMAIL_ADDRESS', 'no-reply@example.com') }
   layout 'mailer'
 end

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: -> { ENV.fetch('GMAIL_ADDRESS') }
   layout 'mailer'
 end

--- a/api/app/mailers/generic_mailer.rb
+++ b/api/app/mailers/generic_mailer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class GenericMailer < ApplicationMailer
+  def plain_text_email(to:, subject:, body:)
+    mail(to: to, subject: subject, body: body, content_type: 'text/plain')
+  end
+end

--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -37,6 +37,8 @@ module Myapp
     config.api_only = true
 
     # Default locale for PDF rendering and API responses.
+    config.time_zone = 'Tokyo'
+
     config.i18n.default_locale = :ja
     config.i18n.available_locales = %i[ja en]
     config.i18n.load_path += Rails.root.glob('config/locales/**/*.{rb,yml}')

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -30,9 +30,6 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -54,4 +54,10 @@ Rails.application.configure do
     localhost
     api
   ]
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.asset_host = 'http://localhost:3000'
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
 end

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -56,6 +56,23 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: 'group-manager.nutfes.net',
+    protocol: 'https'
+  }
+  config.action_mailer.asset_host = 'https://group-manager.nutfes.net'
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'gmail.com',
+    user_name: ENV.fetch('GMAIL_ADDRESS'),
+    password: ENV.fetch('GMAIL_APP_PASSWORD'),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+
   # 識別番号割り当て
   get 'group_identification' => 'group_identification#index'
   post 'group_identification' => 'group_identification#create'
@@ -290,6 +292,8 @@ Rails.application.routes.draw do
       get 'get_stage_rentable_items' => 'rental_items_api#get_stage_rentable_items'
 
       #---CSV出力
+      resources :mail_deliveries, only: [:create]
+
       get 'get_groups_csv/:fes_year_id' => 'output_csv#output_groups_csv'
       get 'get_sub_reps_csv/:fes_year_id' => 'output_csv#output_sub_reps_csv'
       get 'get_rental_orders_csv/:fes_year_id' => 'output_csv#output_rental_orders_csv'

--- a/api/lib/tasks/mail_delivery_test.rake
+++ b/api/lib/tasks/mail_delivery_test.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :mail do
+  desc 'Send a real test email to confirm Gmail delivery. Requires ALLOW_MAIL_DELIVERY_TEST=true.'
+  task delivery_test: :environment do
+    abort 'Set ALLOW_MAIL_DELIVERY_TEST=true to send a real test email.' unless ENV['ALLOW_MAIL_DELIVERY_TEST'] == 'true'
+
+    to = ENV.fetch('MAIL_DELIVERY_TEST_TO', ENV.fetch('GMAIL_ADDRESS'))
+    subject = ENV.fetch('MAIL_DELIVERY_TEST_SUBJECT', 'Group Manager mail delivery test')
+    body = ENV.fetch(
+      'MAIL_DELIVERY_TEST_BODY',
+      "This is a mail delivery test from #{Rails.env} at #{Time.current}."
+    )
+
+    mail = GenericMailer.plain_text_email(to: to, subject: subject, body: body)
+    mail.deliver_now
+
+    puts "Delivered test email to #{mail.to.join(', ')} from #{mail.from.join(', ')}"
+  end
+end

--- a/api/lib/tasks/mail_delivery_test.rake
+++ b/api/lib/tasks/mail_delivery_test.rake
@@ -55,11 +55,11 @@ namespace :mail do
       base_url: ENV.fetch('MAIL_DELIVERY_TEST_API_URL', 'http://api:3000')
     )
     headers = client.sign_in(
-      email: ENV.fetch('MAIL_DELIVERY_TEST_EMAIL'),
-      password: ENV.fetch('MAIL_DELIVERY_TEST_PASSWORD')
+      email: required_env('MAIL_DELIVERY_TEST_EMAIL'),
+      password: required_env('MAIL_DELIVERY_TEST_PASSWORD')
     )
 
-    to = ENV.fetch('MAIL_DELIVERY_TEST_TO', ENV.fetch('GMAIL_ADDRESS'))
+    to = required_env('MAIL_DELIVERY_TEST_TO')
     subject = ENV.fetch('MAIL_DELIVERY_TEST_SUBJECT', 'Group Manager mail delivery API test')
     body = ENV.fetch(
       'MAIL_DELIVERY_TEST_BODY',
@@ -70,5 +70,9 @@ namespace :mail do
 
     puts "Requested mail delivery API at #{ENV.fetch('MAIL_DELIVERY_TEST_API_URL', 'http://api:3000')}"
     puts "Sent test email to #{to}"
+  end
+
+  def required_env(key)
+    ENV.fetch(key) { abort "Set #{key} in .env or command env." }
   end
 end

--- a/api/lib/tasks/mail_delivery_test.rake
+++ b/api/lib/tasks/mail_delivery_test.rake
@@ -1,20 +1,74 @@
 # frozen_string_literal: true
 
-namespace :mail do
-  desc 'Send a real test email to confirm Gmail delivery. Requires ALLOW_MAIL_DELIVERY_TEST=true.'
-  task delivery_test: :environment do
-    abort 'Set ALLOW_MAIL_DELIVERY_TEST=true to send a real test email.' unless ENV['ALLOW_MAIL_DELIVERY_TEST'] == 'true'
+require 'json'
+require 'net/http'
+require 'uri'
 
-    to = ENV.fetch('MAIL_DELIVERY_TEST_TO', ENV.fetch('GMAIL_ADDRESS'))
-    subject = ENV.fetch('MAIL_DELIVERY_TEST_SUBJECT', 'Group Manager mail delivery test')
-    body = ENV.fetch(
-      'MAIL_DELIVERY_TEST_BODY',
-      "This is a mail delivery test from #{Rails.env} at #{Time.current}."
+class MailDeliveryApiTestClient
+  def initialize(base_url:)
+    @base_url = base_url.to_s
+  end
+
+  def sign_in(email:, password:)
+    response = post_json('/api/auth/sign_in', email: email, password: password)
+    raise "Sign in failed: #{response.code} #{response.body}" unless success?(response)
+
+    {
+      'access-token' => response['access-token'],
+      'client' => response['client'],
+      'uid' => response['uid']
+    }
+  end
+
+  def deliver_mail(headers:, to:, subject:, body:)
+    response = post_json('/api/v1/mail_deliveries', { to: to, subject: subject, body: body }, headers)
+    raise "Mail delivery API failed: #{response.code} #{response.body}" unless success?(response)
+
+    response
+  end
+
+  private
+
+  def post_json(path, payload, headers = {})
+    uri = URI.join("#{@base_url.chomp('/')}/", path.delete_prefix('/'))
+    request = Net::HTTP::Post.new(uri)
+    request['Content-Type'] = 'application/json'
+    headers.each { |key, value| request[key] = value }
+    request.body = payload.to_json
+
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
+  end
+
+  def success?(response)
+    response.code.to_i.between?(200, 299)
+  end
+end
+
+namespace :mail do
+  desc 'Send a real test email through the mail delivery API. Requires ALLOW_MAIL_DELIVERY_TEST=true.'
+  task delivery_test: :environment do
+    abort 'Set ALLOW_MAIL_DELIVERY_TEST=true to send a real test email through the API.' unless ENV['ALLOW_MAIL_DELIVERY_TEST'] == 'true'
+
+    client = MailDeliveryApiTestClient.new(
+      base_url: ENV.fetch('MAIL_DELIVERY_TEST_API_URL', 'http://api:3000')
+    )
+    headers = client.sign_in(
+      email: ENV.fetch('MAIL_DELIVERY_TEST_EMAIL'),
+      password: ENV.fetch('MAIL_DELIVERY_TEST_PASSWORD')
     )
 
-    mail = GenericMailer.plain_text_email(to: to, subject: subject, body: body)
-    mail.deliver_now
+    to = ENV.fetch('MAIL_DELIVERY_TEST_TO', ENV.fetch('GMAIL_ADDRESS'))
+    subject = ENV.fetch('MAIL_DELIVERY_TEST_SUBJECT', 'Group Manager mail delivery API test')
+    body = ENV.fetch(
+      'MAIL_DELIVERY_TEST_BODY',
+      "This is a mail delivery API test from #{Rails.env} at #{Time.current}."
+    )
 
-    puts "Delivered test email to #{mail.to.join(', ')} from #{mail.from.join(', ')}"
+    client.deliver_mail(headers: headers, to: to, subject: subject, body: body)
+
+    puts "Requested mail delivery API at #{ENV.fetch('MAIL_DELIVERY_TEST_API_URL', 'http://api:3000')}"
+    puts "Sent test email to #{to}"
   end
 end

--- a/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
+++ b/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Api::V1::MailDeliveriesControllerTest < ActionDispatch::IntegrationTest
+  self.fixture_table_names = []
+
+  setup do
+    ENV['GMAIL_ADDRESS'] = 'no-reply@example.com'
+    ActionMailer::Base.deliveries.clear
+    Role.create!(id: 1, name: 'admin')
+    Role.create!(id: 2, name: 'user')
+    @admin = create_user!(email: 'admin@example.com', role_id: 1)
+    @user = create_user!(email: 'user@example.com', role_id: 2)
+  end
+
+  test 'admin can deliver a mail' do
+    assert_difference -> { ActionMailer::Base.deliveries.size }, 1 do
+      post api_v1_mail_deliveries_path,
+           params: valid_params,
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :success
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal ['recipient@example.com'], mail.to
+    assert_equal 'テスト件名', mail.subject
+    assert_equal 'テスト本文', mail.body.encoded
+  end
+
+  test 'non admin cannot deliver a mail' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: valid_params,
+           headers: auth_headers(@user),
+           as: :json
+    end
+
+    assert_response :forbidden
+  end
+
+  test 'unauthenticated request cannot deliver a mail' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path, params: valid_params, as: :json
+    end
+
+    assert_response :unauthorized
+  end
+
+  test 'missing required params returns unprocessable entity' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: { to: '', subject: '', body: '' },
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test 'invalid email returns unprocessable entity' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: valid_params.merge(to: 'not-an-email'),
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test 'multiple recipients return unprocessable entity' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: valid_params.merge(to: 'one@example.com,two@example.com'),
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  private
+
+  def valid_params
+    {
+      to: 'recipient@example.com',
+      subject: 'テスト件名',
+      body: 'テスト本文'
+    }
+  end
+
+  def create_user!(email:, role_id:)
+    User.create!(
+      name: email.split('@').first,
+      email: email,
+      uid: email,
+      provider: 'email',
+      password: 'password',
+      password_confirmation: 'password',
+      role_id: role_id
+    )
+  end
+
+  def auth_headers(user)
+    user.create_new_auth_token
+  end
+end

--- a/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
+++ b/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
@@ -6,12 +6,17 @@ class Api::V1::MailDeliveriesControllerTest < ActionDispatch::IntegrationTest
   self.fixture_table_names = []
 
   setup do
+    @original_gmail_address = ENV['GMAIL_ADDRESS']
     ENV['GMAIL_ADDRESS'] = 'no-reply@example.com'
     ActionMailer::Base.deliveries.clear
     Role.create!(id: 1, name: 'admin')
     Role.create!(id: 2, name: 'user')
     @admin = create_user!(email: 'admin@example.com', role_id: 1)
     @user = create_user!(email: 'user@example.com', role_id: 2)
+  end
+
+  teardown do
+    ENV['GMAIL_ADDRESS'] = @original_gmail_address
   end
 
   test 'admin can deliver a mail' do
@@ -80,6 +85,31 @@ class Api::V1::MailDeliveriesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unprocessable_entity
+    assert_includes response.parsed_body['data'], 'to must be a single email address'
+  end
+
+  test 'space separated multiple recipients return unprocessable entity' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: valid_params.merge(to: 'one@example.com two@example.com'),
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body['data'], 'to must be a single email address'
+  end
+
+  test 'multiple display-name recipients return unprocessable entity' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: valid_params.merge(to: 'One <one@example.com> Two <two@example.com>'),
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body['data'], 'to must be a single email address'
   end
 
   private

--- a/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
+++ b/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
@@ -6,7 +6,7 @@ class Api::V1::MailDeliveriesControllerTest < ActionDispatch::IntegrationTest
   self.fixture_table_names = []
 
   setup do
-    @original_gmail_address = ENV['GMAIL_ADDRESS']
+    @original_gmail_address = ENV.fetch('GMAIL_ADDRESS', nil)
     ENV['GMAIL_ADDRESS'] = 'no-reply@example.com'
     ActionMailer::Base.deliveries.clear
     Role.create!(id: 1, name: 'admin')

--- a/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
+++ b/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
@@ -29,6 +29,24 @@ class Api::V1::MailDeliveriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'テスト本文', mail.body.encoded
   end
 
+  test 'admin can dry run a mail without delivery' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post api_v1_mail_deliveries_path,
+           params: valid_params.merge(to: nil, dry_run: true),
+           headers: auth_headers(@admin),
+           as: :json
+    end
+
+    assert_response :success
+    body = response.parsed_body
+    data = body.fetch('data')
+    assert_equal true, data.fetch('dry_run')
+    assert_equal false, data.fetch('delivered')
+    assert_equal ['no-reply@example.com'], data.fetch('to')
+    assert_equal ['no-reply@example.com'], data.fetch('from')
+    assert_equal 'テスト件名', data.fetch('subject')
+  end
+
   test 'non admin cannot deliver a mail' do
     assert_no_difference -> { ActionMailer::Base.deliveries.size } do
       post api_v1_mail_deliveries_path,

--- a/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
+++ b/api/test/controllers/api/v1/mail_deliveries_controller_test.rb
@@ -25,26 +25,9 @@ class Api::V1::MailDeliveriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     mail = ActionMailer::Base.deliveries.last
     assert_equal ['recipient@example.com'], mail.to
+    assert_equal ['no-reply@example.com'], mail.from
     assert_equal 'テスト件名', mail.subject
     assert_equal 'テスト本文', mail.body.encoded
-  end
-
-  test 'admin can dry run a mail without delivery' do
-    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
-      post api_v1_mail_deliveries_path,
-           params: valid_params.merge(to: nil, dry_run: true),
-           headers: auth_headers(@admin),
-           as: :json
-    end
-
-    assert_response :success
-    body = response.parsed_body
-    data = body.fetch('data')
-    assert_equal true, data.fetch('dry_run')
-    assert_equal false, data.fetch('delivered')
-    assert_equal ['no-reply@example.com'], data.fetch('to')
-    assert_equal ['no-reply@example.com'], data.fetch('from')
-    assert_equal 'テスト件名', data.fetch('subject')
   end
 
   test 'non admin cannot deliver a mail' do

--- a/api/test/mailers/generic_mailer_test.rb
+++ b/api/test/mailers/generic_mailer_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GenericMailerTest < ActionMailer::TestCase
+  self.fixture_table_names = []
+
+  setup do
+    ENV['GMAIL_ADDRESS'] = 'no-reply@example.com'
+  end
+
+  test 'plain_text_email builds a text email' do
+    mail = GenericMailer.plain_text_email(
+      to: 'recipient@example.com',
+      subject: 'テスト件名',
+      body: 'テスト本文'
+    )
+
+    assert_equal ['recipient@example.com'], mail.to
+    assert_equal ['no-reply@example.com'], mail.from
+    assert_equal 'テスト件名', mail.subject
+    assert_equal 'テスト本文', mail.body.encoded
+    assert_match %r{\Atext/plain}, mail.content_type
+  end
+end

--- a/api/test/mailers/generic_mailer_test.rb
+++ b/api/test/mailers/generic_mailer_test.rb
@@ -6,7 +6,12 @@ class GenericMailerTest < ActionMailer::TestCase
   self.fixture_table_names = []
 
   setup do
+    @original_gmail_address = ENV['GMAIL_ADDRESS']
     ENV['GMAIL_ADDRESS'] = 'no-reply@example.com'
+  end
+
+  teardown do
+    ENV['GMAIL_ADDRESS'] = @original_gmail_address
   end
 
   test 'plain_text_email builds a text email' do
@@ -21,5 +26,17 @@ class GenericMailerTest < ActionMailer::TestCase
     assert_equal 'テスト件名', mail.subject
     assert_equal 'テスト本文', mail.body.encoded
     assert_match %r{\Atext/plain}, mail.content_type
+  end
+
+  test 'plain_text_email uses fallback sender when gmail address is unset' do
+    ENV.delete('GMAIL_ADDRESS')
+
+    mail = GenericMailer.plain_text_email(
+      to: 'recipient@example.com',
+      subject: 'テスト件名',
+      body: 'テスト本文'
+    )
+
+    assert_equal ['no-reply@example.com'], mail.from
   end
 end

--- a/api/test/mailers/generic_mailer_test.rb
+++ b/api/test/mailers/generic_mailer_test.rb
@@ -6,7 +6,7 @@ class GenericMailerTest < ActionMailer::TestCase
   self.fixture_table_names = []
 
   setup do
-    @original_gmail_address = ENV['GMAIL_ADDRESS']
+    @original_gmail_address = ENV.fetch('GMAIL_ADDRESS', nil)
     ENV['GMAIL_ADDRESS'] = 'no-reply@example.com'
   end
 

--- a/api/test/tasks/mail_delivery_test_task_test.rb
+++ b/api/test/tasks/mail_delivery_test_task_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class MailDeliveryTestTaskTest < ActiveSupport::TestCase
+  self.fixture_table_names = []
+
+  setup do
+    Rails.application.load_tasks if Rake::Task.tasks.none? { |task| task.name == 'mail:delivery_test' }
+    Rake::Task['mail:delivery_test'].reenable
+    ActionMailer::Base.deliveries.clear
+    ENV['GMAIL_ADDRESS'] = 'sender@example.com'
+    ENV.delete('MAIL_DELIVERY_TEST_TO')
+    ENV.delete('MAIL_DELIVERY_TEST_SUBJECT')
+    ENV.delete('MAIL_DELIVERY_TEST_BODY')
+  end
+
+  teardown do
+    ENV.delete('ALLOW_MAIL_DELIVERY_TEST')
+    ENV.delete('MAIL_DELIVERY_TEST_TO')
+    ENV.delete('MAIL_DELIVERY_TEST_SUBJECT')
+    ENV.delete('MAIL_DELIVERY_TEST_BODY')
+  end
+
+  test 'does not send without explicit allow flag' do
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      assert_raises(SystemExit) { Rake::Task['mail:delivery_test'].invoke }
+    end
+  end
+
+  test 'sends to gmail address when explicitly allowed' do
+    ENV['ALLOW_MAIL_DELIVERY_TEST'] = 'true'
+
+    assert_difference -> { ActionMailer::Base.deliveries.size }, 1 do
+      Rake::Task['mail:delivery_test'].invoke
+    end
+
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal ['sender@example.com'], mail.to
+    assert_equal ['sender@example.com'], mail.from
+    assert_equal 'Group Manager mail delivery test', mail.subject
+  end
+
+  test 'can override recipient and message' do
+    ENV['ALLOW_MAIL_DELIVERY_TEST'] = 'true'
+    ENV['MAIL_DELIVERY_TEST_TO'] = 'recipient@example.com'
+    ENV['MAIL_DELIVERY_TEST_SUBJECT'] = 'custom subject'
+    ENV['MAIL_DELIVERY_TEST_BODY'] = 'custom body'
+
+    Rake::Task['mail:delivery_test'].invoke
+
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal ['recipient@example.com'], mail.to
+    assert_equal 'custom subject', mail.subject
+    assert_equal 'custom body', mail.body.encoded
+  end
+end

--- a/api/test/tasks/mail_delivery_test_task_test.rb
+++ b/api/test/tasks/mail_delivery_test_task_test.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'minitest/mock'
 require 'rake'
 
 class MailDeliveryTestTaskTest < ActiveSupport::TestCase
   self.fixture_table_names = []
 
+  FakeResponse = Struct.new(:code, :body, :headers) do
+    delegate :[], to: :headers
+  end
+
   setup do
     Rails.application.load_tasks if Rake::Task.tasks.none? { |task| task.name == 'mail:delivery_test' }
     Rake::Task['mail:delivery_test'].reenable
-    ActionMailer::Base.deliveries.clear
     ENV['GMAIL_ADDRESS'] = 'sender@example.com'
+    ENV['MAIL_DELIVERY_TEST_EMAIL'] = 'admin@example.com'
+    ENV['MAIL_DELIVERY_TEST_PASSWORD'] = 'password'
+    ENV.delete('MAIL_DELIVERY_TEST_API_URL')
     ENV.delete('MAIL_DELIVERY_TEST_TO')
     ENV.delete('MAIL_DELIVERY_TEST_SUBJECT')
     ENV.delete('MAIL_DELIVERY_TEST_BODY')
@@ -18,41 +25,91 @@ class MailDeliveryTestTaskTest < ActiveSupport::TestCase
 
   teardown do
     ENV.delete('ALLOW_MAIL_DELIVERY_TEST')
+    ENV.delete('MAIL_DELIVERY_TEST_API_URL')
+    ENV.delete('MAIL_DELIVERY_TEST_EMAIL')
+    ENV.delete('MAIL_DELIVERY_TEST_PASSWORD')
     ENV.delete('MAIL_DELIVERY_TEST_TO')
     ENV.delete('MAIL_DELIVERY_TEST_SUBJECT')
     ENV.delete('MAIL_DELIVERY_TEST_BODY')
   end
 
-  test 'does not send without explicit allow flag' do
-    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
-      assert_raises(SystemExit) { Rake::Task['mail:delivery_test'].invoke }
-    end
+  test 'does not call the API without explicit allow flag' do
+    assert_raises(SystemExit) { Rake::Task['mail:delivery_test'].invoke }
   end
 
-  test 'sends to gmail address when explicitly allowed' do
+  test 'signs in and requests mail delivery API when explicitly allowed' do
     ENV['ALLOW_MAIL_DELIVERY_TEST'] = 'true'
+    requests = []
 
-    assert_difference -> { ActionMailer::Base.deliveries.size }, 1 do
+    Net::HTTP.stub(:start, fake_http_start(requests)) do
       Rake::Task['mail:delivery_test'].invoke
     end
 
-    mail = ActionMailer::Base.deliveries.last
-    assert_equal ['sender@example.com'], mail.to
-    assert_equal ['sender@example.com'], mail.from
-    assert_equal 'Group Manager mail delivery test', mail.subject
+    request_paths = requests.map { |request| request.uri.path }
+    assert_equal ['/api/auth/sign_in', '/api/v1/mail_deliveries'], request_paths
+    assert_equal({ 'email' => 'admin@example.com', 'password' => 'password' }, JSON.parse(requests.first.body))
+    assert_equal(
+      { 'to' => 'sender@example.com', 'subject' => 'Group Manager mail delivery API test' },
+      JSON.parse(requests.second.body).slice('to', 'subject')
+    )
+    assert_equal 'token', requests.second['access-token']
+    assert_equal 'client-id', requests.second['client']
+    assert_equal 'admin@example.com', requests.second['uid']
   end
 
-  test 'can override recipient and message' do
+  test 'can override API URL recipient and message' do
     ENV['ALLOW_MAIL_DELIVERY_TEST'] = 'true'
+    ENV['MAIL_DELIVERY_TEST_API_URL'] = 'https://group-manager-api.example.com'
     ENV['MAIL_DELIVERY_TEST_TO'] = 'recipient@example.com'
     ENV['MAIL_DELIVERY_TEST_SUBJECT'] = 'custom subject'
     ENV['MAIL_DELIVERY_TEST_BODY'] = 'custom body'
+    requests = []
 
-    Rake::Task['mail:delivery_test'].invoke
+    Net::HTTP.stub(:start, fake_http_start(requests)) do
+      Rake::Task['mail:delivery_test'].invoke
+    end
 
-    mail = ActionMailer::Base.deliveries.last
-    assert_equal ['recipient@example.com'], mail.to
-    assert_equal 'custom subject', mail.subject
-    assert_equal 'custom body', mail.body.encoded
+    assert_equal 'group-manager-api.example.com', requests.first.uri.hostname
+    assert_equal true, requests.first.uri.instance_of?(URI::HTTPS)
+    assert_equal(
+      { 'to' => 'recipient@example.com', 'subject' => 'custom subject', 'body' => 'custom body' },
+      JSON.parse(requests.second.body)
+    )
+  end
+
+  private
+
+  def fake_http_start(requests)
+    lambda do |_hostname, _port, use_ssl:, &block|
+      requests.define_singleton_method(:use_ssl) { use_ssl }
+      block.call(FakeHttp.new(requests))
+    end
+  end
+
+  class FakeHttp
+    def initialize(requests)
+      @requests = requests
+    end
+
+    def request(request)
+      @requests << request
+      return sign_in_response if request.uri.path == '/api/auth/sign_in'
+
+      FakeResponse.new('200', '{"status":{"code":200}}', {})
+    end
+
+    private
+
+    def sign_in_response
+      FakeResponse.new(
+        '200',
+        '{"data":{"email":"admin@example.com"}}',
+        {
+          'access-token' => 'token',
+          'client' => 'client-id',
+          'uid' => 'admin@example.com'
+        }
+      )
+    end
   end
 end

--- a/api/test/tasks/mail_delivery_test_task_test.rb
+++ b/api/test/tasks/mail_delivery_test_task_test.rb
@@ -17,8 +17,8 @@ class MailDeliveryTestTaskTest < ActiveSupport::TestCase
     ENV['GMAIL_ADDRESS'] = 'sender@example.com'
     ENV['MAIL_DELIVERY_TEST_EMAIL'] = 'admin@example.com'
     ENV['MAIL_DELIVERY_TEST_PASSWORD'] = 'password'
+    ENV['MAIL_DELIVERY_TEST_TO'] = 'recipient@example.com'
     ENV.delete('MAIL_DELIVERY_TEST_API_URL')
-    ENV.delete('MAIL_DELIVERY_TEST_TO')
     ENV.delete('MAIL_DELIVERY_TEST_SUBJECT')
     ENV.delete('MAIL_DELIVERY_TEST_BODY')
   end
@@ -49,7 +49,7 @@ class MailDeliveryTestTaskTest < ActiveSupport::TestCase
     assert_equal ['/api/auth/sign_in', '/api/v1/mail_deliveries'], request_paths
     assert_equal({ 'email' => 'admin@example.com', 'password' => 'password' }, JSON.parse(requests.first.body))
     assert_equal(
-      { 'to' => 'sender@example.com', 'subject' => 'Group Manager mail delivery API test' },
+      { 'to' => 'recipient@example.com', 'subject' => 'Group Manager mail delivery API test' },
       JSON.parse(requests.second.body).slice('to', 'subject')
     )
     assert_equal 'token', requests.second['access-token']
@@ -60,7 +60,7 @@ class MailDeliveryTestTaskTest < ActiveSupport::TestCase
   test 'can override API URL recipient and message' do
     ENV['ALLOW_MAIL_DELIVERY_TEST'] = 'true'
     ENV['MAIL_DELIVERY_TEST_API_URL'] = 'https://group-manager-api.example.com'
-    ENV['MAIL_DELIVERY_TEST_TO'] = 'recipient@example.com'
+    ENV['MAIL_DELIVERY_TEST_TO'] = 'custom-recipient@example.com'
     ENV['MAIL_DELIVERY_TEST_SUBJECT'] = 'custom subject'
     ENV['MAIL_DELIVERY_TEST_BODY'] = 'custom body'
     requests = []
@@ -72,7 +72,7 @@ class MailDeliveryTestTaskTest < ActiveSupport::TestCase
     assert_equal 'group-manager-api.example.com', requests.first.uri.hostname
     assert_equal true, requests.first.uri.instance_of?(URI::HTTPS)
     assert_equal(
-      { 'to' => 'recipient@example.com', 'subject' => 'custom subject', 'body' => 'custom body' },
+      { 'to' => 'custom-recipient@example.com', 'subject' => 'custom subject', 'body' => 'custom body' },
       JSON.parse(requests.second.body)
     )
   end

--- a/compose.yml
+++ b/compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: "API"
     volumes: [./api:/myapp]
     ports: ["3000:3000"]
-    env_file: [webhook.env, ./api/.env]
+    env_file: [webhook.env, .env]
     depends_on: [db]
 
   admin_view:

--- a/compose.yml
+++ b/compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: "API"
     volumes: [./api:/myapp]
     ports: ["3000:3000"]
-    env_file: [webhook.env, .env]
+    env_file: [webhook.env, .env, ./api/.env]
     environment:
       - TZ=Asia/Tokyo
     depends_on: [db]

--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,8 @@ services:
     volumes: [./api:/myapp]
     ports: ["3000:3000"]
     env_file: [webhook.env, .env]
+    environment:
+      - TZ=Asia/Tokyo
     depends_on: [db]
 
   admin_view:

--- a/compose.yml
+++ b/compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: "API"
     volumes: [./api:/myapp]
     ports: ["3000:3000"]
-    env_file: [webhook.env, .env, ./api/.env]
+    env_file: [webhook.env, ./api/.env]
     environment:
       - TZ=Asia/Tokyo
     depends_on: [db]

--- a/docs/メール送信テスト手順.md
+++ b/docs/メール送信テスト手順.md
@@ -13,6 +13,31 @@ GMAIL_APP_PASSWORD=Gmailアプリパスワード
 
 管理者ログイン用のメールアドレスとパスワードは、`.env` ではなく実行時に指定します。
 
+## ローカルで letter_opener を使って確認する
+
+先に API を起動します。
+
+```bash
+docker compose up api
+```
+
+別ターミナルで、以下を実行します。
+
+```bash
+docker compose run --rm api bash -lc '
+bundle exec rails runner "
+GenericMailer.plain_text_email(
+  to: \"受信確認したいメールアドレス\",
+  subject: \"letter_opener テスト\",
+  body: \"ローカルテストです\"
+).deliver_now
+"'
+```
+
+実行後に `http://localhost:3000/letter_opener` を開くとメールの内容が確認できます。
+
+実際には送信されず、ブラウザ上で内容を確認するだけです。
+
 ## ローカルで API 経由の実送信を確認する
 
 先に API を起動します。

--- a/docs/メール送信テスト手順.md
+++ b/docs/メール送信テスト手順.md
@@ -4,7 +4,7 @@
 
 ## 前提
 
-root `.env` に Gmail 送信用の設定を置きます。
+`api/.env` に Gmail 送信用の設定を置きます。
 
 ```env
 GMAIL_ADDRESS=送信用Gmailアドレス

--- a/docs/メール送信テスト手順.md
+++ b/docs/メール送信テスト手順.md
@@ -1,0 +1,79 @@
+# メール送信テスト手順
+
+汎用メール送信 API をローカルまたは本番相当の環境から手動確認するための手順です。
+
+## 前提
+
+root `.env` に Gmail 送信用の設定を置きます。
+
+```env
+GMAIL_ADDRESS=送信用Gmailアドレス
+GMAIL_APP_PASSWORD=Gmailアプリパスワード
+```
+
+管理者ログイン用のメールアドレスとパスワードは、`.env` ではなく実行時に指定します。
+
+## ローカルで API 経由の実送信を確認する
+
+先に API を起動します。
+
+```bash
+docker compose up api
+```
+
+別ターミナルで、以下を実行します。
+
+```bash
+docker compose run --rm api bash -lc '
+ALLOW_MAIL_DELIVERY_TEST=true \
+MAIL_DELIVERY_TEST_EMAIL=管理者ログインメール \
+MAIL_DELIVERY_TEST_PASSWORD=管理者ログインパスワード \
+MAIL_DELIVERY_TEST_TO=受信確認したいメールアドレス \
+bundle exec rails mail:delivery_test
+'
+```
+
+この task は以下の順に実行します。
+
+1. `http://api:3000/api/auth/sign_in` にログイン
+2. 取得した `access-token` / `client` / `uid` で `POST /api/v1/mail_deliveries` を呼び出し
+3. API 側の ActionMailer 設定で Gmail から実送信
+
+`ALLOW_MAIL_DELIVERY_TEST=true` を付けない場合、API 呼び出し前に終了します。
+
+## 件名・本文を指定する
+
+必要な場合は件名と本文も指定できます。
+
+```bash
+docker compose run --rm api bash -lc '
+ALLOW_MAIL_DELIVERY_TEST=true \
+MAIL_DELIVERY_TEST_EMAIL=管理者ログインメール \
+MAIL_DELIVERY_TEST_PASSWORD=管理者ログインパスワード \
+MAIL_DELIVERY_TEST_TO=受信確認したいメールアドレス \
+MAIL_DELIVERY_TEST_SUBJECT="Group Manager送信テスト" \
+MAIL_DELIVERY_TEST_BODY="メール送信APIの実送信テストです。" \
+bundle exec rails mail:delivery_test
+'
+```
+
+## 本番 API を直接叩く場合
+
+本番 API のルーティング・認証・メール送信まで確認したい場合は、API URL を明示します。
+
+```bash
+docker compose run --rm api bash -lc '
+ALLOW_MAIL_DELIVERY_TEST=true \
+MAIL_DELIVERY_TEST_API_URL=https://group-manager-api.nutfes.net \
+MAIL_DELIVERY_TEST_EMAIL=管理者ログインメール \
+MAIL_DELIVERY_TEST_PASSWORD=管理者ログインパスワード \
+MAIL_DELIVERY_TEST_TO=受信確認したいメールアドレス \
+bundle exec rails mail:delivery_test
+'
+```
+
+## 注意
+
+- この手順は実際にメールを送信します。
+- Gmail アプリパスワードが正しくない場合、API 呼び出し後に送信エラーになります。
+- 受信確認では迷惑メールフォルダも確認してください。


### PR DESCRIPTION
- resolved #2086
## 概要
- 管理者のみ利用できる汎用メール送信 API `POST /api/v1/mail_deliveries` を追加
- ローカルは `letter_opener`、本番は Gmail アプリパスワードで送信する ActionMailer 設定を追加
- 実際の API 経由でメール送信確認を行う手動 rake task `mail:delivery_test` を追加
- API コンテナの env 読み込みを root `.env` に統一

## 検証結果
<img width="821" height="275" alt="image" src="https://github.com/user-attachments/assets/22e0422a-bab8-4198-a844-9fe17d1e3608" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者のみが利用できるメール送信APIを追加（入力検証・JSONで成功/失敗を返却）。
  * 開発環境でメール内容をブラウザから確認できるようにしました（LetterOpener Web）。
  * 環境変数で送信元アドレスを切り替えるよう変更。
  * 実送信テスト用の `mail:delivery_test` タスクを追加。
* **ドキュメント**
  * メール送信テスト手順を追加。
* **テスト**
  * メール送信API/メール生成/実送信テストタスクのテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->