### PR TITLE
[fix] アナウンス項目の削除

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -196,11 +196,6 @@ export default {
           click: "/public_relations",
         },
         {
-          title: "会場アナウンス文申請",
-          icon: "campaign",
-          click: "/announcement",
-        },
-        {
           title: "模擬店平面図申請",
           icon: "map",
           click: "/venue_maps",
@@ -246,6 +241,7 @@ export default {
         { title: "物品移動計画", icon: "swap_horiz", click: "/assign_item_movements" },
         { title: "会場割り当て", icon: "event_seat", click: "/assign_places" },
         { title: "ステージ割り当て", icon: "stadium", click: "/assign_stages" },
+        { title: "会場アナウンス文申請", icon: "campaign", click: "/announcement" },
       ],
       isOpened: false
     };

--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -118,12 +118,6 @@
               <div v-if="group.public_relation">◯</div>
               <div v-else>✖️</div>
             </td>
-            <!-- アナウンス -->
-            <td :class="{ unregistered: !group.announcement }">
-              <div v-if="group.announcement==='申請済み'">◯</div>
-              <div v-else-if="group.announcement==='申請しない'">ー</div>
-              <div v-else>✖️</div>
-            </td>
             <!-- 模擬店平面図 -->
             <td :class="{ unregistered: !group.venue_map && group.group_category === 1 }">
               <div v-if="group.venue_map">◯</div>
@@ -169,7 +163,6 @@ export default {
         "販売品",
         "購入品",
         "PR",
-        "アナウンス",
         "模擬店平面図",
         "調理工程",
         "火気使用申請",

--- a/admin_view/nuxt-project/pages/order_status_check/index.vue
+++ b/admin_view/nuxt-project/pages/order_status_check/index.vue
@@ -55,72 +55,88 @@
         </template>
         <template v-slot:table-body>
           <tr v-for="(group, index) in groups" :key="index">
+            <!-- ID -->
             <td>{{ group.group.id }}</td>
+            <!-- 参加団体 -->
             <td>{{ group.group.name }}</td>
+            <!-- 副代表 -->
             <td :class="{ unregistered: !group.sub_rep && !isUnregistered(group.group.id, 'sub_rep') }">
               <div v-if="group.sub_rep">◯</div>
               <div v-else-if="isUnregistered(group.group.id, 'sub_rep')">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 会場 -->
             <td :class="{ unregistered: !group.place_order && !group.group.is_international && group.group_category !== 3 }">
               <div v-if="group.place_order">◯</div>
               <div v-else-if="group.group.is_international || group.group_category === 3">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 消費電力 -->
             <td :class="{ unregistered: !group.power_orders && !isUnregistered(group.group.id, 'power_order') }">
               <div v-if="group.power_orders">◯</div>
               <div v-else-if="isUnregistered(group.group.id, 'power_order')">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 物品 -->
             <td :class="{ unregistered: !group.rental_orders && !isUnregistered(group.group.id, 'rental_item_order') }">
               <div v-if="group.rental_orders">◯</div>
               <div v-else-if="isUnregistered(group.group.id, 'rental_item_order')">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- ステージ -->
             <td :class="{ unregistered: !group.stage_orders && group.group_category === 3 }">
               <div v-if="group.stage_orders">◯</div>
               <div v-else-if="group.group_category !== 3">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- ステージオプション -->
             <td :class="{ unregistered: !group.stage_common_option && group.group_category === 3 }">
               <div v-if="group.stage_common_option">◯</div>
               <div v-else-if="group.group_category !== 3">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 従業員 -->
             <td :class="{ unregistered: !group.employees && group.group_category === 1 }">
               <div v-if="group.employees">◯</div>
               <div v-else-if="group.group_category !== 1">ー</div>
               <div v-else>✖️</div>
             </td>
-            <td :class="{ unregistered: !group.cooking_process_order && group.group_category === 1 }">
-              <div v-if="group.cooking_process_order">◯</div>
-              <div v-else-if="group.group_category !== 1">ー</div>
-              <div v-else>✖️</div>
-            </td>
+            <!-- 販売品 -->
             <td :class="{ unregistered: !group.food_product && (group.group_category === 1 || group.group_category === 2) }">
               <div v-if="group.food_product">◯</div>
               <div v-else-if="group.group_category !== 1 && group.group_category !== 2">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 購入品 -->
             <td :class="{ unregistered: !group.purchase_list && group.group_category === 1 }">
               <div v-if="group.purchase_list">◯</div>
               <div v-else-if="group.group_category !== 1">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- PR -->
             <td :class="{ unregistered: !group.public_relation }">
               <div v-if="group.public_relation">◯</div>
               <div v-else>✖️</div>
             </td>
+            <!-- アナウンス -->
             <td :class="{ unregistered: !group.announcement }">
               <div v-if="group.announcement==='申請済み'">◯</div>
               <div v-else-if="group.announcement==='申請しない'">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 模擬店平面図 -->
             <td :class="{ unregistered: !group.venue_map && group.group_category === 1 }">
               <div v-if="group.venue_map">◯</div>
               <div v-else-if="group.group_category !== 1">ー</div>
               <div v-else>✖️</div>
             </td>
+            <!-- 調理工程 -->
+            <td :class="{ unregistered: !group.cooking_process_order && group.group_category === 1 }">
+              <div v-if="group.cooking_process_order">◯</div>
+              <div v-else-if="group.group_category !== 1">ー</div>
+              <div v-else>✖️</div>
+            </td>
+            <!-- 火気使用申請 -->
             <td :class="{ unregistered: !group.fire_equipment_order_status && !isUnregistered(group.group.id, 'fire_equipment_order') && [1, 2, 4, 5].includes(group.group_category) }">
               <div v-if="group.fire_equipment_order_status && [1, 2, 4, 5].includes(group.group_category)">◯</div>
               <div v-else-if="isUnregistered(group.group.id, 'fire_equipment_order') || ![1, 2, 4, 5].includes(group.group_category)">ー</div>


### PR DESCRIPTION
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2093

# 概要
- admin画面の申請状況一覧画面で、テーブルのヘッダーと内容がズレていたのを修正した
- admin画面の申請状況一覧画面で、「アナウンス」項目を削除した
- admin画面のメニューバーの「会場アナウンス文申請」を「開発中」配下に移動させた

# 実装詳細

 ` admin_view/nuxt-project/pages/order_status_check/index.vue`
  - 申請状況一覧テーブルのヘッダー配列から "アナウンス" を削除
  - group.announcement を参照していたアナウンス列の `<td>` を削除
  - テーブルのヘッダーに合わせてデータの順序を変更
    - group.cooking_process_order の `<td>` を移動

`  admin_view/nuxt-project/components/Menu.vue`
  - order_items から「会場アナウンス申請」に関する要素を削除
  - 同じメニュー項目を development_items に追加

# 画面スクリーンショット等
申請状況一覧 ページ
<img width="1403" height="466" alt="image" src="https://github.com/user-attachments/assets/a882a036-114a-450a-b5f3-b1e00bfc9764" />

メニューバー
<img width="265" height="426" alt="image" src="https://github.com/user-attachments/assets/4cc99018-69ee-49c7-9c65-c9b7fb2ecac8" />

# テスト項目
テストコードは実装せず、手動でテストを行った


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * メニュー内の「会場アナウンス文申請」が「開発中」カテゴリに移動しました。

* **改善**
  * 受注状況確認の一覧テーブルで表示項目を整理し、「アナウンス」列を削除しました。
  * 併せて、PR・模擬店平面図・調理工程などの列順を見直し、表示をわかりやすく調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->