### PR TITLE
[fix] 従業員申請csv出力における氏名重複時の過度な非表示を改善

### DIFF
--- a/api/app/controllers/api/v1/output_csv_controller.rb
+++ b/api/app/controllers/api/v1/output_csv_controller.rb
@@ -315,13 +315,13 @@ class Api::V1::OutputCsvController < ApplicationController
       rep_student = nil
       # グループ内既出チェック用セット
       group_seen_student_ids = Set.new
-      group_seen_normalized = Set.new
+      group_seen_norm_and_id = Set.new
       if rep
         rep_norm = rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
         rep_student = rep.user_detail&.student_id
         # mark seen
         group_seen_student_ids << rep_student if rep_student.present?
-        group_seen_normalized << rep_norm if rep_norm.present?
+        group_seen_norm_and_id << [rep_norm, rep_student] if rep_norm.present?
         persons << { group_id: group.id, group: group.name, name: rep.name.to_s, student_id: rep_student, roles: ['代'] }
       end
 
@@ -334,7 +334,7 @@ class Api::V1::OutputCsvController < ApplicationController
         sub_rep_student = sub_rep.student_id
         # mark seen
         group_seen_student_ids << sub_rep_student if sub_rep_student.present?
-        group_seen_normalized << sub_rep_norm if sub_rep_norm.present?
+        group_seen_norm_and_id << [sub_rep_norm, sub_rep_student] if sub_rep_norm.present?
         persons << { group_id: group.id, group: group.name, name: sub_rep.name.to_s, student_id: sub_rep_student, roles: ['副'] }
       end
 
@@ -357,15 +357,15 @@ class Api::V1::OutputCsvController < ApplicationController
         if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
           group_dup_student_ids[group.id] << emp_student
           next
-        elsif !student_id_dup_check_target && emp_norm.present? && group_seen_normalized.include?(emp_norm)
-          group_dup_names[group.id] << emp_norm
+        elsif !student_id_dup_check_target && emp_norm.present? && group_seen_norm_and_id.include?([emp_norm, emp_student])
+          group_dup_names[group.id] << [emp_norm, emp_student]
           next
         end
 
         # 正常な従業員は persons に追加し、グループ内の既出に追加する
         persons << { group_id: group.id, group: group.name, name: emp_name, student_id: emp_student, roles: [] }
         group_seen_student_ids << emp_student if emp_student.present?
-        group_seen_normalized << emp_norm if emp_norm.present?
+        group_seen_norm_and_id << [emp_norm, emp_student] if emp_norm.present?
       end
     end
 
@@ -443,7 +443,7 @@ class Api::V1::OutputCsvController < ApplicationController
         remark = ''
         if p[:is_student] && p[:student_id].present?
           remark = '同一団体内で2重登録（非表示で対応）' if group_dup_student_ids[current_group_id].include?(p[:student_id])
-        elsif group_dup_names[current_group_id].include?(p[:normalized_name])
+        elsif group_dup_names[current_group_id].include?([p[:normalized_name], p[:student_id]])
           remark = '同一団体内で2重登録（非表示で対応）'
         end
 

--- a/api/simulate_csv.rb
+++ b/api/simulate_csv.rb
@@ -48,7 +48,7 @@ def test_logic(groups)
       emp_student = employee.student_id
       common_student_ids = [UserDetail_STUDENT_ID_EXTERNAL, UserDetail_STUDENT_ID_STAFF]
 
-      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && !common_student_ids.include?(emp_student)
+      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && common_student_ids.exclude?(emp_student)
 
       if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
         group_dup_student_ids[group.id] << emp_student

--- a/api/simulate_csv.rb
+++ b/api/simulate_csv.rb
@@ -48,7 +48,7 @@ def test_logic(groups)
       emp_student = employee.student_id
       common_student_ids = [UserDetail_STUDENT_ID_EXTERNAL, UserDetail_STUDENT_ID_STAFF]
 
-      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && common_student_ids.exclude?(emp_student)
+      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && !common_student_ids.include?(emp_student)
 
       if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
         group_dup_student_ids[group.id] << emp_student
@@ -75,7 +75,7 @@ g1 = GroupMock.new(1, 'Group 1', [
 # Test 2: 99999999
 g2 = GroupMock.new(2, 'Group 2', [
                      EmployeeMock.new('教員A', 99999999),
-                     EmployeeMock.new('教員B', 99999999)
+                     EmployeeMock.new('教員A', 99999999)
                    ], nil, nil)
 
 puts test_logic([g1, g2]).inspect

--- a/api/simulate_csv.rb
+++ b/api/simulate_csv.rb
@@ -23,13 +23,13 @@ def test_logic(groups)
     rep_norm = nil
     rep_student = nil
     group_seen_student_ids = Set.new
-    group_seen_normalized = Set.new
+    group_seen_norm_and_id = Set.new
 
     if rep
       rep_norm = rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
       rep_student = rep.user_detail&.student_id
       group_seen_student_ids << rep_student if rep_student.present?
-      group_seen_normalized << rep_norm if rep_norm.present?
+      group_seen_norm_and_id << [rep_norm, rep_student] if rep_norm.present?
       persons << { group_id: group.id, group: group.name, name: rep.name.to_s, student_id: rep_student, roles: ['代'] }
     end
 
@@ -38,7 +38,7 @@ def test_logic(groups)
       sub_rep_norm = sub_rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
       sub_rep_student = sub_rep.student_id
       group_seen_student_ids << sub_rep_student if sub_rep_student.present?
-      group_seen_normalized << sub_rep_norm if sub_rep_norm.present?
+      group_seen_norm_and_id << [sub_rep_norm, sub_rep_student] if sub_rep_norm.present?
       persons << { group_id: group.id, group: group.name, name: sub_rep.name.to_s, student_id: sub_rep_student, roles: ['副'] }
     end
 
@@ -48,19 +48,19 @@ def test_logic(groups)
       emp_student = employee.student_id
       common_student_ids = [UserDetail_STUDENT_ID_EXTERNAL, UserDetail_STUDENT_ID_STAFF]
 
-      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && common_student_ids.exclude?(emp_student)
+      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && !common_student_ids.include?(emp_student)
 
       if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
         group_dup_student_ids[group.id] << emp_student
         next
-      elsif !student_id_dup_check_target && emp_norm != '' && group_seen_normalized.include?(emp_norm)
-        group_dup_names[group.id] << emp_norm
+      elsif !student_id_dup_check_target && emp_norm != '' && group_seen_norm_and_id.include?([emp_norm, emp_student])
+        group_dup_names[group.id] << [emp_norm, emp_student]
         next
       end
 
       persons << { group_id: group.id, group: group.name, name: emp_name, student_id: emp_student, roles: [] }
       group_seen_student_ids << emp_student if emp_student
-      group_seen_normalized << emp_norm if emp_norm != ''
+      group_seen_norm_and_id << [emp_norm, emp_student] if emp_norm != ''
     end
   end
   persons

--- a/api/simulate_csv.rb
+++ b/api/simulate_csv.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'set'
 
 # Mocks
-class GroupMock < Struct.new(:id, :name, :employees, :user, :sub_rep); end
-class EmployeeMock < Struct.new(:name, :student_id); end
-class UserMock < Struct.new(:name, :user_detail); end
-class UserDetailMock < Struct.new(:student_id); end
+GroupMock = Struct.new(:id, :name, :employees, :user, :sub_rep)
+EmployeeMock = Struct.new(:name, :student_id)
+UserMock = Struct.new(:name, :user_detail)
+UserDetailMock = Struct.new(:student_id)
 
 # Test case: 2 regular students, diff ID, same name
 # Test case: 99999999 staff
@@ -46,7 +48,7 @@ def test_logic(groups)
       emp_student = employee.student_id
       common_student_ids = [UserDetail_STUDENT_ID_EXTERNAL, UserDetail_STUDENT_ID_STAFF]
 
-      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && !common_student_ids.include?(emp_student)
+      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && common_student_ids.exclude?(emp_student)
 
       if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
         group_dup_student_ids[group.id] << emp_student
@@ -65,15 +67,15 @@ def test_logic(groups)
 end
 
 # Test 1: Same name, different IDs
-g1 = GroupMock.new(1, "Group 1", [
-  EmployeeMock.new("山田太郎", 11111111),
-  EmployeeMock.new("山田太郎", 22222222)
-], nil, nil)
+g1 = GroupMock.new(1, 'Group 1', [
+                     EmployeeMock.new('山田太郎', 11111111),
+                     EmployeeMock.new('山田太郎', 22222222)
+                   ], nil, nil)
 
 # Test 2: 99999999
-g2 = GroupMock.new(2, "Group 2", [
-  EmployeeMock.new("教員A", 99999999),
-  EmployeeMock.new("教員B", 99999999)
-], nil, nil)
+g2 = GroupMock.new(2, 'Group 2', [
+                     EmployeeMock.new('教員A', 99999999),
+                     EmployeeMock.new('教員B', 99999999)
+                   ], nil, nil)
 
 puts test_logic([g1, g2]).inspect

--- a/api/simulate_csv.rb
+++ b/api/simulate_csv.rb
@@ -1,0 +1,79 @@
+require 'set'
+
+# Mocks
+class GroupMock < Struct.new(:id, :name, :employees, :user, :sub_rep); end
+class EmployeeMock < Struct.new(:name, :student_id); end
+class UserMock < Struct.new(:name, :user_detail); end
+class UserDetailMock < Struct.new(:student_id); end
+
+# Test case: 2 regular students, diff ID, same name
+# Test case: 99999999 staff
+UserDetail_STUDENT_ID_EXTERNAL = 88888888
+UserDetail_STUDENT_ID_STAFF = 99999999
+
+def test_logic(groups)
+  persons = []
+  group_dup_student_ids = Hash.new { |h, k| h[k] = Set.new }
+  group_dup_names = Hash.new { |h, k| h[k] = Set.new }
+
+  groups.each do |group|
+    rep = group.user
+    rep_norm = nil
+    rep_student = nil
+    group_seen_student_ids = Set.new
+    group_seen_normalized = Set.new
+
+    if rep
+      rep_norm = rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
+      rep_student = rep.user_detail&.student_id
+      group_seen_student_ids << rep_student if rep_student.present?
+      group_seen_normalized << rep_norm if rep_norm.present?
+      persons << { group_id: group.id, group: group.name, name: rep.name.to_s, student_id: rep_student, roles: ['代'] }
+    end
+
+    sub_rep = group.sub_rep
+    if sub_rep
+      sub_rep_norm = sub_rep.name.to_s.gsub(/[[:space:]\u3000]+/, '')
+      sub_rep_student = sub_rep.student_id
+      group_seen_student_ids << sub_rep_student if sub_rep_student.present?
+      group_seen_normalized << sub_rep_norm if sub_rep_norm.present?
+      persons << { group_id: group.id, group: group.name, name: sub_rep.name.to_s, student_id: sub_rep_student, roles: ['副'] }
+    end
+
+    (group.employees || []).each do |employee|
+      emp_name = employee.name.to_s
+      emp_norm = emp_name.gsub(/[[:space:]\u3000]+/, '')
+      emp_student = employee.student_id
+      common_student_ids = [UserDetail_STUDENT_ID_EXTERNAL, UserDetail_STUDENT_ID_STAFF]
+
+      student_id_dup_check_target = !emp_student.nil? && emp_student.to_s != '' && !common_student_ids.include?(emp_student)
+
+      if student_id_dup_check_target && group_seen_student_ids.include?(emp_student)
+        group_dup_student_ids[group.id] << emp_student
+        next
+      elsif !student_id_dup_check_target && emp_norm != '' && group_seen_normalized.include?(emp_norm)
+        group_dup_names[group.id] << emp_norm
+        next
+      end
+
+      persons << { group_id: group.id, group: group.name, name: emp_name, student_id: emp_student, roles: [] }
+      group_seen_student_ids << emp_student if emp_student
+      group_seen_normalized << emp_norm if emp_norm != ''
+    end
+  end
+  persons
+end
+
+# Test 1: Same name, different IDs
+g1 = GroupMock.new(1, "Group 1", [
+  EmployeeMock.new("山田太郎", 11111111),
+  EmployeeMock.new("山田太郎", 22222222)
+], nil, nil)
+
+# Test 2: 99999999
+g2 = GroupMock.new(2, "Group 2", [
+  EmployeeMock.new("教員A", 99999999),
+  EmployeeMock.new("教員B", 99999999)
+], nil, nil)
+
+puts test_logic([g1, g2]).inspect

--- a/api/test_csv.rb
+++ b/api/test_csv.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 require './config/environment'
 
-groups = Group.where(group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
+Group.where(group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
 # We will just print the logic exactly as it is in the controller to see if it skips.

--- a/api/test_csv.rb
+++ b/api/test_csv.rb
@@ -1,0 +1,4 @@
+require './config/environment'
+
+groups = Group.where(group_category_id: 1).preload(:employees, :sub_rep, user: :user_detail)
+# We will just print the logic exactly as it is in the controller to see if it skips.


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2089

# 概要
<!-- 開発内容の概要を記載 -->
- 従業員CSV出力（`output_employees_csv`）において、同姓同名の別人が誤って非表示（重複スキップ）されてしまうバグを修正しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- 氏名のみで行っていた「特別ID（99999999など）の重複チェック」を、「氏名と学籍番号の両方が一致した場合」にのみスキップするように条件を厳密化しました。
- これにより、通常学籍番号（12345678等）と特別ID（99999999等）の同姓同名ペアが同一団体内に存在した場合、別人と判定されて処理順序に関わらず両方が正常に出力されるようになります。
- 完全に同一のIDと氏名を持つ2重登録の場合はこれまで通りスキップされ、代表する行の備考欄に「同一団体内で2重登録（非表示で対応）」と出力される仕様は維持・強化されています。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
（バックエンドのCSV出力ロジック変更のみのため割愛します）

# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 従業員申請CSVを出力し、同一団体内に「通常学籍番号」と「特別ID」の同姓同名がいる場合に両方が出力されていること
- [ ] 完全な2重登録（IDも氏名も同じデータ）が同一団体内に存在した場合、片方がスキップされ、出力された行の備考欄に「同一団体内で2重登録（非表示で対応）」と記載されること

# 備考
<!-- 実装していて困った箇所・質問など -->
- 今回の修正では同一団体内の重複に絞っています。他団体の重複（掛け持ち）チェックに関する同姓同名の扱いは、別人の可能性が高いため既存仕様を維持しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV出力時の従業員重複判定を「正規化氏名＋学籍番号」の組に基づく判定に変更し、代表・副代表取り込みや備考欄の重複表示をより正確にしました。
* **Tests**
  * 重複判定の動作を検証するスクリプトを追加し、典型的なケースの挙動を確認できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->