### PR TITLE
fix: 期限切れ時計アイコンをreact-icons化

### DIFF
--- a/user/src/components/Applications/Employees/Employees.tsx
+++ b/user/src/components/Applications/Employees/Employees.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
 import { NEED_APPLICATION, RADIO_VALUE } from '@/utils/constants';
 import { FormProvider } from 'react-hook-form';
+import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu';
 import Button from '@/components/Button';
 import Radio from '@/components/Form/Radio';
@@ -72,20 +73,7 @@ const Content: FC<ContentProps> = ({
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
         <div className="rounded-lg border border-gray-300 bg-gray-50 p-6">
           <div className="mb-4">
-            <svg
-              className="mx-auto size-12 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
+            <MdOutlineAccessTime className="mx-auto size-12 text-gray-400" />
           </div>
           <h3 className="mb-2 text-lg font-semibold text-gray-800">
             {texts.deadline.title}

--- a/user/src/components/Applications/FoodProduct/FoodProduct.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProduct.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu/AccordionMenu';
 import FoodProductForm from '@/components/Applications/FoodProduct/FoodProductForm/FoodProductForm';
 import {
@@ -94,20 +95,7 @@ const Content: FC<ContentProps> = ({
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
         <div className="rounded-lg border border-gray-300 bg-gray-50 p-6">
           <div className="mb-4">
-            <svg
-              className="mx-auto size-12 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
+            <MdOutlineAccessTime className="mx-auto size-12 text-gray-400" />
           </div>
           <h3 className="mb-2 text-lg font-semibold text-gray-800">
             {foodProductViewTexts.deadline.title}

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu/AccordionMenu';
 import Button from '@/components/Button';
 import FormList from '@/components/FormList/FormList';
@@ -111,20 +112,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
         <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
           <div className="rounded-lg border border-gray-300 bg-gray-50 p-6">
             <div className="mb-4">
-              <svg
-                className="mx-auto size-12 text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <MdOutlineAccessTime className="mx-auto size-12 text-gray-400" />
             </div>
             <h3 className="mb-2 text-lg font-semibold text-gray-800">
               {purchaseListsViewTexts.deadline.title}


### PR DESCRIPTION
## 課題と解決策

申請期限切れの未登録表示で、同じ時計アイコンの inline SVG が複数コンポーネントに重複していました。

`react-icons/md` の `MdAccessTime` に置き換え、既存の表示条件・文言・余白・カード外枠・文字スタイルは変更していません。

## 変更内容

- 従業員申請の期限切れ時計アイコンを `MdAccessTime` に置換
- 販売品申請の期限切れ時計アイコンを `MdAccessTime` に置換
- 購入品申請の期限切れ時計アイコンを `MdAccessTime` に置換

## 関連 Issue

Close #2116

## 検証結果

- `docker compose run --rm user pnpm run type-check`
- `docker compose run --rm user pnpm run lint`
- Storybook + Playwright で期限切れ表示の描画を確認
  - `Applications/Employees / AfterDeadlineNoApplication`: 期限切れ文言と時計アイコン描画 OK
  - `Components/PurchaseLists / AfterDeadlineNoData`: 期限切れ文言と時計アイコン描画 OK

## スクリーンショット
chromaticから確認しました。
<img width="827" height="265" alt="image" src="https://github.com/user-attachments/assets/5e0ecba5-a11c-42c5-95e4-3c8b42336c25" />


## データ・設定変更

なし
