### PR TITLE
物品貸出場所調整画面の実装

### DIFF
--- a/admin_view/nuxt-project/components/Menu.vue
+++ b/admin_view/nuxt-project/components/Menu.vue
@@ -224,6 +224,11 @@ export default {
           icon: "assignment_return", 
           click: "/assign_items" 
         },
+        {
+          title: "物品貸出場所調整",
+          icon: "assignment_ind",
+          click: "/rental_item_location"
+        },
         { title: "識別番号", icon: "format_list_numbered", click: "/group_identify" },
         { title: "お知らせ作成", icon: "newspaper", click: "/news" },
         {

--- a/admin_view/nuxt-project/pages/assign_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_items/index.vue
@@ -321,7 +321,7 @@ export default {
         if (Object.keys(this.modalSettings).length === 0) {
           const settings = {};
           this.items.forEach(item => {
-            const isDefault = item.id === 1 || item.id === 3; // 机と椅子
+            const isDefault = item.name === '机' || item.name === '椅子';
             settings[item.id] = { selected: isDefault, rule: 'requested', fixedValue: 0 };
           });
           this.modalSettings = JSON.parse(JSON.stringify(settings));

--- a/admin_view/nuxt-project/pages/assign_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_items/index.vue
@@ -1,21 +1,26 @@
 <template>
-  <div class="assign_items">
-    <SubHeader pageTitle="物品割り当て"></SubHeader>
-    <div class="SearchContainer">
-      <div class="SearchContainer-left">
-        <SearchDropDown
-        :nameList="yearList"
-        :on_click="refinementGroups"
-        value="year_num"
+  <div>
+    <div class="assign_items" v-if="this.$role(roleID).assign_items.read">
+      <SubHeader pageTitle="物品割り当て"></SubHeader>
+      <div class="SearchContainer">
+        <div class="SearchContainer-left">
+          <SearchDropDown
+          :nameList="yearList"
+          :on_click="refinementGroups"
+          value="year_num"
+          >
+          {{ refYears }}
+          </SearchDropDown>
+        </div>
+        <CommonButton
+          v-if="this.$role(roleID).assign_items.update"
+          class="btn-primary"
+          iconName="edit"
+          :on_click="openModal"
         >
-        {{ refYears }}
-        </SearchDropDown>
+          対象物品を設定
+        </CommonButton>
       </div>
-      <CommonButton class="btn-primary" 
-        iconName="edit" :on_click="openModal">
-        対象物品を設定
-      </CommonButton>
-    </div>
 
      <div v-if="isModalOpen" class="modal-overlay" @click.self="closeModal">
       <div class="modal-content">
@@ -66,7 +71,12 @@
         </div>
         <div class="modal-actions">
           <NoButton class="btn-secondary" iconName="close" :on_click="closeModal">キャンセル</NoButton>
-          <YesButton class="btn-primary" iconName="add_circle" :on_click="applyModalSettings">決定</YesButton>
+          <YesButton
+            v-if="this.$role(roleID).assign_items.update"
+            class="btn-primary"
+            iconName="add_circle"
+            :on_click="applyModalSettings"
+          >決定</YesButton>
         </div>
       </div>
      </div>
@@ -153,6 +163,7 @@
           @dragover.prevent 
           @drop="handleDropOnStock($event, stock)" 
           class="stock-card"
+          :class="{ 'non-interactive': !$role(roleID).assign_items.update }"
         >
           <div class="stock-info">
             <h3>{{ stock.name }}</h3>
@@ -189,7 +200,7 @@
                     class="num-input highlight"
                   >
                 </div>
-                <button class="btn-delete"  @click="openAssignDeleteModal(assign.id)">✕</button>
+                <button v-if="$role(roleID).assign_items.delete" class="btn-delete"  @click="openAssignDeleteModal(assign.id)">✕</button>
               </div>
           </div>
         </div>
@@ -208,6 +219,8 @@
         <NoButton iconName="close" :on_click="closeAssignDeleteModal">いいえ</NoButton>
       </template>
     </DeleteModal>
+    </div>
+    <h1 v-else>閲覧権限がありません</h1>
   </div>
 </template>
 
@@ -464,6 +477,7 @@ export default {
     },
 
     async handleDropOnStock(e, stock) {
+      if (!this.$role(this.roleID).assign_items.update) return;
       const type = e.dataTransfer.getData('type');
       if (type !== 'GROUP') return;
       
@@ -542,6 +556,7 @@ export default {
     },
     // 数の手動変更と保存処理
     async updateManualAssign(e, assign, itemId) {
+      if (!this.$role(this.roleID).assign_items.update) return;
      let newValue = parseInt(e.target.value, 10);
       if (isNaN(newValue) || newValue < 0) {
         newValue = 0;
@@ -604,6 +619,7 @@ export default {
 
     // 削除処理
     async deleteAssign() {
+      if (!this.$role(this.roleID).assign_items.delete) return;
       const targetAssign = this.assignments.find(a => a.id === this.assignRentalItemDeleteId);
 
       if (targetAssign && targetAssign.dbIds && targetAssign.dbIds.length > 0) {
@@ -637,6 +653,7 @@ export default {
       this.closeAssignDeleteModal();
     },
     openAssignDeleteModal(id) {
+      if (!this.$role(this.roleID).assign_items.delete) return;
       this.assignRentalItemDeleteId = id;
       this.isOpenAssignDeleteModal = true;
     },
@@ -646,6 +663,7 @@ export default {
 
     // モーダル制御
     openModal() {
+      if (!this.$role(this.roleID).assign_items.update) return;
       this.modalSettings = JSON.parse(JSON.stringify(this.activeSettings));
       this.isModalOpen = true;
     },
@@ -653,6 +671,7 @@ export default {
       this.isModalOpen = false;
     },
     applyModalSettings() {
+      if (!this.$role(this.roleID).assign_items.update) return;
       this.activeSettings = JSON.parse(JSON.stringify(this.modalSettings));
       this.isModalOpen = false;
     },

--- a/admin_view/nuxt-project/pages/assign_items/index.vue
+++ b/admin_view/nuxt-project/pages/assign_items/index.vue
@@ -103,7 +103,7 @@
           <div 
             v-for="group in filteredGroups" 
             :key="group.id" 
-            draggable="true" 
+            :draggable="$role(roleID).assign_items.update"
             @dragstart="handleDragStartGroup($event, group)" 
             class="group-card"
             :class="{ 'is-fulfilled': isGroupFulfilled(group) }"
@@ -194,6 +194,7 @@
                   <input
                     type="number"
                     min="0"
+                    :disabled="!$role(roleID).assign_items.update"
                     :value="assign.assigned[itemId] || 0"
                     @blur="updateManualAssign($event, assign, itemId)"
                     @keyup.enter="$event.target.blur()"
@@ -472,6 +473,7 @@ export default {
 
     // ドラッグ＆ドロップと保存処理
     handleDragStartGroup(e, group) {
+      if (!this.$role(this.roleID).assign_items.update) return;
       e.dataTransfer.setData('type', 'GROUP');
       e.dataTransfer.setData('groupId', group.id);
     },

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -128,9 +128,16 @@
       <section class="stock-area">
         <div class="order-group-header">
           <h2>貸出場所</h2>
+          <SearchDropDown
+          :nameList="placeCategoryList"
+          :on_click="refinementPlaces"
+          value="formatted_name"
+        >
+          {{ refPlaces }}
+        </SearchDropDown>
         </div>
         <div class="cards">
-          <template v-for="place in places">
+          <template v-for="place in filteredPlaces">
             <template v-for="[placeSourceBreakdown, groupsInPlace] in [[getPlaceSourceBreakdown(place.id), getGroupsInPlace(place.id)]]">
             <div
               :key="place.id" 
@@ -261,22 +268,29 @@ export default {
       groupCategoryList: [], 
       refCategoryID: 0,      
       refCategoryName: "ALL",
+      placeCategoryList: [],
+      refPlaceID: 0,
+      refPlaces: "ALL"
     };
   },
 
   async asyncData({ $axios }) {
-    const [yearsRes, categoriesRes] = await Promise.all([
+    const [yearsRes, categoriesRes, placeCategoriesRes] = await Promise.all([
       $axios.$get("/fes_years").catch(() => ({ data: [] })),
-      $axios.$get("/group_categories").catch(() => ({ data: [] }))
+      $axios.$get("/group_categories").catch(() => ({ data: [] })),
+      $axios.$get("/place_categories").catch(() => ({ data: [] }))
     ]);
 
     return {
       yearList: yearsRes.data || [],
       groupCategoryList: categoriesRes.data || [],
+      placeCategoryList: placeCategoriesRes.data || [],
       refYearID: 0,
       refYears: "ALL",
       refCategoryID: 0,
       refCategoryName: "ALL",
+      refPlaceID: 0,
+      refPlaces: "ALL"
     };
   },
 
@@ -292,6 +306,18 @@ export default {
         (id) => this.activeSettings[id].selected
       ).map(Number);
     },
+    validPlaceCategoryIds() {
+      if (this.refPlaceID === 0) return [];
+      const category = this.placeCategoryList.find(c => Number(c.id) === this.refPlaceID);
+      if (!category) return [this.refPlaceID];
+      return [this.refPlaceID, ...(category.descendant_ids || [])].map(Number);
+    },
+    filteredPlaces() {
+      if (this.refPlaceID === 0) return this.places;
+      return this.places.filter(p => 
+        this.validPlaceCategoryIds.includes(Number(p.place_category_id))
+      );
+    },
     activeAssignedGroups() {
       return this.groups.filter(g => {
         // 年度での絞り込み
@@ -299,7 +325,17 @@ export default {
         
         // 団体のカテゴリーでの絞り込み
         if (this.refCategoryID !== 0 && Number(g.group_category_id) !== this.refCategoryID) return false;
-        
+
+        // 場所での絞り込み
+        if (this.refPlaceID !== 0) {
+          const rentalPlaceId = this.getGroupRentalPlace(g.id);
+          if (!rentalPlaceId) return false;
+          const place = this.places.find(p => Number(p.id) === Number(rentalPlaceId));
+          if (!place || !this.validPlaceCategoryIds.includes(Number(place.place_category_id))) {
+            return false;
+          }
+        }
+
         const groupAssigns = this.assignments.filter(a => Number(a.group_id) === Number(g.id));
         if (groupAssigns.length === 0) return false;
 
@@ -545,6 +581,15 @@ export default {
         this.refCategoryID = item_id;
         const found = name_list.find(x => x.id === item_id);
         this.refCategoryName = item_id === 0 ? "ALL" : (found ? found.name : "Category");
+      }
+    },
+
+    // 場所の絞り込み
+    refinementPlaces(item_id, name_list) {
+      if (name_list === this.placeCategoryList) {
+        this.refPlaceID = item_id;
+        const found = name_list.find(x => x.id === item_id);
+        this.refPlaces = item_id === 0 ? "ALL" : (found ? found.name : "Place");
       }
     }
   }

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -137,7 +137,6 @@
             <!-- 貸出場所情報（テーブルによる合計・内訳の常時表示） -->
             <div class="stock-info">
               <h3>{{ place.name }}</h3>
-              
               <div class="stock-info-tables">
                 <!-- 貸出合計テーブル -->
                 <div class="assign-result-container">
@@ -475,15 +474,15 @@ export default {
 
     getGroupSourceBreakdown(groupId) {
       const assigns = this.assignments.filter(a => Number(a.group_id) === Number(groupId));
-      return this._calculateSourceBreakdown(assigns);
+      return this.calculateSourceBreakdown(assigns);
     },
 
     getPlaceSourceBreakdown(placeId) {
       const assigns = this.assignments.filter(a => Number(a.rental_place_id) === Number(placeId));
-      return this._calculateSourceBreakdown(assigns);
+      return this.calculateSourceBreakdown(assigns);
     },
 
-    _calculateSourceBreakdown(assignRecords) {
+    calculateSourceBreakdown(assignRecords) {
       const sourcesMap = {};
 
       assignRecords.forEach(a => {

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="assign_items">
-    <SubHeader pageTitle="物品貸出場所調整"></SubHeader>
+  <div class="assign_items" v-if="$role(roleID).assign_items.read">
+      <SubHeader pageTitle="物品貸出場所調整"></SubHeader>
     <div class="SearchContainer">
       <div class="SearchContainer-left">
         <SearchDropDown
@@ -60,8 +60,8 @@
           本当にこの団体の割り当てを削除しますか？<br>
         </h4>
         <div class="modal-actions">
-          <YesButton  iconName="delete" :on_click="confirmDelete">削除する</YesButton>
-          <NoButton  iconName="close" :on_click="closeDeleteModal">キャンセル</NoButton>
+          <YesButton v-if="$role(roleID).assign_items.delete" iconName="delete" :on_click="confirmDelete">削除する</YesButton>
+          <NoButton iconName="close" :on_click="closeDeleteModal">キャンセル</NoButton>
         </div>
       </div>
     </div>
@@ -86,13 +86,13 @@
         <div class="order-group-content">
           <template v-for="group in activeAssignedGroups">
             <template v-for="[rentalPlaceId, sourceBreakdown] in [[getGroupRentalPlace(group.id), getGroupSourceBreakdown(group.id)]]">
-              <div 
-                :key="group.id" 
-                draggable="true" 
-                @dragstart="handleDragStartGroup($event, group)" 
-                class="group-card"
-                :class="{ 'is-fulfilled': rentalPlaceId }"
-              >
+            <div
+              :key="group.id" 
+              draggable="true"
+              @dragstart="handleDragStartGroup($event, group)"
+              class="group-card"
+              :class="{ 'is-fulfilled': rentalPlaceId }"
+            >
                 <div class="group-name">
                   {{ group.name }}
                   <span class="assigned" v-if="rentalPlaceId">
@@ -132,12 +132,12 @@
         <div class="cards">
           <template v-for="place in places">
             <template v-for="[placeSourceBreakdown, groupsInPlace] in [[getPlaceSourceBreakdown(place.id), getGroupsInPlace(place.id)]]">
-              <div 
-                :key="place.id" 
-                @dragover.prevent 
-                @drop="handleDropOnPlace($event, place)" 
-                class="stock-card"
-              >
+            <div
+              :key="place.id" 
+              @dragover.prevent
+              @drop="handleDropOnPlace($event, place)"
+              class="stock-card"
+            >
                 <!-- 貸出場所情報（テーブルによる合計・内訳の常時表示） -->
                 <div class="stock-info">
                   <h3>{{ place.name }}</h3>
@@ -224,17 +224,18 @@
                           </span>
                         </div>
                       </div>
-                      <button class="btn-delete" @click="openDeleteModal(group.id)">✕</button>
+                      <button v-if="$role(roleID).assign_items.delete" class="btn-delete" @click="openDeleteModal(group.id)">✕</button>
                     </div>
                   </template>
+                  </div>
                 </div>
-              </div>
             </template>
           </template>
-        </div>
+          </div>
       </section>
     </main>
   </div>
+  <h1 v-else>閲覧権限がありません</h1>
 </template>
 
 <script>
@@ -356,6 +357,7 @@ export default {
     },
 
     async updateAssignmentsPlace(groupAssignments, rentalPlaceId) { 
+      if (!this.$role(this.roleID).assign_items.update) return;
       if (groupAssignments.length === 0) return;
 
       const promises = groupAssignments.map(assign => {
@@ -379,6 +381,8 @@ export default {
     },
 
     async handleDropOnPlace(e, rentalPlace) {
+      if (!this.$role(this.roleID).assign_items.update) return;
+
       const type = e.dataTransfer.getData('type');
       if (type !== 'GROUP_LOCATION') return;
       
@@ -400,6 +404,7 @@ export default {
     // 削除確認モーダルの制御
     // ----------------------------
     openDeleteModal(groupId) {
+      if (!this.$role(this.roleID).assign_items.delete) return;
       this.targetDeleteGroupId = groupId;
       this.isDeleteModalOpen = true;
     },
@@ -408,12 +413,14 @@ export default {
       this.targetDeleteGroupId = null;
     },
     async confirmDelete() {
+      if (!this.$role(this.roleID).assign_items.delete) return;
       if (!this.targetDeleteGroupId) return;
       await this.removeGroupFromPlace(this.targetDeleteGroupId);
       this.closeDeleteModal();
     },
 
     async removeGroupFromPlace(groupId) {
+      if (!this.$role(this.roleID).assign_items.delete) return;
       const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
       try {
         await this.updateAssignmentsPlace(groupAssignments, null);

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -594,11 +594,11 @@ export default {
 }
 .modal-content {
   background-color: white;
-    padding: 24px;
-    border-radius: 12px;
-    width: 90%;
-    max-width: 600px;
-    box-shadow: 0 20px 24px -4px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 600px;
+  box-shadow: 0 20px 24px -4px rgba(0, 0, 0, 0.1);
 }
 .modal-content h2 {
   color: #000000;

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -326,16 +326,6 @@ export default {
         // 団体のカテゴリーでの絞り込み
         if (this.refCategoryID !== 0 && Number(g.group_category_id) !== this.refCategoryID) return false;
 
-        // 場所での絞り込み
-        if (this.refPlaceID !== 0) {
-          const rentalPlaceId = this.getGroupRentalPlace(g.id);
-          if (!rentalPlaceId) return false;
-          const place = this.places.find(p => Number(p.id) === Number(rentalPlaceId));
-          if (!place || !this.validPlaceCategoryIds.includes(Number(place.place_category_id))) {
-            return false;
-          }
-        }
-
         const groupAssigns = this.assignments.filter(a => Number(a.group_id) === Number(g.id));
         if (groupAssigns.length === 0) return false;
 

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -84,40 +84,43 @@
         </SearchDropDown>
         </div>
         <div class="order-group-content">
-          <div 
-            v-for="group in activeAssignedGroups" 
-            :key="group.id" 
-            draggable="true" 
-            @dragstart="handleDragStartGroup($event, group)" 
-            class="group-card"
-            :class="{ 'is-fulfilled': getGroupRentalPlace(group.id) }"
-          >
-            <div class="group-name">
-              {{ group.name }}
-              <span class="assigned" v-if="getGroupRentalPlace(group.id)">
-                {{ getPlaceName(getGroupRentalPlace(group.id)) }}へ
-              </span>
-            </div>
-            <!-- 左側にも搬入元内訳を簡易表示 -->
-            <div class="assign-result-container">
-              <table>
-                <tbody>
-                  <tr v-for="source in getGroupSourceBreakdown(group.id)" :key="source.id">
-                    <td>{{ source.name }}より</td>
-                    <td v-for="itemId in activeItemIds" :key="itemId">
-                      {{ getItemName(itemId) }}: {{ source.items[itemId] || 0 }}
-                    </td>
-                  </tr>
-                  <tr class="total-row">
-                    <td><strong>合計</strong></td>
-                    <td v-for="itemId in activeItemIds" :key="itemId">
-                      <strong>{{ getItemName(itemId) }}: {{ getGroupTotalItem(group.id, itemId) }}</strong>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
+          <template v-for="group in activeAssignedGroups">
+            <template v-for="[rentalPlaceId, sourceBreakdown] in [[getGroupRentalPlace(group.id), getGroupSourceBreakdown(group.id)]]">
+              <div 
+                :key="group.id" 
+                draggable="true" 
+                @dragstart="handleDragStartGroup($event, group)" 
+                class="group-card"
+                :class="{ 'is-fulfilled': rentalPlaceId }"
+              >
+                <div class="group-name">
+                  {{ group.name }}
+                  <span class="assigned" v-if="rentalPlaceId">
+                    {{ getPlaceName(rentalPlaceId) }}へ
+                  </span>
+                </div>
+                <!-- 左側にも搬入元内訳を簡易表示 -->
+                <div class="assign-result-container">
+                  <table>
+                    <tbody>
+                      <tr v-for="source in sourceBreakdown" :key="source.id">
+                        <td>{{ source.name }}より</td>
+                        <td v-for="itemId in activeItemIds" :key="itemId">
+                          {{ getItemName(itemId) }}: {{ source.items[itemId] || 0 }}
+                        </td>
+                      </tr>
+                      <tr class="total-row">
+                        <td><strong>合計</strong></td>
+                        <td v-for="itemId in activeItemIds" :key="itemId">
+                          <strong>{{ getItemName(itemId) }}: {{ getGroupTotalItem(group.id, itemId) }}</strong>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </template>
+          </template>
         </div>
       </aside>
 
@@ -127,101 +130,107 @@
           <h2>貸出場所</h2>
         </div>
         <div class="cards">
-          <div 
-            v-for="place in places" 
-            :key="place.id" 
-            @dragover.prevent 
-            @drop="handleDropOnPlace($event, place)" 
-            class="stock-card"
-          >
-            <!-- 貸出場所情報（テーブルによる合計・内訳の常時表示） -->
-            <div class="stock-info">
-              <h3>{{ place.name }}</h3>
-              <div class="stock-info-tables">
-                <!-- 貸出合計テーブル -->
-                <div class="assign-result-container">
-                  <div class="assign-result">貸出合計</div>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th v-for="itemId in activeItemIds" :key="itemId">{{ getItemName(itemId) }}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td class="text-center" v-for="itemId in activeItemIds" :key="itemId">
-                          <span class="badge-value">
-                            {{ getPlaceTotalItem(place.id, itemId) }}
-                          </span>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-
-                <!-- 搬入元内訳テーブル -->
-                <div class="assign-result-container">
-                  <div class="assign-result">搬入元内訳</div>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>搬入元</th>
-                        <th v-for="itemId in activeItemIds" :key="itemId">{{ getItemName(itemId) }}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="source in getPlaceSourceBreakdown(place.id)" :key="source.id">
-                        <td>{{ source.name }}</td>
-                        <td class="text-center" v-for="itemId in activeItemIds" :key="itemId">
-                          {{ source.items[itemId] || 0 }}
-                        </td>
-                      </tr>
-                      <tr v-if="getPlaceSourceBreakdown(place.id).length === 0">
-                        <td :colspan="activeItemIds.length + 1" class="text-center">
-                          割り当てがありません
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-
-            <!-- ドロップされた団体のリスト -->
-            <div class="assignment-list">
-              <div v-if="getGroupsInPlace(place.id).length === 0" class="empty-state">
-                割り当て済み団体をここにドロップ
-              </div>
+          <template v-for="place in places">
+            <template v-for="[placeSourceBreakdown, groupsInPlace] in [[getPlaceSourceBreakdown(place.id), getGroupsInPlace(place.id)]]">
               <div 
-                v-else 
-                v-for="group in getGroupsInPlace(place.id)"
-                :key="group.id" 
-                class="assignment-item"
+                :key="place.id" 
+                @dragover.prevent 
+                @drop="handleDropOnPlace($event, place)" 
+                class="stock-card"
               >
-                <div class="assign-group-name">
-                  {{ group.name }}
-                  <div class="import-source">
-                    <span v-for="source in getGroupSourceBreakdown(group.id)" :key="source.id">
-                      {{ source.name }}より: 
-                      <template v-for="itemId in activeItemIds">
-                        <span v-if="source.items[itemId] > 0" :key="itemId" style="margin-right: 8px;">
-                          {{ getItemName(itemId) }}{{ source.items[itemId] }}
-                        </span>
+                <!-- 貸出場所情報（テーブルによる合計・内訳の常時表示） -->
+                <div class="stock-info">
+                  <h3>{{ place.name }}</h3>
+                  <div class="stock-info-tables">
+                    <!-- 貸出合計テーブル -->
+                    <div class="assign-result-container">
+                      <div class="assign-result">貸出合計</div>
+                      <table>
+                        <thead>
+                          <tr>
+                            <th v-for="itemId in activeItemIds" :key="itemId">{{ getItemName(itemId) }}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td class="text-center" v-for="itemId in activeItemIds" :key="itemId">
+                              <span class="badge-value">
+                                {{ getPlaceTotalItem(place.id, itemId) }}
+                              </span>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+
+                    <!-- 搬入元内訳テーブル -->
+                    <div class="assign-result-container">
+                      <div class="assign-result">搬入元内訳</div>
+                      <table>
+                        <thead>
+                          <tr>
+                            <th>搬入元</th>
+                            <th v-for="itemId in activeItemIds" :key="itemId">{{ getItemName(itemId) }}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr v-for="source in placeSourceBreakdown" :key="source.id">
+                            <td>{{ source.name }}</td>
+                            <td class="text-center" v-for="itemId in activeItemIds" :key="itemId">
+                              {{ source.items[itemId] || 0 }}
+                            </td>
+                          </tr>
+                          <tr v-if="placeSourceBreakdown.length === 0">
+                            <td :colspan="activeItemIds.length + 1" class="text-center">
+                              割り当てがありません
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- ドロップされた団体のリスト -->
+                <div class="assignment-list">
+                  <div v-if="groupsInPlace.length === 0" class="empty-state">
+                    割り当て済み団体をここにドロップ
+                  </div>
+                  <template v-else>
+                    <div 
+                      v-for="group in groupsInPlace"
+                      :key="group.id" 
+                      class="assignment-item"
+                    >
+                      <template v-for="[groupSourceBreakdown] in [[getGroupSourceBreakdown(group.id)]]">
+                        <div class="assign-group-name">
+                          {{ group.name }}
+                          <div class="import-source">
+                            <span v-for="source in groupSourceBreakdown" :key="source.id">
+                              {{ source.name }}より: 
+                              <template v-for="itemId in activeItemIds">
+                                <span v-if="source.items[itemId] > 0" :key="itemId" style="margin-right: 8px;">
+                                  {{ getItemName(itemId) }}{{ source.items[itemId] }}
+                                </span>
+                              </template>
+                            </span>
+                          </div>
+                        </div>
                       </template>
-                    </span>
-                  </div>
+                      <div class="assign-inputs">
+                        <div v-for="itemId in activeItemIds" :key="itemId" class="assign-input-group">
+                          <span class="input-label">
+                            {{ getItemName(itemId) }} {{ getGroupTotalItem(group.id, itemId) }}
+                          </span>
+                        </div>
+                      </div>
+                      <button class="btn-delete" @click="openDeleteModal(group.id)">✕</button>
+                    </div>
+                  </template>
                 </div>
-                <div class="assign-inputs">
-                  <div v-for="itemId in activeItemIds" :key="itemId" class="assign-input-group">
-                    <span class="input-label">
-                      {{ getItemName(itemId) }} {{ getGroupTotalItem(group.id, itemId) }}
-                    </span>
-                  </div>
-                </div>
-                <button class="btn-delete" @click="openDeleteModal(group.id)">✕</button>
               </div>
-            </div>
-          </div>
+            </template>
+          </template>
         </div>
       </section>
     </main>
@@ -332,7 +341,6 @@ export default {
           this.modalSettings = JSON.parse(JSON.stringify(settings));
           this.activeSettings = JSON.parse(JSON.stringify(settings));
         }
-
       } catch (error) {
       } finally {
         this.isLoading = false;
@@ -347,7 +355,7 @@ export default {
       e.dataTransfer.setData('groupId', group.id);
     },
 
-     async updateAssignmentsPlace(groupAssignments, rentalPlaceId) { 
+    async updateAssignmentsPlace(groupAssignments, rentalPlaceId) { 
       if (groupAssignments.length === 0) return;
 
       const promises = groupAssignments.map(assign => {
@@ -358,8 +366,7 @@ export default {
           stockerPlaceId: assign.stockerPlaceId,
           rental_place_id: rentalPlaceId
         };
-        return this.$axios.$put(`/assign_rental_items/${assign.id}`,
-  payload);
+        return this.$axios.$put(`/assign_rental_items/${assign.id}`, payload);
       });
 
       await Promise.all(promises);
@@ -378,7 +385,7 @@ export default {
       const groupId = e.dataTransfer.getData('groupId');
       if (!groupId) return;
 
-      const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId));
+      const groupAssignments = this.getAssignmentsBy('group_id', groupId);
       if (groupAssignments.length === 0) return;
 
       try {
@@ -408,7 +415,6 @@ export default {
 
     async removeGroupFromPlace(groupId) {
       const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
-      
       try {
         await this.updateAssignmentsPlace(groupAssignments, null);
       } catch (error) {
@@ -417,59 +423,64 @@ export default {
     },
 
     // ----------------------------
+    // ベースメソッド
+    // ----------------------------
+    getNameById(list, id) {
+      const record = list.find(item => Number(item.id) === Number(id));
+      return record ? record.name : '不明';
+    },
+
+    getAssignmentsBy(key, value) {
+      return this.assignments.filter(a => Number(a[key]) === Number(value));
+    },
+
+    getTotalItem(assignRecords, itemId) {
+      return assignRecords
+        .filter(a => Number(a.rental_item_id) === Number(itemId))
+        .reduce((sum, a) => sum + Number(a.num || 0), 0);
+    },
+
+    // ----------------------------
     // 計算・表示用メソッド
     // ----------------------------
     getItemName(itemId) {
-      const item = this.items.find(i => Number(i.id) === Number(itemId));
-      return item ? item.name : '不明';
+      return this.getNameById(this.items, itemId);
     },
 
     getPlaceName(placeId) {
-      const place = this.places.find(p => Number(p.id) === Number(placeId));
-      return place ? place.name : '不明';
+      return this.getNameById(this.places, placeId);
     },
 
     getGroupRentalPlace(groupId) {
-      const assign = this.assignments.find(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
+      const assign = this.getAssignmentsBy('group_id', groupId).find(a => a.rental_place_id);
       return assign ? assign.rental_place_id : null;
     },
 
     getGroupsInPlace(placeId) {
       const groupIdsInPlace = [...new Set(
-        this.assignments
-          .filter(a => Number(a.rental_place_id) === Number(placeId))
-          .map(a => Number(a.group_id))
+        this.getAssignmentsBy('rental_place_id', placeId).map(a => Number(a.group_id))
       )];
       
       return this.groups.filter(g => {
         if (!groupIdsInPlace.includes(Number(g.id))) return false;
-
-        return this.activeItemIds.some(itemId => {
-          return this.getGroupTotalItem(g.id, itemId) > 0;
-        });
+        return this.activeItemIds.some(itemId => this.getGroupTotalItem(g.id, itemId) > 0);
       });
     },
 
     getGroupTotalItem(groupId, itemId) {
-      return this.assignments
-        .filter(a => Number(a.group_id) === Number(groupId) && Number(a.rental_item_id) === Number(itemId))
-        .reduce((sum, a) => sum + Number(a.num || 0), 0);
+      return this.getTotalItem(this.getAssignmentsBy('group_id', groupId), itemId);
     },
 
     getPlaceTotalItem(placeId, itemId) {
-      return this.assignments
-        .filter(a => Number(a.rental_place_id) === Number(placeId) && Number(a.rental_item_id) === Number(itemId))
-        .reduce((sum, a) => sum + Number(a.num || 0), 0);
+      return this.getTotalItem(this.getAssignmentsBy('rental_place_id', placeId), itemId);
     },
 
     getGroupSourceBreakdown(groupId) {
-      const assigns = this.assignments.filter(a => Number(a.group_id) === Number(groupId));
-      return this.calculateSourceBreakdown(assigns);
+      return this.calculateSourceBreakdown(this.getAssignmentsBy('group_id', groupId));
     },
 
     getPlaceSourceBreakdown(placeId) {
-      const assigns = this.assignments.filter(a => Number(a.rental_place_id) === Number(placeId));
-      return this.calculateSourceBreakdown(assigns);
+      return this.calculateSourceBreakdown(this.getAssignmentsBy('rental_place_id', placeId));
     },
 
     calculateSourceBreakdown(assignRecords) {

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -326,7 +326,7 @@ export default {
         if (Object.keys(this.modalSettings).length === 0) {
           const settings = {};
           this.items.forEach(item => {
-            const isDefault = item.id === 1 || item.id === 3;
+            const isDefault = item.name === '机' || item.name === '椅子';
             settings[item.id] = { selected: isDefault };
           });
           this.modalSettings = JSON.parse(JSON.stringify(settings));

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -350,6 +350,7 @@ export default {
   },
 
   mounted() {
+    if (!this.$role(this.roleID).assign_items.read) return;
     this.fetchDataFromDB();
   },
 

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -335,7 +335,6 @@ export default {
         }
 
       } catch (error) {
-        console.error("データの取得に失敗", error);
       } finally {
         this.isLoading = false;
       }
@@ -379,7 +378,6 @@ export default {
         
         this.assignments = [...this.assignments];
       } catch (error) {
-        console.error("貸出場所の更新に失敗しました", error);
         alert("貸出場所の割り当てに失敗しました。");
         await this.fetchDataFromDB();
       }
@@ -425,7 +423,6 @@ export default {
         
         this.assignments = [...this.assignments];
       } catch (error) {
-        console.error("貸出場所の解除に失敗しました", error);
         alert("割り当ての解除に失敗しました。");
       }
     },

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -110,7 +110,7 @@
                   </tr>
                   <tr class="total-row">
                     <td><strong>合計</strong></td>
-                    <td v-for="itemId in activeItemIds">
+                    <td v-for="itemId in activeItemIds" :key="itemId">
                       <strong>{{ getItemName(itemId) }}: {{ getGroupTotalItem(group.id, itemId) }}</strong>
                     </td>
                   </tr>

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -1,0 +1,935 @@
+<template>
+  <div class="assign_items">
+    <SubHeader pageTitle="物品貸出場所調整"></SubHeader>
+    <div class="SearchContainer">
+      <div class="SearchContainer-left">
+        <SearchDropDown
+          :nameList="yearList"
+          :on_click="refinementYears"
+          value="year_num"
+        >
+          {{ refYears }}
+        </SearchDropDown>
+      </div>
+      <CommonButton class="btn-primary" iconName="edit" :on_click="openModal">
+        対象物品を設定
+      </CommonButton>
+    </div>
+
+    <!-- 物品設定モーダル -->
+    <div v-if="isModalOpen" class="modal-overlay" @click.self="closeModal">
+      <div class="modal-content">
+        <h2>対象物品の選択 (最大5つ)</h2>
+        <div class="modal-info">
+          現在選択中: <strong>{{ selectedItemCount }}</strong> / 5
+        </div>
+        <div class="table-container"> 
+          <table class="item-table">
+            <thead>
+              <tr>
+                <th class="text-center">選択</th>
+                <th>物品名</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in items" :key="item.id">
+                <td class="text-center">
+                  <input 
+                    type="checkbox" 
+                    v-model="modalSettings[item.id].selected"
+                    :disabled="!modalSettings[item.id].selected && selectedItemCount >= 5"
+                  >
+                </td>
+                <td>{{ item.name }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="modal-actions">
+          <NoButton class="btn-secondary" iconName="close" :on_click="closeModal">キャンセル</NoButton>
+          <YesButton class="btn-primary" iconName="add_circle" :on_click="applyModalSettings">決定</YesButton>
+        </div>
+      </div>
+    </div>
+
+    <!-- 削除確認モーダル -->
+    <div v-if="isDeleteModalOpen" class="modal-overlay" @click.self="closeDeleteModal">
+      <div class="delete-modal-content">
+        <h2>割り当ての削除</h2>
+        <h4>
+          本当にこの団体の割り当てを削除しますか？<br>
+        </h4>
+        <div class="modal-actions">
+          <YesButton  iconName="delete" :on_click="confirmDelete">削除する</YesButton>
+          <NoButton  iconName="close" :on_click="closeDeleteModal">キャンセル</NoButton>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="isLoading" class="loading-area">
+      <p>読み込み中...</p>
+    </div>
+
+    <main v-else class="main-layout">
+      <!-- 左側：割り当て済み団体リスト -->
+      <aside class="order-group">
+        <div class="order-group-header">
+          <h2>割り当て済み団体</h2>
+          <SearchDropDown
+          :nameList="groupCategoryList"
+          :on_click="refinementCategories"
+          value="name"
+        >
+          {{ refCategoryName }}
+        </SearchDropDown>
+        </div>
+        <div class="order-group-content">
+          <div 
+            v-for="group in activeAssignedGroups" 
+            :key="group.id" 
+            draggable="true" 
+            @dragstart="handleDragStartGroup($event, group)" 
+            class="group-card"
+            :class="{ 'is-fulfilled': getGroupRentalPlace(group.id) }"
+          >
+            <div class="group-name">
+              {{ group.name }}
+              <span class="assigned" v-if="getGroupRentalPlace(group.id)">
+                {{ getPlaceName(getGroupRentalPlace(group.id)) }}へ
+              </span>
+            </div>
+            <!-- 左側にも搬入元内訳を簡易表示 -->
+            <div class="assign-result-container">
+              <table>
+                <tbody>
+                  <tr v-for="source in getGroupSourceBreakdown(group.id)" :key="source.id">
+                    <td>{{ source.name }}より</td>
+                    <td v-for="itemId in activeItemIds" :key="itemId">
+                      {{ getItemName(itemId) }}: {{ source.items[itemId] || 0 }}
+                    </td>
+                  </tr>
+                  <tr class="total-row">
+                    <td><strong>合計</strong></td>
+                    <td v-for="itemId in activeItemIds">
+                      <strong>{{ getItemName(itemId) }}: {{ getGroupTotalItem(group.id, itemId) }}</strong>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <!-- 右側：貸出場所エリア -->
+      <section class="stock-area">
+        <div class="order-group-header">
+          <h2>貸出場所</h2>
+        </div>
+        <div class="cards">
+          <div 
+            v-for="place in places" 
+            :key="place.id" 
+            @dragover.prevent 
+            @drop="handleDropOnPlace($event, place)" 
+            class="stock-card"
+          >
+            <!-- 貸出場所情報（テーブルによる合計・内訳の常時表示） -->
+            <div class="stock-info">
+              <h3>{{ place.name }}</h3>
+              
+              <div class="stock-info-tables">
+                <!-- 貸出合計テーブル -->
+                <div class="assign-result-container">
+                  <div class="assign-result">貸出合計</div>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th v-for="itemId in activeItemIds" :key="itemId">{{ getItemName(itemId) }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td class="text-center" v-for="itemId in activeItemIds" :key="itemId">
+                          <span class="badge-value">
+                            {{ getPlaceTotalItem(place.id, itemId) }}
+                          </span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <!-- 搬入元内訳テーブル -->
+                <div class="assign-result-container">
+                  <div class="assign-result">搬入元内訳</div>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>搬入元</th>
+                        <th v-for="itemId in activeItemIds" :key="itemId">{{ getItemName(itemId) }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="source in getPlaceSourceBreakdown(place.id)" :key="source.id">
+                        <td>{{ source.name }}</td>
+                        <td class="text-center" v-for="itemId in activeItemIds" :key="itemId">
+                          {{ source.items[itemId] || 0 }}
+                        </td>
+                      </tr>
+                      <tr v-if="getPlaceSourceBreakdown(place.id).length === 0">
+                        <td :colspan="activeItemIds.length + 1" class="text-center">
+                          割り当てがありません
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            <!-- ドロップされた団体のリスト -->
+            <div class="assignment-list">
+              <div v-if="getGroupsInPlace(place.id).length === 0" class="empty-state">
+                割り当て済み団体をここにドロップ
+              </div>
+              <div 
+                v-else 
+                v-for="group in getGroupsInPlace(place.id)"
+                :key="group.id" 
+                class="assignment-item"
+              >
+                <div class="assign-group-name">
+                  {{ group.name }}
+                  <div class="import-source">
+                    <span v-for="source in getGroupSourceBreakdown(group.id)" :key="source.id">
+                      {{ source.name }}より: 
+                      <template v-for="itemId in activeItemIds">
+                        <span v-if="source.items[itemId] > 0" :key="itemId" style="margin-right: 8px;">
+                          {{ getItemName(itemId) }}{{ source.items[itemId] }}
+                        </span>
+                      </template>
+                    </span>
+                  </div>
+                </div>
+                <div class="assign-inputs">
+                  <div v-for="itemId in activeItemIds" :key="itemId" class="assign-input-group">
+                    <span class="input-label">
+                      {{ getItemName(itemId) }} {{ getGroupTotalItem(group.id, itemId) }}
+                    </span>
+                  </div>
+                </div>
+                <button class="btn-delete" @click="openDeleteModal(group.id)">✕</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+export default {
+  name: 'FestManagerLocationDynamic',
+  data() {
+    return {
+      isLoading: true,
+      isModalOpen: false,
+      isDeleteModalOpen: false,
+      targetDeleteGroupId: null,
+      items: [],
+      groups: [],
+      places: [],
+      assignments: [],
+      modalSettings: {},
+      activeSettings: {},
+      yearList: [],
+      refYearID: 0,
+      refYears: "ALL",
+      groupCategoryList: [], 
+      refCategoryID: 0,      
+      refCategoryName: "ALL",
+    };
+  },
+
+  async asyncData({ $axios }) {
+    const [yearsRes, categoriesRes] = await Promise.all([
+      $axios.$get("/fes_years").catch(() => ({ data: [] })),
+      $axios.$get("/group_categories").catch(() => ({ data: [] }))
+    ]);
+
+    return {
+      yearList: yearsRes.data || [],
+      groupCategoryList: categoriesRes.data || [],
+      refYearID: 0,
+      refYears: "ALL",
+      refCategoryID: 0,
+      refCategoryName: "ALL",
+    };
+  },
+
+  computed: {
+    ...mapState({
+      roleID: (state) => state.users.role,
+    }),
+    selectedItemCount() {
+      return Object.values(this.modalSettings).filter((s) => s.selected).length;
+    },
+    activeItemIds() {
+      return Object.keys(this.activeSettings).filter(
+        (id) => this.activeSettings[id].selected
+      ).map(Number);
+    },
+    activeAssignedGroups() {
+      return this.groups.filter(g => {
+        // 年度での絞り込み
+        if (this.refYearID !== 0 && Number(g.fes_year_id) !== this.refYearID) return false;
+        
+        // 団体のカテゴリーでの絞り込み
+        if (this.refCategoryID !== 0 && Number(g.group_category_id) !== this.refCategoryID) return false;
+        
+        const groupAssigns = this.assignments.filter(a => Number(a.group_id) === Number(g.id));
+        if (groupAssigns.length === 0) return false;
+
+        return this.activeItemIds.some(itemId => {
+          const total = groupAssigns
+            .filter(a => Number(a.rental_item_id) === itemId)
+            .reduce((sum, a) => sum + Number(a.num || 0), 0);
+          return total > 0;
+        });
+      });
+    }
+  },
+
+  mounted() {
+    this.fetchDataFromDB();
+  },
+
+  methods: {
+    async fetchDataFromDB() {
+      this.isLoading = true;
+      try {
+        const [itemsRes, groupsRes, placesRes, assignRes] = await Promise.all([
+          this.$axios.$get('/rental_items'),
+          this.$axios.$get('/groups'),
+          this.$axios.$get('/stocker_places'), 
+          this.$axios.$get('/assign_rental_items')
+        ]);
+
+        this.items = Array.isArray(itemsRes) ? itemsRes : itemsRes.data;
+        this.groups = Array.isArray(groupsRes) ? groupsRes : groupsRes.data;
+        this.places = Array.isArray(placesRes) ? placesRes : placesRes.data;
+        this.assignments = Array.isArray(assignRes) ? assignRes : assignRes.data;
+
+        if (Object.keys(this.modalSettings).length === 0) {
+          const settings = {};
+          this.items.forEach(item => {
+            const isDefault = item.id === 1 || item.id === 3;
+            settings[item.id] = { selected: isDefault };
+          });
+          this.modalSettings = JSON.parse(JSON.stringify(settings));
+          this.activeSettings = JSON.parse(JSON.stringify(settings));
+        }
+
+      } catch (error) {
+        console.error("データの取得に失敗", error);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+
+    // ----------------------------
+    // ドラッグ＆ドロップ制御
+    // ----------------------------
+    handleDragStartGroup(e, group) {
+      e.dataTransfer.setData('type', 'GROUP_LOCATION');
+      e.dataTransfer.setData('groupId', group.id);
+    },
+
+    async handleDropOnPlace(e, rentalPlace) {
+      const type = e.dataTransfer.getData('type');
+      if (type !== 'GROUP_LOCATION') return;
+      
+      const groupId = e.dataTransfer.getData('groupId');
+      if (!groupId) return;
+
+      const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId));
+      if (groupAssignments.length === 0) return;
+
+      try {
+        const promises = groupAssignments.map(assign => {
+          const payload = {
+            group_id: assign.groupId,
+            rentalItemId: assign.rentalItemId,
+            num: assign.num,
+            stockerPlaceId: assign.stockerPlaceId,
+            rental_place_id: rentalPlace.id
+          };
+          return this.$axios.$put(`/assign_rental_items/${assign.id}`, payload);
+        });
+
+        await Promise.all(promises);
+
+        groupAssignments.forEach(a => {
+          a.rental_place_id = rentalPlace.id;
+        });
+        
+        this.assignments = [...this.assignments];
+      } catch (error) {
+        console.error("貸出場所の更新に失敗しました", error);
+        alert("貸出場所の割り当てに失敗しました。");
+        await this.fetchDataFromDB();
+      }
+    },
+
+    // ----------------------------
+    // 削除確認モーダルの制御
+    // ----------------------------
+    openDeleteModal(groupId) {
+      this.targetDeleteGroupId = groupId;
+      this.isDeleteModalOpen = true;
+    },
+    closeDeleteModal() {
+      this.isDeleteModalOpen = false;
+      this.targetDeleteGroupId = null;
+    },
+    async confirmDelete() {
+      if (!this.targetDeleteGroupId) return;
+      await this.removeGroupFromPlace(this.targetDeleteGroupId);
+      this.closeDeleteModal();
+    },
+
+    async removeGroupFromPlace(groupId) {
+      const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
+      
+      try {
+        const promises = groupAssignments.map(assign => {
+          const payload = {
+            group_id: assign.groupId,
+            rentalItemId: assign.rentalItemId,
+            num: assign.num,
+            stockerPlaceId: assign.stockerPlaceId,
+            rental_place_id: null
+          };
+          return this.$axios.$put(`/assign_rental_items/${assign.id}`, payload);
+        });
+
+        await Promise.all(promises);
+
+        groupAssignments.forEach(a => {
+          a.rental_place_id = null;
+        });
+        
+        this.assignments = [...this.assignments];
+      } catch (error) {
+        console.error("貸出場所の解除に失敗しました", error);
+        alert("割り当ての解除に失敗しました。");
+      }
+    },
+
+    // ----------------------------
+    // 計算・表示用メソッド
+    // ----------------------------
+    getItemName(itemId) {
+      const item = this.items.find(i => Number(i.id) === Number(itemId));
+      return item ? item.name : '不明';
+    },
+
+    getPlaceName(placeId) {
+      const place = this.places.find(p => Number(p.id) === Number(placeId));
+      return place ? place.name : '不明';
+    },
+
+    getGroupRentalPlace(groupId) {
+      const assign = this.assignments.find(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
+      return assign ? assign.rental_place_id : null;
+    },
+
+    getGroupsInPlace(placeId) {
+      const groupIdsInPlace = [...new Set(
+        this.assignments
+          .filter(a => Number(a.rental_place_id) === Number(placeId))
+          .map(a => Number(a.group_id))
+      )];
+      
+      return this.groups.filter(g => {
+        if (!groupIdsInPlace.includes(Number(g.id))) return false;
+
+        return this.activeItemIds.some(itemId => {
+          return this.getGroupTotalItem(g.id, itemId) > 0;
+        });
+      });
+    },
+
+    getGroupTotalItem(groupId, itemId) {
+      return this.assignments
+        .filter(a => Number(a.group_id) === Number(groupId) && Number(a.rental_item_id) === Number(itemId))
+        .reduce((sum, a) => sum + Number(a.num || 0), 0);
+    },
+
+    getPlaceTotalItem(placeId, itemId) {
+      return this.assignments
+        .filter(a => Number(a.rental_place_id) === Number(placeId) && Number(a.rental_item_id) === Number(itemId))
+        .reduce((sum, a) => sum + Number(a.num || 0), 0);
+    },
+
+    getGroupSourceBreakdown(groupId) {
+      const assigns = this.assignments.filter(a => Number(a.group_id) === Number(groupId));
+      return this._calculateSourceBreakdown(assigns);
+    },
+
+    getPlaceSourceBreakdown(placeId) {
+      const assigns = this.assignments.filter(a => Number(a.rental_place_id) === Number(placeId));
+      return this._calculateSourceBreakdown(assigns);
+    },
+
+    _calculateSourceBreakdown(assignRecords) {
+      const sourcesMap = {};
+
+      assignRecords.forEach(a => {
+        const sourceId = Number(a.stocker_place_id);
+        const itemId = Number(a.rental_item_id);
+
+        if (!this.activeItemIds.includes(itemId)) return;
+
+        if (!sourcesMap[sourceId]) {
+          sourcesMap[sourceId] = {
+            id: sourceId,
+            name: this.getPlaceName(sourceId),
+            items: {}
+          };
+        }
+
+        sourcesMap[sourceId].items[itemId] = (sourcesMap[sourceId].items[itemId] || 0) + Number(a.num || 0);
+      });
+
+      return Object.values(sourcesMap).filter(source => {
+        return Object.values(source.items).some(count => count > 0);
+      });
+    },
+
+    // ----------------------------
+    // モーダル＆絞り込み制御
+    // ----------------------------
+    openModal() {
+      this.modalSettings = JSON.parse(JSON.stringify(this.activeSettings));
+      this.isModalOpen = true;
+    },
+    closeModal() {
+      this.isModalOpen = false;
+    },
+    applyModalSettings() {
+      this.activeSettings = JSON.parse(JSON.stringify(this.modalSettings));
+      this.isModalOpen = false;
+    },
+    
+    // 年度の絞り込み
+    refinementYears(item_id, name_list) {
+      if (name_list === this.yearList) {
+        this.refYearID = item_id;
+        const found = name_list.find(x => x.id === item_id);
+        this.refYears = item_id === 0 ? "ALL" : (found ? found.year_num : "Year");
+      }
+    },
+
+    // カテゴリーの絞り込み
+    refinementCategories(item_id, name_list) {
+      if (name_list === this.groupCategoryList) {
+        this.refCategoryID = item_id;
+        const found = name_list.find(x => x.id === item_id);
+        this.refCategoryName = item_id === 0 ? "ALL" : (found ? found.name : "Category");
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.assign_items {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+.SearchContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  color: white;
+  padding: 8px 18px;
+}
+.SearchContainer h1 {
+  margin: 0;
+  font-size: 16px;
+}
+.SearchContainer-left {
+  display: flex; 
+  gap: 16px;
+}
+.btn-delete {
+  background: none;
+  border: none;
+  color: #cbd5e1;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 12px;
+}
+.btn-delete:hover {
+  color: #ef4444;
+}
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3;
+}
+.modal-content {
+  background-color: white;
+    padding: 24px;
+    border-radius: 12px;
+    width: 90%;
+    max-width: 600px;
+    box-shadow: 0 20px 24px -4px rgba(0, 0, 0, 0.1);
+}
+.modal-content h2 {
+  color: #000000;
+  margin-bottom: 16px;
+}
+.modal-content p {
+  margin-bottom: 24px; 
+  font-size: 14px; 
+  color: #334155;
+}
+.modal-content p span {
+  font-size: 12px; 
+  color: #64748b;
+}
+.modal-info {
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: #64748b;
+}
+.delete-modal-content {
+  width: 600px;
+  height: 400px;
+  z-index: 15;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column;
+  padding: 50px 50px;
+  color: #fff;
+  background: radial-gradient(ellipse at top left, rgba(251, 251, 251, 0.9), rgba(251, 251, 251, 0.8));
+  backdrop-filter: blur(4px);
+  gap: 30px;
+}
+.delete-modal-content h2 {
+  color: #666666;
+}
+.delete-modal-content h4 {
+  color: #666666;
+  font-size: 16px;
+  padding: 50px;
+}
+.table-container {
+  max-height: 50vh; 
+  overflow-y: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  margin-bottom: 18px;
+}
+.item-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+}
+.item-table th {
+  position: sticky;
+  top: 0;
+  background-color:#f8fafc;
+  font-weight: bold;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 2px solid #cbd5e1;
+  padding: 10px;
+  text-align: left;
+}
+.item-table td {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 10px;
+  text-align: left;
+  background-color: white;
+}
+.text-center {
+  text-align: center;
+  font-size: 14px;
+}
+.modal-actions {
+  display: flex;
+  justify-content: center; 
+  gap: 16px;
+}
+.assign-result-container {
+  overflow-x: auto;
+  border-left: 1px solid #e2e8f0;
+  border-right: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+  border-radius: 8px;
+  margin-top: 10px;
+  flex: 1; 
+  background: white; 
+}
+.assign-result-container table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.assign-result-container th {
+  background-color:#f8fafc;
+  font-weight: bold;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 2px solid #cbd5e1;
+  padding: 10px;
+  white-space: nowrap;
+}
+.assign-result-container td {
+  padding: 8px;
+  background-color: white;
+  border-bottom: 1px solid #e2e8f0;
+}
+.loading-area {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  color: #64748b;
+}
+.main-layout {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  margin: 0%;
+  padding: 0%;
+  flex-direction: row;
+  align-items: stretch;
+  border: 1px solid #ebebeb;
+}
+.order-group {
+  width: 35%;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  scrollbar-width: thin;
+}
+.order-group-header {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 80px;
+  background-color: #ffffff;
+  border-bottom: 1px solid #000000;
+}
+.order-group-header h2 {
+  margin: 0;
+  padding: 12px;
+  font-size: 16px;
+  color: #334155;
+}
+.order-group-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  scrollbar-width: thin;
+}
+.group-card {
+  padding: 10px;
+  border: 1px solid #999999;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+  cursor: grab;
+  transition: all 0.2s;
+}
+.group-card:active {
+  cursor: grabbing;
+}
+.group-card:hover {
+  border-color: #4c4c4c;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.2);
+}
+.group-card.is-fulfilled {
+  background-color: #f0fdf4;
+  border-color: #16a34a;
+  opacity: 0.6;
+}
+.group-name {
+  font-weight: bold;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.total-row td {
+  border-top: 2px solid #94a3b8;
+  background-color: #f1f5f9;    
+  color: #0f172a;
+}
+.request-badge {
+  flex: 1;
+  min-width: 60px;
+  background-color: #f1f5f9;
+  padding: 4px;
+  border-radius: 4px;
+  text-align: center;
+  font-size: 12px;
+}
+.badge-label {
+  display: block;
+  color: #64748b;
+  font-size: 12px;
+}
+.badge-value {
+  font-weight: bold;
+  font-size: 12px;
+}
+.text-success { 
+  color: #16a34a; 
+  font-weight: bold;
+}
+
+.assign-result {
+  font-weight: bold;
+  font-size: 13px;
+  color: #16a34a;
+  padding-top: 8px;
+  padding-bottom: 4px;
+  padding-left: 8px;
+}
+.assigned {  
+  font-size: 12px;
+  background-color: #e2e8f0;
+  border-radius: 10px;
+  padding: 4px 8px;
+  color: #000000;
+}
+.stock-area {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.cards {
+  padding: 16px;
+  scrollbar-width: thin;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.stock-card {
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  min-height: 200px;
+  flex-shrink: 0;
+}
+.stock-info {
+  padding: 16px;
+  border-right: 1px solid #e0e7ff;
+  display: flex;
+  align-items: flex-start; 
+  flex-direction: column; 
+  background-color: #EBEBEB;
+}
+.stock-info h3 {
+  margin: 0 0 12px 0;
+  color: #000000; 
+  font-size: 16px;
+}
+.stock-info-tables {
+  display: flex; 
+  gap: 16px; 
+  width: 100%;
+}
+.assignment-list {
+  flex: 1;
+  background-color: white;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+  font-size: 14px;
+  border: 2px dashed #cbd5e1;
+  border-radius: 8px;
+}
+.assignment-item {
+  display: flex;
+  align-items: center;
+  background-color: white;
+  padding: 12px;
+  border: 1px solid #16a34a;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+.assign-group-name {
+  flex: 1;
+  font-weight: bold;
+  font-size: 14px;
+  color: #1e293b;
+  padding-left: 8px;
+}
+.assign-inputs {
+  display: flex;
+  gap: 8px;
+  margin-right: 12px;
+  justify-content: flex-end;
+}
+.assign-input-group {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+.input-label {
+  font-size: 13px;
+  background-color: #dcfce7; 
+  padding: 2px 8px; 
+  border-radius: 10px; 
+  color: #16a34a; 
+  font-weight: bold;
+}
+.import-source {
+  font-size: 11px; 
+  font-weight: normal; 
+  color: #64748b; 
+  margin-top: 4px;
+}
+.import-source span {
+  margin-right: 4px;
+}
+</style>

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -308,14 +308,14 @@ export default {
     },
     validPlaceCategoryIds() {
       if (this.refPlaceID === 0) return [];
-      const category = this.placeCategoryList.find(c => Number(c.id) === this.refPlaceID);
+      const category = this.placeCategoryList.find(placeCategory => Number(placeCategory.id) === this.refPlaceID);
       if (!category) return [this.refPlaceID];
       return [this.refPlaceID, ...(category.descendant_ids || [])].map(Number);
     },
     filteredPlaces() {
       if (this.refPlaceID === 0) return this.places;
-      return this.places.filter(p => 
-        this.validPlaceCategoryIds.includes(Number(p.place_category_id))
+      return this.places.filter(place =>
+        this.validPlaceCategoryIds.includes(Number(place.place_category_id))
       );
     },
     activeAssignedGroups() {
@@ -579,8 +579,15 @@ export default {
     refinementPlaces(item_id, name_list) {
       if (name_list === this.placeCategoryList) {
         this.refPlaceID = item_id;
-        const found = name_list.find(x => x.id === item_id);
-        this.refPlaces = item_id === 0 ? "ALL" : (found ? found.name : "Place");
+        const matchedPlace = name_list.find(x => x.id === item_id);
+
+        if (item_id === 0) {
+          this.refPlaces = "ALL";
+        } else if (!matchedPlace) {
+          this.refPlaces = "Place";
+        } else {
+          this.refPlaces = matchedPlace.name;
+        }
       }
     }
   }

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -347,6 +347,30 @@ export default {
       e.dataTransfer.setData('groupId', group.id);
     },
 
+     async updateAssignmentsPlace(groupAssignments, rentalPlaceId) { 
+      if (groupAssignments.length === 0) return;
+
+      const promises = groupAssignments.map(assign => {
+        const payload = {
+          group_id: assign.groupId,
+          rentalItemId: assign.rentalItemId,
+          num: assign.num,
+          stockerPlaceId: assign.stockerPlaceId,
+          rental_place_id: rentalPlaceId
+        };
+        return this.$axios.$put(`/assign_rental_items/${assign.id}`,
+  payload);
+      });
+
+      await Promise.all(promises);
+
+      groupAssignments.forEach(a => {
+        a.rental_place_id = rentalPlaceId;
+      });
+
+      this.assignments = [...this.assignments];
+    },
+
     async handleDropOnPlace(e, rentalPlace) {
       const type = e.dataTransfer.getData('type');
       if (type !== 'GROUP_LOCATION') return;
@@ -358,24 +382,7 @@ export default {
       if (groupAssignments.length === 0) return;
 
       try {
-        const promises = groupAssignments.map(assign => {
-          const payload = {
-            group_id: assign.groupId,
-            rentalItemId: assign.rentalItemId,
-            num: assign.num,
-            stockerPlaceId: assign.stockerPlaceId,
-            rental_place_id: rentalPlace.id
-          };
-          return this.$axios.$put(`/assign_rental_items/${assign.id}`, payload);
-        });
-
-        await Promise.all(promises);
-
-        groupAssignments.forEach(a => {
-          a.rental_place_id = rentalPlace.id;
-        });
-        
-        this.assignments = [...this.assignments];
+        await this.updateAssignmentsPlace(groupAssignments, rentalPlace.id);
       } catch (error) {
         alert("貸出場所の割り当てに失敗しました。");
         await this.fetchDataFromDB();
@@ -403,24 +410,7 @@ export default {
       const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
       
       try {
-        const promises = groupAssignments.map(assign => {
-          const payload = {
-            group_id: assign.groupId,
-            rentalItemId: assign.rentalItemId,
-            num: assign.num,
-            stockerPlaceId: assign.stockerPlaceId,
-            rental_place_id: null
-          };
-          return this.$axios.$put(`/assign_rental_items/${assign.id}`, payload);
-        });
-
-        await Promise.all(promises);
-
-        groupAssignments.forEach(a => {
-          a.rental_place_id = null;
-        });
-        
-        this.assignments = [...this.assignments];
+        await this.updateAssignmentsPlace(groupAssignments, null);
       } catch (error) {
         alert("割り当ての解除に失敗しました。");
       }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #2106 

# 概要
<!-- 開発内容の概要を記載 -->
- 物品割り当て画面をベースにした物品貸出場所調整画面の実装

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- ドラッグアンドドロップによる物品貸出場所割り当て機能の実装
- 団体ごとの搬入元内訳は常時表示
- 貸出場所ごとに合計搬入数と搬入元内訳をテーブルで表示
- ドロップすると自動で保存がかかるようにする
- 物品選択モーダル、年度・団体カテゴリーの絞り込みの実装

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1896" height="905" alt="スクリーンショット 2026-07-11 185852" src="https://github.com/user-attachments/assets/fb967d7f-fabb-443a-b229-4c7532fa326f" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 貸出場所が正しく設定できるか
- [ ] 対象物品を設定できるか
- [ ] 自動でデータベースに保存されるか

# 備考
<!-- 実装していて困った箇所・質問など -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 「物品貸出場所調整」メニューを追加しました。
  - 物品（最大5つ）を選択し、団体の貸出場所への割当／解除をドラッグ＆ドロップで行える画面を追加しました（貸出合計・搬入元内訳・割当済み一覧、削除確認あり）。
- **改善**
  - 初期選択を物品名（「机」「椅子」）に基づく方式へ変更しました。
  - 権限に応じて表示・操作を制御し、年度／団体カテゴリ／貸出場所カテゴリの絞り込みに対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->