### PR TITLE
fix: 物品申請未登録時に受付終了後も申請できてしまうバグを修正

### DIFF
--- a/user/public/locales/en/common.json
+++ b/user/public/locales/en/common.json
@@ -361,6 +361,10 @@
         "longTableLimit": "You can request at most one long table.",
         "tableOutdoorLimit": "Outdoor groups can request up to 20 tables.",
         "chairOutdoorLimit": "Outdoor groups can request up to 20 chairs."
+      },
+      "deadline": {
+        "title": "Application period has ended",
+        "description": "The deadline for rental item applications has passed. New applications are not accepted."
       }
     },
     "purchaseLists": {

--- a/user/public/locales/ja/common.json
+++ b/user/public/locales/ja/common.json
@@ -361,6 +361,10 @@
         "longTableLimit": "長机は1個までしか申請できません",
         "tableOutdoorLimit": "屋外団体は机を20個までしか申請できません",
         "chairOutdoorLimit": "屋外団体は椅子を20個までしか申請できません"
+      },
+      "deadline": {
+        "title": "申請期限が過ぎています",
+        "description": "物品申請の締切期限が過ぎているため、新規申請はできません。"
       }
     },
     "purchaseLists": {

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -43,6 +43,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
     openEditMode,
     isEditMode,
     hasExplicitlyDeclinedItems,
+    isDeclinedStateLoading,
     handleFormSubmit,
     hideLocationTypeSelect, // 会場タイプ選択を非表示にするフラグ
     isFoodSellingGroup, // 食品販売団体かどうかのフラグ
@@ -72,10 +73,12 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
   }
 
   // 締め切り後で、データがない（未登録）かつ再提出でない場合
+  // isDeclinedStateLoadingがtrueの間は非同期チェック完了前なので、この分岐を保留する
   if (
+    !isDeclinedStateLoading &&
     !isDeadline &&
     !hasExisting &&
-    !hasExplicitlyDeclinedItems &&
+    hasExplicitlyDeclinedItems === false &&
     status !== 'waiting_resubmission'
   ) {
     return (

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -71,6 +71,38 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
     );
   }
 
+  // 締め切り後で、データがない（未登録）かつ再提出でない場合
+  if (!isDeadline && !hasExisting && !hasExplicitlyDeclinedItems && status !== 'waiting_resubmission') {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <div className="rounded-lg border border-gray-300 bg-gray-50 p-6">
+          <div className="mb-4">
+            <svg
+              className="mx-auto size-12 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <h3 className="mb-2 text-lg font-semibold text-gray-800">
+            {rentItemsFormTexts.deadline.title}
+          </h3>
+          <p className="text-sm text-gray-600">
+            {rentItemsFormTexts.deadline.description}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   // 「物品申請を行わない」場合の表示（UnRegisteredGroupが登録されている場合）
   if (!isEditMode && hasExplicitlyDeclinedItems && !hasExisting) {
     return (

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -72,7 +72,12 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
   }
 
   // 締め切り後で、データがない（未登録）かつ再提出でない場合
-  if (!isDeadline && !hasExisting && !hasExplicitlyDeclinedItems && status !== 'waiting_resubmission') {
+  if (
+    !isDeadline &&
+    !hasExisting &&
+    !hasExplicitlyDeclinedItems &&
+    status !== 'waiting_resubmission'
+  ) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
         <div className="rounded-lg border border-gray-300 bg-gray-50 p-6">

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
@@ -387,8 +387,9 @@ export const useRentItemsFormHooks = (
   ]);
 
   // 物品申請を行わないことを明示的に記録するフラグ
+  // null = 確認中, false = 申請しない記録なし, true = 申請しない記録あり
   const [hasExplicitlyDeclinedItems, setHasExplicitlyDeclinedItems] =
-    useState<boolean>(false);
+    useState<boolean | null>(null);
 
   // 初期化時にUnRegisteredGroupをチェック
   useEffect(() => {
@@ -397,9 +398,12 @@ export const useRentItemsFormHooks = (
         const result = await checkUnRegisteredGroup(currentGroupId, 0);
         if (result.success && result.exists) {
           setHasExplicitlyDeclinedItems(true);
+        } else {
+          setHasExplicitlyDeclinedItems(false);
         }
       } catch (error) {
         console.error('UnRegisteredGroupの確認エラー:', error);
+        setHasExplicitlyDeclinedItems(false);
       }
     };
 
@@ -412,6 +416,10 @@ export const useRentItemsFormHooks = (
     checkUnRegisteredGroup,
     currentGroupId,
   ]);
+
+  // UnRegisteredGroup確認が完了するまで締切分岐を保留するためのフラグ
+  const isDeclinedStateLoading =
+    hasExplicitlyDeclinedItems === null && rentalOrders.length === 0;
 
   // 互換性チェックと自動会場タイプ変更のための特別なフラグ
   const [ignoreItemChanges, setIgnoreItemChanges] = useState<boolean>(false);
@@ -833,6 +841,7 @@ export const useRentItemsFormHooks = (
     openEditMode,
     isEditMode,
     hasExplicitlyDeclinedItems,
+    isDeclinedStateLoading,
     resetFormToDefault,
     handleFormSubmit,
     hideLocationTypeSelect, // 団体タイプに応じたUI表示制御フラグ

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
@@ -807,6 +807,10 @@ export const useRentItemsFormHooks = (
       delete: t('form.actions.delete'),
       addItem: t('applications.rentItems.buttons.addItem'),
     },
+    deadline: {
+      title: t('applications.rentItems.deadline.title'),
+      description: t('applications.rentItems.deadline.description'),
+    },
   };
 
   return {

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
@@ -388,8 +388,9 @@ export const useRentItemsFormHooks = (
 
   // 物品申請を行わないことを明示的に記録するフラグ
   // null = 確認中, false = 申請しない記録なし, true = 申請しない記録あり
-  const [hasExplicitlyDeclinedItems, setHasExplicitlyDeclinedItems] =
-    useState<boolean | null>(null);
+  const [hasExplicitlyDeclinedItems, setHasExplicitlyDeclinedItems] = useState<
+    boolean | null
+  >(null);
 
   // 初期化時にUnRegisteredGroupをチェック
   useEffect(() => {


### PR DESCRIPTION
# 対応Issue
<!-- 対応したIssue番号を記載 -->
物品申請が未登録の状態で受付が終了しているにもかかわらず、フォームが表示されて申請できてしまうバグの修正

# 概要
- 物品申請（RentItems）が未登録かつ受付終了後（`isDeadline=false` in RentItemsForm = 締切が過ぎている状態）の場合に、フォームが表示されて申請できてしまう問題を修正
- 受付終了・未登録・再提出待ちでない場合は申請締切メッセージを表示するようにした

# 実装詳細
- `RentItemsForm.tsx`: 締切後かつ未申請かつ再提出待ちでない場合の早期リターンを追加（`!isDeadline && !hasExisting && !hasExplicitlyDeclinedItems && status !== 'waiting_resubmission'`）
- `useRentItemsFormHooks.ts`: `rentItemsFormTexts` に `deadline` キー（title / description）を追加
- `locales/ja/common.json`: `applications.rentItems.deadline` の日本語翻訳を追加
- `locales/en/common.json`: `applications.rentItems.deadline` の英語翻訳を追加

**条件ロジックの整理（RentItemsForm内での `isDeadline` の意味）:**
- 親コンポーネント `RentItems.tsx` は `isDeadline={!isDeadline}` と反転して渡しているため、`RentItemsForm` 内では `isDeadline=false` が「締切が過ぎた」状態を意味する
- 修正のガード条件: `!isDeadline`（締切超過）`&& !hasExisting`（申請データなし）`&& !hasExplicitlyDeclinedItems`（「申請しない」登録もなし）`&& status !== 'waiting_resubmission'`（再提出待ちでない）

# 画面スクリーンショット等
<img width="913" height="516" alt="スクリーンショット 2026-06-28 121242" src="https://github.com/user-attachments/assets/225aa104-370d-40bf-a836-8e518ca3ebb2" />


# テスト項目
- [ ] 受付終了後・物品申請未登録の場合に申請フォームではなく締切メッセージが表示されること
- [ ] 受付中・物品申請未登録の場合は引き続き申請フォームが表示されること
- [ ] 受付終了後・「申請しない」を登録済みの場合は「物品申請を行わない」メッセージが表示されること（編集ボタンは非表示）
- [ ] `waiting_resubmission` ステータスの場合は締切後でも申請フォームが表示されること
- [ ] 申請データが既にある場合は締切後も申請内容が表示されること（編集ボタン付き）

# 備考
- `PurchaseLists.tsx` が同様のパターンをすでに実装しており、それに倣った修正


---
_Generated by [Claude Code](https://claude.ai/code/session_01PezicWjDgHCpyNNNvY91dK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 申請受付終了後に、未登録で再提出でもない場合は入力フォームの代わりに締め切り案内を表示するようになりました。
  * 申請期限に関するタイトルと説明文が追加され、締め切り状況がより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->