### PR TITLE
再提出時にSlack通知を送信する処理を追加

### DIFF
--- a/api/app/models/health_center_submission_status.rb
+++ b/api/app/models/health_center_submission_status.rb
@@ -88,7 +88,7 @@ class HealthCenterSubmissionStatus < ApplicationRecord
       参加形式：#{group_category_name}
 
       申請種類：#{application_type_name}
-      
+
 
       管理者画面にログインして内容を確認し、承認してください
       URL: #{admin_url}

--- a/api/app/models/health_center_submission_status.rb
+++ b/api/app/models/health_center_submission_status.rb
@@ -80,7 +80,7 @@ class HealthCenterSubmissionStatus < ApplicationRecord
       group_category_name = group.group_category&.name
 
       message_text = <<~MSG
-        「#{group_name}」が再提出されました
+        参加団体「#{group_name}」の申請が再提出されました
         ーーーーーーーーーーーーーーーー
         参加団体：#{group_name}
         企画名：#{project_name}

--- a/api/app/models/health_center_submission_status.rb
+++ b/api/app/models/health_center_submission_status.rb
@@ -79,19 +79,18 @@ class HealthCenterSubmissionStatus < ApplicationRecord
       project_name = group.project_name
       group_category_name = group.group_category&.name
 
-      message_text = "
-      「#{group_name}」が再提出されました
-      ーーーーーーーーーーーーーーーー
-      参加団体：#{group_name}
-      企画名：#{project_name}
-      参加形式：#{group_category_name}
+      message_text = <<~MSG
+        「#{group_name}」が再提出されました
+        ーーーーーーーーーーーーーーーー
+        参加団体：#{group_name}
+        企画名：#{project_name}
+        参加形式：#{group_category_name}
 
-      申請種類：#{application_type_name}
+        申請種類：#{application_type_name}
 
-
-      管理者画面にログインして内容を確認し、承認してください
-      ーーーーーーーーーーーーーーーー
-      "
+        管理者画面にログインして内容を確認し、承認してください
+        ーーーーーーーーーーーーーーーー
+      MSG
 
       begin
         client.chat_postMessage(

--- a/api/app/models/health_center_submission_status.rb
+++ b/api/app/models/health_center_submission_status.rb
@@ -25,6 +25,17 @@ class HealthCenterSubmissionStatus < ApplicationRecord
   validates :application_type, presence: true, uniqueness: { scope: :group_id }
   validates :status, presence: true
 
+  after_update :notify_slack_if_resubmitted_to_unapproved
+
+  APPLICATION_TYPE_JA = {
+    'food_product' => '販売品申請',
+    'purchase_list' => '購入品申請',
+    'cooking_process_order' => '調理工程申請',
+    'employee' => '従業員申請',
+    'venue_map' => '模擬店平面図申請',
+    'equipment' => '物品申請'
+  }.freeze
+
   def self.ensure_for_group_and_application_type!(group_id:, application_type:, status: DEFAULT_STATUS)
     submission_status = find_or_initialize_by(group_id: group_id, application_type: application_type)
     submission_status.status = status
@@ -51,6 +62,48 @@ class HealthCenterSubmissionStatus < ApplicationRecord
         comments: submission_status&.comments || [],
         detail: nil
       }
+    end
+  end
+
+  private
+
+  def notify_slack_if_resubmitted_to_unapproved
+    was_resubmission = status_before_last_save == 'waiting_resubmission'
+    is_unapproved_now = status == 'unapproved'
+
+    if saved_change_to_status? && was_resubmission && is_unapproved_now
+      client = Slack::Web::Client.new
+
+      application_type_name = APPLICATION_TYPE_JA[application_type.to_s] || application_type
+      group_name = group.name
+      project_name = group.project_name
+      group_category_name = group.group_category&.name
+      admin_url = "#{ENV.fetch('ADMIN_FRONT_URL', '')}/health_center_document_review/#{group_id}"
+
+      message_text = "
+      「#{group_name}」が再提出されました
+      ーーーーーーーーーーーーーーーー
+      参加団体：#{group_name}
+      企画名：#{project_name}
+      参加形式：#{group_category_name}
+
+      申請種類：#{application_type_name}
+      
+
+      管理者画面にログインして内容を確認し、承認してください
+      URL: #{admin_url}
+      ーーーーーーーーーーーーーーーー
+      "
+
+      begin
+        client.chat_postMessage(
+          token: ENV.fetch('BOT_USER_ACCESS_TOKEN', nil),
+          channel: "##{ENV.fetch('CHANNEL', nil)}",
+          text: message_text
+        )
+      rescue StandardError => e
+        Rails.logger.error("Slack通知に失敗しました: #{e.message}")
+      end
     end
   end
 end

--- a/api/app/models/health_center_submission_status.rb
+++ b/api/app/models/health_center_submission_status.rb
@@ -25,7 +25,7 @@ class HealthCenterSubmissionStatus < ApplicationRecord
   validates :application_type, presence: true, uniqueness: { scope: :group_id }
   validates :status, presence: true
 
-  after_update_commit :notify_slack_if_resubmitted_to_unapproved
+  after_update_commit :notify_slack_on_unapproved_resubmission
 
   APPLICATION_TYPE_JA = {
     'food_product' => '販売品申請',
@@ -67,11 +67,11 @@ class HealthCenterSubmissionStatus < ApplicationRecord
 
   private
 
-  def notify_slack_if_resubmitted_to_unapproved
+  def notify_slack_on_unapproved_resubmission
     was_resubmission = status_before_last_save == 'waiting_resubmission'
-    is_unapproved_now = status == 'unapproved'
+    is_unapproved = status == 'unapproved'
 
-    if saved_change_to_status? && was_resubmission && is_unapproved_now
+    if saved_change_to_status? && was_resubmission && is_unapproved
       client = Slack::Web::Client.new
 
       application_type_name = APPLICATION_TYPE_JA[application_type.to_s] || application_type

--- a/api/app/models/health_center_submission_status.rb
+++ b/api/app/models/health_center_submission_status.rb
@@ -25,7 +25,7 @@ class HealthCenterSubmissionStatus < ApplicationRecord
   validates :application_type, presence: true, uniqueness: { scope: :group_id }
   validates :status, presence: true
 
-  after_update :notify_slack_if_resubmitted_to_unapproved
+  after_update_commit :notify_slack_if_resubmitted_to_unapproved
 
   APPLICATION_TYPE_JA = {
     'food_product' => '販売品申請',
@@ -78,7 +78,6 @@ class HealthCenterSubmissionStatus < ApplicationRecord
       group_name = group.name
       project_name = group.project_name
       group_category_name = group.group_category&.name
-      admin_url = "#{ENV.fetch('ADMIN_FRONT_URL', '')}/health_center_document_review/#{group_id}"
 
       message_text = "
       「#{group_name}」が再提出されました
@@ -91,7 +90,6 @@ class HealthCenterSubmissionStatus < ApplicationRecord
 
 
       管理者画面にログインして内容を確認し、承認してください
-      URL: #{admin_url}
       ーーーーーーーーーーーーーーーー
       "
 


### PR DESCRIPTION
# 対応Issue
resolve #2108

# 概要
- 保健所申請が「再提出」から「未承認」に変わった際に、管理者へ向けてSlackへ通知を送る処理を追加しました。

# 実装詳細
- `HealthCenterSubmissionStatus` モデルに `after_update` コールバックを追加し、ステータスの遷移（`waiting_resubmission` -> `unapproved`）を検知。
- 通知メッセージに「参加団体名」「企画名」「参加形式」「申請種類（日本語）」を含めるように実装。
- 通知処理中のエラー（Slack API通信エラー等）がアプリケーション全体の処理に影響しないよう、例外捕捉を実装。

# 画面スクリーンショット等
(バックエンドの処理のため画面の変更はありません)

# テスト項目
- [ ] 任意の団体で保健所関連の申請を「再提出」から「未承認」ステータスへ変更し、Slackの指定チャンネルに通知が届くこと。
- [ ] 通知の文面に、団体名、企画名、参加形式、申請の日本語名が含まれていること。

# 備考
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **不具合修正**
  * 再提出待ちから不承認へのステータス遷移、およびステータス変更が行われた場合に限って通知を送信するようにし、誤通知を防ぎました。  
  * 申請種別の表示名を日本語ラベルで組み立て、通知内容をより分かりやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->