### PR TITLE
fix: 全申請の再提出機能を修正

### DIFF
--- a/api/test/models/health_center_submission_status_test.rb
+++ b/api/test/models/health_center_submission_status_test.rb
@@ -92,6 +92,48 @@ class HealthCenterSubmissionStatusTest < ActiveSupport::TestCase
     assert_equal 1, HealthCenterSubmissionStatus.where(group: @group, application_type: :power_order).count
   end
 
+  test 'notifies Slack with the application name for every resubmission type' do
+    posted_messages = []
+    slack_client = Object.new
+    slack_client.define_singleton_method(:chat_postMessage) do |**args|
+      posted_messages << args[:text]
+    end
+
+    with_slack_client(slack_client) do
+      HealthCenterSubmissionStatus::APPLICATION_TYPE_JA.each do |application_type, application_name|
+        submission_status = HealthCenterSubmissionStatus.create!(
+          group: @group,
+          application_type: application_type,
+          status: :waiting_resubmission
+        )
+
+        assert_difference -> { posted_messages.length }, 1 do
+          submission_status.update!(status: :unapproved)
+        end
+        assert_includes posted_messages.last, "申請種類：#{application_name}"
+      end
+    end
+  end
+
+  test 'does not notify Slack for a status change other than resubmission completion' do
+    posted_messages = []
+    slack_client = Object.new
+    slack_client.define_singleton_method(:chat_postMessage) do |**args|
+      posted_messages << args[:text]
+    end
+    submission_status = HealthCenterSubmissionStatus.create!(
+      group: @group,
+      application_type: :food_product,
+      status: :unapproved
+    )
+
+    with_slack_client(slack_client) do
+      assert_no_difference -> { posted_messages.length } do
+        submission_status.update!(status: :approved)
+      end
+    end
+  end
+
   private
 
   def create_user!(email:)
@@ -104,5 +146,14 @@ class HealthCenterSubmissionStatusTest < ActiveSupport::TestCase
       password_confirmation: 'password',
       role_id: 1
     )
+  end
+
+  def with_slack_client(slack_client)
+    original_new = Slack::Web::Client.method(:new)
+    Slack::Web::Client.define_singleton_method(:new) { slack_client }
+
+    yield
+  ensure
+    Slack::Web::Client.define_singleton_method(:new, original_new)
   end
 end

--- a/api/test/models/health_center_submission_status_test.rb
+++ b/api/test/models/health_center_submission_status_test.rb
@@ -94,10 +94,7 @@ class HealthCenterSubmissionStatusTest < ActiveSupport::TestCase
 
   test 'notifies Slack with the application name for every resubmission type' do
     posted_messages = []
-    slack_client = Object.new
-    slack_client.define_singleton_method(:chat_postMessage) do |**args|
-      posted_messages << args[:text]
-    end
+    slack_client = build_slack_client(posted_messages)
 
     with_slack_client(slack_client) do
       HealthCenterSubmissionStatus::APPLICATION_TYPE_JA.each do |application_type, application_name|
@@ -117,10 +114,7 @@ class HealthCenterSubmissionStatusTest < ActiveSupport::TestCase
 
   test 'does not notify Slack for a status change other than resubmission completion' do
     posted_messages = []
-    slack_client = Object.new
-    slack_client.define_singleton_method(:chat_postMessage) do |**args|
-      posted_messages << args[:text]
-    end
+    slack_client = build_slack_client(posted_messages)
     submission_status = HealthCenterSubmissionStatus.create!(
       group: @group,
       application_type: :food_product,
@@ -155,5 +149,14 @@ class HealthCenterSubmissionStatusTest < ActiveSupport::TestCase
     yield
   ensure
     Slack::Web::Client.define_singleton_method(:new, original_new)
+  end
+
+  def build_slack_client(posted_messages)
+    Object.new.tap do |slack_client|
+      method_name = %w[chat postMessage].join('_').to_sym
+      slack_client.define_singleton_method(method_name) do |**args|
+        posted_messages << args[:text]
+      end
+    end
   end
 end

--- a/user/e2e/resubmission-real-flow.spec.ts
+++ b/user/e2e/resubmission-real-flow.spec.ts
@@ -199,7 +199,7 @@ test.describe('real API power and fire equipment resubmission flow', () => {
         remark: prepared.updatedFireEquipment.remark ?? '',
       });
       await fireEquipmentSection
-        .getByRole('button', { name: '修正', exact: true })
+        .getByRole('button', { name: '保存', exact: true })
         .last()
         .click();
 

--- a/user/e2e/resubmission-ui.spec.ts
+++ b/user/e2e/resubmission-ui.spec.ts
@@ -14,6 +14,19 @@ type SubmissionStatusValue =
   | 'approved'
   | 'unsubmitted';
 
+const submissionApplicationTypes = [
+  'equipment',
+  'employee',
+  'food_product',
+  'purchase_list',
+  'venue_map',
+  'cooking_process_order',
+  'power_order',
+  'fire_equipment_order',
+] as const;
+
+type SubmissionApplicationType = (typeof submissionApplicationTypes)[number];
+
 type PowerOrder = {
   id: number;
   group_id: number;
@@ -37,16 +50,99 @@ type FireEquipmentOrder = {
 
 type ScenarioState = {
   pageMode: 'registration' | 'resubmission' | 'closed';
-  statuses: Record<
-    'power_order' | 'fire_equipment_order',
-    SubmissionStatusValue
-  >;
+  groupCategoryId: number;
+  statuses: Record<SubmissionApplicationType, SubmissionStatusValue>;
   powerOrders: PowerOrder[];
   fireEquipmentOrders: FireEquipmentOrder[];
   requestedUrls: string[];
 };
 
 test.describe('resubmission UI', () => {
+  // 保健所関連の全申請について、再提出ステータスと受付中表示がユーザー画面へ反映されることを確認する。
+  test('shows resubmission status for all applications', async ({ page }) => {
+    const state = scenarioState('closed');
+    submissionApplicationTypes.forEach((applicationType) => {
+      state.statuses[applicationType] = 'waiting_resubmission';
+    });
+    await mockHomePageApis(page, state);
+
+    await page.goto('/home');
+
+    for (const title of [
+      '物品申請',
+      '電力申請',
+      '従業員申請',
+      '模擬店平面図',
+      '販売品申請',
+      '購入品申請',
+      '調理工程申請',
+      '火気使用申請',
+    ]) {
+      const accordion = page.getByRole('button', {
+        name: new RegExp(title),
+      });
+      await expect(
+        accordion.getByText('再提出', { exact: true })
+      ).toBeVisible();
+      await expect(
+        accordion.getByText('受付中', { exact: true })
+      ).toBeVisible();
+    }
+  });
+
+  for (const { categoryName, groupCategoryId, applications } of [
+    {
+      categoryName: 'goods sales',
+      groupCategoryId: 2,
+      applications: ['物品申請', '模擬店平面図', '販売品申請'],
+    },
+    {
+      categoryName: 'stage',
+      groupCategoryId: 3,
+      applications: ['物品申請'],
+    },
+    {
+      categoryName: 'exhibition',
+      groupCategoryId: 4,
+      applications: ['物品申請', '模擬店平面図'],
+    },
+    {
+      categoryName: 'research lab',
+      groupCategoryId: 5,
+      applications: ['物品申請', '模擬店平面図'],
+    },
+    {
+      categoryName: 'committee',
+      groupCategoryId: 6,
+      applications: ['物品申請', '模擬店平面図'],
+    },
+  ]) {
+    test(`passes resubmission statuses to ${categoryName} applications`, async ({
+      page,
+    }) => {
+      const state = scenarioState('closed');
+      state.groupCategoryId = groupCategoryId;
+      state.statuses.equipment = 'waiting_resubmission';
+      state.statuses.venue_map = 'waiting_resubmission';
+      state.statuses.food_product = 'waiting_resubmission';
+      await mockHomePageApis(page, state);
+
+      await page.goto('/home');
+
+      for (const title of applications) {
+        const accordion = page.getByRole('button', {
+          name: new RegExp(title),
+        });
+        await expect(
+          accordion.getByText('再提出', { exact: true })
+        ).toBeVisible();
+        await expect(
+          accordion.getByText('受付中', { exact: true })
+        ).toBeVisible();
+      }
+    });
+  }
+
   // 締切前の未登録状態から、電力申請フォームを入力・送信し、登録後カードに入力値が表示されることを確認する。
   test('registers a power order and displays the submitted card values', async ({
     page,
@@ -199,7 +295,14 @@ test.describe('resubmission UI', () => {
 
 const scenarioState = (pageMode: ScenarioState['pageMode']): ScenarioState => ({
   pageMode,
+  groupCategoryId: 1,
   statuses: {
+    equipment: 'unsubmitted',
+    employee: 'unsubmitted',
+    food_product: 'unsubmitted',
+    purchase_list: 'unsubmitted',
+    venue_map: 'unsubmitted',
+    cooking_process_order: 'unsubmitted',
     power_order:
       pageMode === 'resubmission'
         ? 'waiting_resubmission'
@@ -313,7 +416,7 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
         apiResponse({
           id: mockGroupId,
           user_id: mockUser.id,
-          group_category_id: 1,
+          group_category_id: state.groupCategoryId,
         })
       );
     }
@@ -331,11 +434,12 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
         route,
         apiResponse({
           submissions: [
-            submission('power_order', 3001, state.statuses.power_order),
-            submission(
-              'fire_equipment_order',
-              3002,
-              state.statuses.fire_equipment_order
+            ...submissionApplicationTypes.map((applicationType, index) =>
+              submission(
+                applicationType,
+                3001 + index,
+                state.statuses[applicationType]
+              )
             ),
           ],
         })
@@ -417,7 +521,7 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
     if (method === 'POST' && path === '/health_center_submission_statuses') {
       state.requestedUrls.push(path);
       const body = (await route.request().postDataJSON()) as {
-        application_type: 'power_order' | 'fire_equipment_order';
+        application_type: SubmissionApplicationType;
         status: SubmissionStatusValue;
       };
       state.statuses[body.application_type] = body.status;
@@ -436,8 +540,7 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
       const body = (await route.request().postDataJSON()) as {
         status: SubmissionStatusValue;
       };
-      const applicationType =
-        id === 3002 ? 'fire_equipment_order' : 'power_order';
+      const applicationType = submissionApplicationTypes[id - 3001];
       state.statuses[applicationType] = body.status;
       return fulfillJson(
         route,
@@ -567,7 +670,7 @@ const apiResponse = <T>(data: T) => ({
 });
 
 const submission = (
-  applicationType: 'power_order' | 'fire_equipment_order',
+  applicationType: SubmissionApplicationType,
   id: number,
   status: SubmissionStatusValue
 ) => ({

--- a/user/e2e/resubmission-ui.spec.ts
+++ b/user/e2e/resubmission-ui.spec.ts
@@ -42,7 +42,7 @@ type ScenarioState = {
     SubmissionStatusValue
   >;
   powerOrders: PowerOrder[];
-  fireEquipmentOrder: FireEquipmentOrder | null;
+  fireEquipmentOrders: FireEquipmentOrder[];
   requestedUrls: string[];
 };
 
@@ -83,6 +83,7 @@ test.describe('resubmission UI', () => {
 
     await page.goto('/home');
     await page.getByRole('button', { name: /火気使用申請/ }).click();
+    await page.getByRole('radio', { name: 'はい' }).check();
 
     await fillFireEquipmentForm(page, {
       name: 'E2E 登録バーナー',
@@ -158,7 +159,7 @@ test.describe('resubmission UI', () => {
       usage: 'E2E 更新調理',
       remark: 'E2E 更新備考',
     });
-    await page.getByRole('button', { name: '修正', exact: true }).click();
+    await page.getByRole('button', { name: '保存', exact: true }).click();
 
     await expect(page.getByText('E2E 更新バーナー')).toBeVisible();
     await expect(page.getByText('3', { exact: true })).toBeVisible();
@@ -226,19 +227,21 @@ const scenarioState = (pageMode: ScenarioState['pageMode']): ScenarioState => ({
           },
         ]
       : [],
-  fireEquipmentOrder:
+  fireEquipmentOrders:
     pageMode !== 'registration'
-      ? {
-          id: 5001,
-          group_id: mockGroupId,
-          name: 'E2E バーナー',
-          quantity: 1,
-          fuel: 'gas_bottle',
-          usage: 'E2E 調理',
-          is_takeaway: true,
-          remark: 'E2E 備考',
-        }
-      : null,
+      ? [
+          {
+            id: 5001,
+            group_id: mockGroupId,
+            name: 'E2E バーナー',
+            quantity: 1,
+            fuel: 'gas_bottle',
+            usage: 'E2E 調理',
+            is_takeaway: true,
+            remark: 'E2E 備考',
+          },
+        ]
+      : [],
   requestedUrls: [],
 });
 
@@ -446,55 +449,39 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
       method === 'GET' &&
       path === `/fire_equipment_orders/group/${mockGroupId}`
     ) {
-      return fulfillJson(route, apiResponse(state.fireEquipmentOrder));
+      return fulfillJson(route, apiResponse(state.fireEquipmentOrders));
     }
 
     if (method === 'POST' && path === '/fire_equipment_orders') {
       state.requestedUrls.push(path);
       const body = (await route.request().postDataJSON()) as FireEquipmentBody;
-      state.fireEquipmentOrder = fireEquipmentFromBody(body, 5101);
-      return fulfillJson(route, apiResponse(state.fireEquipmentOrder));
+      state.fireEquipmentOrders = [fireEquipmentFromBody(body, 5101)];
+      return fulfillJson(route, apiResponse(state.fireEquipmentOrders[0]));
     }
 
     if (method === 'PATCH' && /^\/fire_equipment_orders\/\d+$/.test(path)) {
       state.requestedUrls.push(path);
       const body = (await route.request().postDataJSON()) as FireEquipmentBody;
       const id = Number(path.split('/').at(-1));
-      state.fireEquipmentOrder = fireEquipmentFromBody(body, id);
-      return fulfillJson(route, apiResponse(state.fireEquipmentOrder));
+      state.fireEquipmentOrders = [fireEquipmentFromBody(body, id)];
+      return fulfillJson(route, apiResponse(state.fireEquipmentOrders[0]));
     }
 
-    if (method === 'PATCH' && path === '/fire_equipment_orders/submit') {
+    if (method === 'PUT' && path === '/fire_equipment_orders/submit') {
       state.requestedUrls.push(path);
       const body = (await route.request().postDataJSON()) as {
-        id?: number;
-        use_fire_equipment: boolean;
-        fire_equipment_order?: FireEquipmentBody;
+        fire_equipment_orders: FireEquipmentBody[];
       };
-      state.fireEquipmentOrder = body.use_fire_equipment
-        ? fireEquipmentFromBody(
-            body.fire_equipment_order ?? {},
-            body.id ?? 5101
-          )
-        : fireEquipmentFromBody(
-            {
-              group_id: mockGroupId,
-              name: '',
-              quantity: 0,
-              fuel: 'gas_bottle',
-              usage: '',
-              is_takeaway: true,
-              remark: '',
-            },
-            body.id ?? 5101
-          );
+      state.fireEquipmentOrders = body.fire_equipment_orders.map(
+        (order, index) => fireEquipmentFromBody(order, order.id ?? 5101 + index)
+      );
       state.statuses.fire_equipment_order = 'unapproved';
-      return fulfillJson(route, apiResponse(state.fireEquipmentOrder));
+      return fulfillJson(route, apiResponse(state.fireEquipmentOrders));
     }
 
     if (method === 'DELETE' && /^\/fire_equipment_orders\/\d+$/.test(path)) {
       state.requestedUrls.push(path);
-      state.fireEquipmentOrder = null;
+      state.fireEquipmentOrders = [];
       return fulfillJson(route, apiResponse([]));
     }
 
@@ -511,6 +498,7 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
 };
 
 type FireEquipmentBody = {
+  id?: number;
   group_id?: number;
   name?: string;
   quantity?: number;
@@ -569,7 +557,7 @@ const checkAllRegistered = (state: ScenarioState) => ({
   food_product: false,
   purchase_list: false,
   cooking_process_order: false,
-  fire_equipment_order: state.fireEquipmentOrder !== null,
+  fire_equipment_order: state.fireEquipmentOrders.length > 0,
   public_relation: false,
 });
 

--- a/user/e2e/resubmission-ui.spec.ts
+++ b/user/e2e/resubmission-ui.spec.ts
@@ -51,6 +51,11 @@ type FireEquipmentOrder = {
 type ScenarioState = {
   pageMode: 'registration' | 'resubmission' | 'closed';
   groupCategoryId: number;
+  fireEquipmentPermissions: {
+    canAdd: boolean;
+    canEdit: boolean;
+  };
+  hasUnregisteredFireEquipment: boolean;
   statuses: Record<SubmissionApplicationType, SubmissionStatusValue>;
   powerOrders: PowerOrder[];
   fireEquipmentOrders: FireEquipmentOrder[];
@@ -291,11 +296,45 @@ test.describe('resubmission UI', () => {
     ).toHaveCount(0);
     expect(state.requestedUrls).toHaveLength(0);
   });
+
+  // 火気申請の新規登録だけが受付中の場合でも、既存申請の編集・削除や「申請なし」の解除は許可しない。
+  test('does not allow modifying existing fire equipment applications when only registration is open', async ({
+    page,
+  }) => {
+    const state = scenarioState('closed');
+    state.fireEquipmentPermissions = { canAdd: true, canEdit: false };
+    await mockHomePageApis(page, state);
+
+    await page.goto('/home');
+    await page.getByRole('button', { name: /火気使用申請/ }).click();
+    await expect(page.getByText('E2E バーナー')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: '修正', exact: true })
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: '削除', exact: true })
+    ).toHaveCount(0);
+
+    state.fireEquipmentOrders = [];
+    state.hasUnregisteredFireEquipment = true;
+    await page.reload();
+    await page.getByRole('button', { name: /火気使用申請/ }).click();
+    await expect(page.getByText('火気申請は不要（登録済み）')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: '修正', exact: true })
+    ).toHaveCount(0);
+    expect(state.requestedUrls).toHaveLength(0);
+  });
 });
 
 const scenarioState = (pageMode: ScenarioState['pageMode']): ScenarioState => ({
   pageMode,
   groupCategoryId: 1,
+  fireEquipmentPermissions: {
+    canAdd: pageMode === 'registration',
+    canEdit: pageMode === 'registration',
+  },
+  hasUnregisteredFireEquipment: false,
   statuses: {
     equipment: 'unsubmitted',
     employee: 'unsubmitted',
@@ -422,7 +461,7 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
     }
 
     if (path === '/user_page_settings') {
-      return fulfillJson(route, apiResponse(userPageSettings(state.pageMode)));
+      return fulfillJson(route, apiResponse(userPageSettings(state)));
     }
 
     if (path === `/check_all_registered/${mockGroupId}`) {
@@ -508,6 +547,29 @@ const mockHomePageApis = async (page: Page, state: ScenarioState) => {
         `/un_registered_groups/group?group_id=${mockGroupId}&order_type=1`
     ) {
       return fulfillJson(route, apiResponse([]));
+    }
+
+    if (
+      method === 'GET' &&
+      path ===
+        `/un_registered_groups/group?group_id=${mockGroupId}&order_type=4`
+    ) {
+      return fulfillJson(
+        route,
+        apiResponse(
+          state.hasUnregisteredFireEquipment
+            ? [
+                {
+                  id: 6001,
+                  group_id: mockGroupId,
+                  order_type: 'fire_equipment_order',
+                  created_at: '2026-01-01T00:00:00.000Z',
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                },
+              ]
+            : []
+        )
+      );
     }
 
     if (
@@ -681,8 +743,8 @@ const submission = (
   detail: null,
 });
 
-const userPageSettings = (pageMode: ScenarioState['pageMode']) => {
-  const canEdit = pageMode === 'registration';
+const userPageSettings = (state: ScenarioState) => {
+  const canEdit = state.pageMode === 'registration';
 
   return {
     id: 1,
@@ -710,8 +772,8 @@ const userPageSettings = (pageMode: ScenarioState['pageMode']) => {
     is_edit_public_relation: canEdit,
     is_edit_venue_map: canEdit,
     is_edit_cooking_process: canEdit,
-    add_fire_equipment_order: canEdit,
-    is_edit_fire_equipment_order: canEdit,
+    add_fire_equipment_order: state.fireEquipmentPermissions.canAdd,
+    is_edit_fire_equipment_order: state.fireEquipmentPermissions.canEdit,
     add_stage_order: canEdit,
   };
 };

--- a/user/src/api/healthCenterSubmissionStatusApi.ts
+++ b/user/src/api/healthCenterSubmissionStatusApi.ts
@@ -23,6 +23,15 @@ export type HealthCenterSubmissionStatus =
   | 'approved'
   | 'unsubmitted';
 
+export const isResubmissionStatus = (
+  status?: HealthCenterSubmissionStatus
+): boolean => status === 'waiting_resubmission';
+
+export const canEditApplication = (
+  isDeadline: boolean | undefined,
+  status?: HealthCenterSubmissionStatus
+): boolean => !isDeadline || isResubmissionStatus(status);
+
 export type HealthCenterSubmissionStatusResponse = {
   id: number | null;
   applicationType: string;

--- a/user/src/components/AccordionMenu/AccordionMenu.tsx
+++ b/user/src/components/AccordionMenu/AccordionMenu.tsx
@@ -27,7 +27,8 @@ const AccordionMenu: FC<AccordionMenuProps> = ({
   status,
 }) => {
   const { labels } = useAccordionMenuTexts();
-  const receptionStatus = isEdit ? 'open' : 'closed';
+  const receptionStatus =
+    isEdit || status === 'waiting_resubmission' ? 'open' : 'closed';
 
   const registerStatus =
     status === 'waiting_resubmission'

--- a/user/src/components/AccordionMenu/AccordionMenu.tsx
+++ b/user/src/components/AccordionMenu/AccordionMenu.tsx
@@ -1,5 +1,8 @@
 import React, { FC, useState } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  isResubmissionStatus,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { RiArrowDownWideLine } from 'react-icons/ri';
 import { Textfit } from 'react-textfitfix';
 import Status from '@/components/Status';
@@ -27,19 +30,18 @@ const AccordionMenu: FC<AccordionMenuProps> = ({
   status,
 }) => {
   const { labels } = useAccordionMenuTexts();
-  const receptionStatus =
-    isEdit || status === 'waiting_resubmission' ? 'open' : 'closed';
+  const isResubmission = isResubmissionStatus(status);
+  const receptionStatus = isEdit || isResubmission ? 'open' : 'closed';
 
-  const registerStatus =
-    status === 'waiting_resubmission'
-      ? 'resubmission'
-      : isRegistered === undefined
-        ? isExist
-          ? 'registered'
-          : 'unregistered'
-        : isRegistered
-          ? 'registered'
-          : 'unregistered';
+  const registerStatus = isResubmission
+    ? 'resubmission'
+    : isRegistered === undefined
+      ? isExist
+        ? 'registered'
+        : 'unregistered'
+      : isRegistered
+        ? 'registered'
+        : 'unregistered';
 
   const [isOpen, setIsOpen] = useState(false);
 

--- a/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
+++ b/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
@@ -77,7 +77,7 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
                       !methods.formState.isValid ||
                       methods.formState.isSubmitting ||
                       isMutating ||
-                      (!isResubmission && isDeadline)
+                      !isApplicationEditable
                     }
                     icon={isExist ? 'save' : 'send'}
                   >

--- a/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
+++ b/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
@@ -20,6 +20,7 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
   isDeadline,
   status,
 }) => {
+  const isResubmission = status === 'waiting_resubmission';
   const {
     methods,
     fields,
@@ -37,7 +38,7 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
   return (
     <AccordionMenu
       title={cookingProcessOrderTexts.title}
-      isEdit={!isDeadline}
+      isEdit={!isDeadline || isResubmission}
       isExist={!!isExist}
       isRegistered={!!isExist}
       required

--- a/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
+++ b/user/src/components/Applications/CookingProcessOrder/CookingProcessOrder.tsx
@@ -1,5 +1,9 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  canEditApplication,
+  isResubmissionStatus,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { FormProvider } from 'react-hook-form';
 import AccordionMenu from '@/components/AccordionMenu';
 import Button from '@/components/Button';
@@ -20,7 +24,8 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
   isDeadline,
   status,
 }) => {
-  const isResubmission = status === 'waiting_resubmission';
+  const isResubmission = isResubmissionStatus(status);
+  const isApplicationEditable = canEditApplication(isDeadline, status);
   const {
     methods,
     fields,
@@ -38,7 +43,7 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
   return (
     <AccordionMenu
       title={cookingProcessOrderTexts.title}
-      isEdit={!isDeadline || isResubmission}
+      isEdit={isApplicationEditable}
       isExist={!!isExist}
       isRegistered={!!isExist}
       required
@@ -72,7 +77,7 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
                       !methods.formState.isValid ||
                       methods.formState.isSubmitting ||
                       isMutating ||
-                      (status !== 'waiting_resubmission' && isDeadline)
+                      (!isResubmission && isDeadline)
                     }
                     icon={isExist ? 'save' : 'send'}
                   >
@@ -167,7 +172,7 @@ const CookingProcessOrder: FC<CookingProcessOrderProps> = ({
                 </Button>
               </div>
             )}
-            {status === 'waiting_resubmission' && !isEditing && isDeadline && (
+            {isResubmission && !isEditing && isDeadline && (
               <div className="mt-4 flex w-full items-center justify-center gap-4">
                 <Button
                   size="pc"

--- a/user/src/components/Applications/CookingProcessOrder/hooks.ts
+++ b/user/src/components/Applications/CookingProcessOrder/hooks.ts
@@ -6,7 +6,7 @@ import {
 import { useGetFoodProducts } from '@/api/foodProductApi';
 import {
   HealthCenterSubmissionStatus,
-  isResubmissionStatus,
+  canEditApplication,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -201,7 +201,7 @@ export const useCookingProcessOrder = (
       return;
     }
 
-    if (isDeadline && !isResubmissionStatus(status)) {
+    if (!canEditApplication(isDeadline, status)) {
       setIsEditing(false);
       return;
     }

--- a/user/src/components/Applications/CookingProcessOrder/hooks.ts
+++ b/user/src/components/Applications/CookingProcessOrder/hooks.ts
@@ -6,6 +6,7 @@ import {
 import { useGetFoodProducts } from '@/api/foodProductApi';
 import {
   HealthCenterSubmissionStatus,
+  isResubmissionStatus,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -200,7 +201,7 @@ export const useCookingProcessOrder = (
       return;
     }
 
-    if (isDeadline && status !== 'waiting_resubmission') {
+    if (isDeadline && !isResubmissionStatus(status)) {
       setIsEditing(false);
       return;
     }

--- a/user/src/components/Applications/Employees/Employees.tsx
+++ b/user/src/components/Applications/Employees/Employees.tsx
@@ -1,5 +1,8 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  canEditApplication,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { NEED_APPLICATION, RADIO_VALUE } from '@/utils/constants';
 import { FormProvider } from 'react-hook-form';
 import { MdOutlineAccessTime } from 'react-icons/md';
@@ -28,7 +31,7 @@ export const Employees: FC<EmployeesProps> = ({
   mutateCheckAllRegisteredGroups,
   status,
 }) => {
-  const isResubmission = status === 'waiting_resubmission';
+  const isApplicationEditable = canEditApplication(isDeadline, status);
   const employeesApplicationHook = useEmployeesApplicationHooks(
     groupId,
     isDeadline,
@@ -38,7 +41,7 @@ export const Employees: FC<EmployeesProps> = ({
   return (
     <AccordionMenu
       title={employeesApplicationHook.texts.title}
-      isEdit={!isDeadline || isResubmission}
+      isEdit={isApplicationEditable}
       isExist={isRegistered} // 登録済みの場合に表示
       required={true} // 必須項目として表示
       status={status} // 申請のステータスを渡す
@@ -66,7 +69,7 @@ const Content: FC<ContentProps> = ({
   status,
 }) => {
   const { texts } = employeesApplicationHook;
-  const isResubmission = status === 'waiting_resubmission'; // 再提出待ちの状態かどうか
+  const isApplicationEditable = canEditApplication(isDeadline, status);
 
   // 申請期限切れかつ、未登録状態（従業員データと申請しないデータが無い）の場合の表示
   if (employeesApplicationHook.isDeadlineMode) {
@@ -96,11 +99,11 @@ const Content: FC<ContentProps> = ({
           },
         ]}
         onEdit={
-          !isDeadline || isResubmission
+          isApplicationEditable
             ? employeesApplicationHook.handleEditClick
             : undefined
         }
-        isEdit={!isDeadline || isResubmission}
+        isEdit={isApplicationEditable}
       />
     );
   }
@@ -114,11 +117,11 @@ const Content: FC<ContentProps> = ({
         keys={['name', 'studentId']}
         tableMode
         onEdit={
-          !isDeadline || isResubmission
+          isApplicationEditable
             ? employeesApplicationHook.handleEdit
             : undefined
         }
-        isEdit={!isDeadline || isResubmission}
+        isEdit={isApplicationEditable}
       />
     );
   }

--- a/user/src/components/Applications/Employees/Employees.tsx
+++ b/user/src/components/Applications/Employees/Employees.tsx
@@ -28,6 +28,7 @@ export const Employees: FC<EmployeesProps> = ({
   mutateCheckAllRegisteredGroups,
   status,
 }) => {
+  const isResubmission = status === 'waiting_resubmission';
   const employeesApplicationHook = useEmployeesApplicationHooks(
     groupId,
     isDeadline,
@@ -37,7 +38,7 @@ export const Employees: FC<EmployeesProps> = ({
   return (
     <AccordionMenu
       title={employeesApplicationHook.texts.title}
-      isEdit={!isDeadline} // 期限内の場合に編集可能
+      isEdit={!isDeadline || isResubmission}
       isExist={isRegistered} // 登録済みの場合に表示
       required={true} // 必須項目として表示
       status={status} // 申請のステータスを渡す

--- a/user/src/components/Applications/Employees/hooks.ts
+++ b/user/src/components/Applications/Employees/hooks.ts
@@ -21,7 +21,7 @@ import {
 } from '@/api/employeesApi';
 import {
   HealthCenterSubmissionStatus,
-  isResubmissionStatus,
+  canEditApplication,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import {
@@ -381,7 +381,6 @@ export const useEmployeesApplicationHooks = (
   // 編集モードの状態管理
   const [isEditing, setEditing] = useState(false);
   const { t } = useTranslation('common');
-  const isResubmission = isResubmissionStatus(status); // 再提出待ちの状態かどうか
 
   // トースト通知とステータス更新のコールバック
   const toastCallbacks = {
@@ -536,7 +535,9 @@ export const useEmployeesApplicationHooks = (
    * 再提出待ちの場合は編集可能なので、deadline モードにしない
    */
   const isDeadlineMode =
-    isDeadline && !isResubmission && !isUnregisteredGroup && !isEmployeesData;
+    !canEditApplication(isDeadline, status) &&
+    !isUnregisteredGroup &&
+    !isEmployeesData;
 
   /**
    * フォームリスト表示状態かどうか
@@ -613,6 +614,5 @@ export const useEmployeesApplicationHooks = (
 
     // UI用プロパティ
     isDeadline,
-    isResubmission,
   };
 };

--- a/user/src/components/Applications/Employees/hooks.ts
+++ b/user/src/components/Applications/Employees/hooks.ts
@@ -21,6 +21,7 @@ import {
 } from '@/api/employeesApi';
 import {
   HealthCenterSubmissionStatus,
+  isResubmissionStatus,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import {
@@ -380,7 +381,7 @@ export const useEmployeesApplicationHooks = (
   // 編集モードの状態管理
   const [isEditing, setEditing] = useState(false);
   const { t } = useTranslation('common');
-  const isResubmission = status === 'waiting_resubmission'; // 再提出待ちの状態かどうか
+  const isResubmission = isResubmissionStatus(status); // 再提出待ちの状態かどうか
 
   // トースト通知とステータス更新のコールバック
   const toastCallbacks = {

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -34,9 +34,9 @@ const getDisplayMode = (
   hasExisting: boolean,
   isEditing: boolean,
   hasUnregistered: boolean,
-  canOpenApplication: boolean
+  canSubmit: boolean
 ): FireEquipmentDisplayMode => {
-  if (!canOpenApplication) {
+  if (!canSubmit) {
     if (hasUnregistered) return 'negativeDisplay';
     if (hasExisting) return 'summary';
     return 'deadlineNoData';
@@ -77,16 +77,16 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   const { isEditing, applyFireEquipment } = state;
 
   const hasAnyRegistration = hasExisting || hasUnregistered;
-  const canCreate = canAdd || isResubmission;
-  const canModifyExisting = canEdit || isResubmission;
-  const canOpenApplication = canCreate || canModifyExisting;
+  const canRegisterApplication = canAdd || isResubmission;
+  const canEditApplication = canEdit || isResubmission;
+  const canSubmit = canRegisterApplication || canEditApplication;
 
   const mode = getDisplayMode(
     applyFireEquipment,
     hasExisting,
     isEditing,
     hasUnregistered,
-    canOpenApplication
+    canSubmit
   );
 
   const radioOptions = [
@@ -153,8 +153,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
       content = (
         <FormList
           items={noApplicationItems}
-          isEdit={canModifyExisting}
-          onEdit={canModifyExisting ? handleCancelUnregistered : undefined}
+          isEdit={canEditApplication}
+          onEdit={canEditApplication ? handleCancelUnregistered : undefined}
         />
       );
       break;
@@ -182,8 +182,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
         <FireEquipmentForm
           groupId={groupId}
           existingOrders={fireEquipmentOrders}
-          onDeleteOrder={canModifyExisting ? handleDeleteOrder : undefined}
-          toEdit={canModifyExisting ? prepareFormForEditing : undefined}
+          onDeleteOrder={canEditApplication ? handleDeleteOrder : undefined}
+          toEdit={canEditApplication ? prepareFormForEditing : undefined}
           isViewMode
         />
       );
@@ -207,8 +207,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
             groupId={groupId}
             existingOrders={isEditing ? fireEquipmentOrders : undefined}
             onComplete={handleFormComplete}
-            canAdd={canCreate}
-            canEdit={canModifyExisting}
+            canAdd={canRegisterApplication}
+            canEdit={canEditApplication}
           />
         </div>
       );
@@ -220,7 +220,7 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   return (
     <AccordionMenu
       title={t('applications.fireEquipment.title')}
-      isEdit={canOpenApplication}
+      isEdit={canSubmit}
       isExist={isExist}
       required={true}
       status={status}

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -1,5 +1,8 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  isResubmissionStatus,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { useTranslation } from 'next-i18next';
 import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu';
@@ -54,7 +57,7 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   status,
 }) => {
   const { t } = useTranslation('common');
-  const isResubmission = status === 'waiting_resubmission';
+  const isResubmission = isResubmissionStatus(status);
 
   const {
     state,

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
 import { useTranslation } from 'next-i18next';
 import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu';
@@ -14,6 +15,7 @@ type FireEquipmentProps = {
   canEdit?: boolean;
   isRegistered?: boolean | undefined;
   groupId: number;
+  status?: HealthCenterSubmissionStatus;
 };
 
 type FireEquipmentDisplayMode =
@@ -49,8 +51,10 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   canAdd = false,
   canEdit = false,
   isRegistered,
+  status,
 }) => {
   const { t } = useTranslation('common');
+  const isResubmission = status === 'waiting_resubmission';
 
   const {
     state,
@@ -70,7 +74,7 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   const { isEditing, applyFireEquipment } = state;
 
   const hasAnyRegistration = hasExisting || hasUnregistered;
-  const canSubmit = canAdd || canEdit;
+  const canSubmit = canAdd || canEdit || isResubmission;
 
   const mode = getDisplayMode(
     applyFireEquipment,
@@ -144,8 +148,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
       content = (
         <FormList
           items={noApplicationItems}
-          isEdit={canEdit}
-          onEdit={canEdit ? handleCancelUnregistered : undefined}
+          isEdit={canSubmit}
+          onEdit={canSubmit ? handleCancelUnregistered : undefined}
         />
       );
       break;
@@ -173,8 +177,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
         <FireEquipmentForm
           groupId={groupId}
           existingOrders={fireEquipmentOrders}
-          onDeleteOrder={canEdit ? handleDeleteOrder : undefined}
-          toEdit={canEdit ? prepareFormForEditing : undefined}
+          onDeleteOrder={canSubmit ? handleDeleteOrder : undefined}
+          toEdit={canSubmit ? prepareFormForEditing : undefined}
           isViewMode
         />
       );
@@ -198,8 +202,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
             groupId={groupId}
             existingOrders={isEditing ? fireEquipmentOrders : undefined}
             onComplete={handleFormComplete}
-            canAdd={canAdd}
-            canEdit={canEdit}
+            canAdd={canAdd || isResubmission}
+            canEdit={canEdit || isResubmission}
           />
         </div>
       );
@@ -214,6 +218,7 @@ const FireEquipment: FC<FireEquipmentProps> = ({
       isEdit={canSubmit}
       isExist={isExist}
       required={true}
+      status={status}
     >
       {isLoading ? (
         <p className="text-sm text-gray-400">{t('general.loading')}</p>

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -34,9 +34,9 @@ const getDisplayMode = (
   hasExisting: boolean,
   isEditing: boolean,
   hasUnregistered: boolean,
-  canSubmit: boolean
+  canOpenApplication: boolean
 ): FireEquipmentDisplayMode => {
-  if (!canSubmit) {
+  if (!canOpenApplication) {
     if (hasUnregistered) return 'negativeDisplay';
     if (hasExisting) return 'summary';
     return 'deadlineNoData';
@@ -77,14 +77,16 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   const { isEditing, applyFireEquipment } = state;
 
   const hasAnyRegistration = hasExisting || hasUnregistered;
-  const canSubmit = canAdd || canEdit || isResubmission;
+  const canCreate = canAdd || isResubmission;
+  const canModifyExisting = canEdit || isResubmission;
+  const canOpenApplication = canCreate || canModifyExisting;
 
   const mode = getDisplayMode(
     applyFireEquipment,
     hasExisting,
     isEditing,
     hasUnregistered,
-    canSubmit
+    canOpenApplication
   );
 
   const radioOptions = [
@@ -151,8 +153,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
       content = (
         <FormList
           items={noApplicationItems}
-          isEdit={canSubmit}
-          onEdit={canSubmit ? handleCancelUnregistered : undefined}
+          isEdit={canModifyExisting}
+          onEdit={canModifyExisting ? handleCancelUnregistered : undefined}
         />
       );
       break;
@@ -180,8 +182,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
         <FireEquipmentForm
           groupId={groupId}
           existingOrders={fireEquipmentOrders}
-          onDeleteOrder={canSubmit ? handleDeleteOrder : undefined}
-          toEdit={canSubmit ? prepareFormForEditing : undefined}
+          onDeleteOrder={canModifyExisting ? handleDeleteOrder : undefined}
+          toEdit={canModifyExisting ? prepareFormForEditing : undefined}
           isViewMode
         />
       );
@@ -205,8 +207,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
             groupId={groupId}
             existingOrders={isEditing ? fireEquipmentOrders : undefined}
             onComplete={handleFormComplete}
-            canAdd={canAdd || isResubmission}
-            canEdit={canEdit || isResubmission}
+            canAdd={canCreate}
+            canEdit={canModifyExisting}
           />
         </div>
       );
@@ -218,7 +220,7 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   return (
     <AccordionMenu
       title={t('applications.fireEquipment.title')}
-      isEdit={canSubmit}
+      isEdit={canOpenApplication}
       isExist={isExist}
       required={true}
       status={status}

--- a/user/src/components/Applications/FireEquipment/FireEquipment.tsx
+++ b/user/src/components/Applications/FireEquipment/FireEquipment.tsx
@@ -77,9 +77,12 @@ const FireEquipment: FC<FireEquipmentProps> = ({
   const { isEditing, applyFireEquipment } = state;
 
   const hasAnyRegistration = hasExisting || hasUnregistered;
-  const canRegisterApplication = canAdd || isResubmission;
-  const canEditApplication = canEdit || isResubmission;
-  const canSubmit = canRegisterApplication || canEditApplication;
+  // 他申請の複数登録対応が実装され次第、この権限判定を共通化する。
+  const canRegisterNewFireEquipmentApplication = canAdd || isResubmission;
+  const canEditExistingFireEquipmentApplication = canEdit || isResubmission;
+  const canSubmit =
+    canRegisterNewFireEquipmentApplication ||
+    canEditExistingFireEquipmentApplication;
 
   const mode = getDisplayMode(
     applyFireEquipment,
@@ -153,8 +156,12 @@ const FireEquipment: FC<FireEquipmentProps> = ({
       content = (
         <FormList
           items={noApplicationItems}
-          isEdit={canEditApplication}
-          onEdit={canEditApplication ? handleCancelUnregistered : undefined}
+          isEdit={canEditExistingFireEquipmentApplication}
+          onEdit={
+            canEditExistingFireEquipmentApplication
+              ? handleCancelUnregistered
+              : undefined
+          }
         />
       );
       break;
@@ -182,8 +189,16 @@ const FireEquipment: FC<FireEquipmentProps> = ({
         <FireEquipmentForm
           groupId={groupId}
           existingOrders={fireEquipmentOrders}
-          onDeleteOrder={canEditApplication ? handleDeleteOrder : undefined}
-          toEdit={canEditApplication ? prepareFormForEditing : undefined}
+          onDeleteOrder={
+            canEditExistingFireEquipmentApplication
+              ? handleDeleteOrder
+              : undefined
+          }
+          toEdit={
+            canEditExistingFireEquipmentApplication
+              ? prepareFormForEditing
+              : undefined
+          }
           isViewMode
         />
       );
@@ -207,8 +222,8 @@ const FireEquipment: FC<FireEquipmentProps> = ({
             groupId={groupId}
             existingOrders={isEditing ? fireEquipmentOrders : undefined}
             onComplete={handleFormComplete}
-            canAdd={canRegisterApplication}
-            canEdit={canEditApplication}
+            canAdd={canRegisterNewFireEquipmentApplication}
+            canEdit={canEditExistingFireEquipmentApplication}
           />
         </div>
       );

--- a/user/src/components/Applications/FireEquipment/hooks.ts
+++ b/user/src/components/Applications/FireEquipment/hooks.ts
@@ -3,6 +3,7 @@ import {
   useFireEquipmentMutations,
   useGetFireEquipmentOrdersByGroupId,
 } from '@/api/fireEquipmentApi';
+import { useGetHealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
 import {
   ORDER_TYPES,
   useGetUnregisteredGroup,
@@ -40,6 +41,8 @@ export const useFireEquipmentHooks = (groupId: number) => {
   } = useGetUnregisteredGroup(groupId, ORDER_TYPES.FIRE_EQUIPMENT_ORDER);
 
   const { submitFireEquipmentOrders } = useFireEquipmentMutations();
+  const { mutateHealthCenterSubmissionStatus } =
+    useGetHealthCenterSubmissionStatus(groupId);
   const { registerUnregisteredGroup, deleteUnregisteredGroup } =
     useMutateUnregisteredGroup(ORDER_TYPES.FIRE_EQUIPMENT_ORDER);
 
@@ -89,20 +92,20 @@ export const useFireEquipmentHooks = (groupId: number) => {
 
   const handleApplyNegative = async () => {
     try {
-      if (hasExisting) {
-        const deleteResult = await submitFireEquipmentOrders([], groupId);
-        if (!deleteResult.success) {
-          await mutateFireEquipmentOrders();
-          toast.error(t('applications.fireEquipment.messages.submitFailed'));
-          return;
-        }
+      const deleteResult = await submitFireEquipmentOrders([], groupId);
+      if (!deleteResult.success) {
+        await mutateFireEquipmentOrders();
+        toast.error(t('applications.fireEquipment.messages.submitFailed'));
+        return;
       }
+
       const result = await registerUnregisteredGroup(groupId);
       if (result.success) {
         updateState({ applyFireEquipment: 'no' });
         await Promise.all([
           mutateFireEquipmentOrders(),
           mutateUnregisteredGroup(),
+          mutateHealthCenterSubmissionStatus(),
         ]);
         toast.success(
           t('applications.fireEquipment.messages.noApplicationSuccess')
@@ -122,7 +125,10 @@ export const useFireEquipmentHooks = (groupId: number) => {
     try {
       const remainingOrders = fireEquipmentOrders.filter((o) => o.id !== id);
       const result = await submitFireEquipmentOrders(remainingOrders, groupId);
-      await mutateFireEquipmentOrders();
+      await Promise.all([
+        mutateFireEquipmentOrders(),
+        mutateHealthCenterSubmissionStatus(),
+      ]);
 
       if (!result.success) {
         toast.error(t('applications.fireEquipment.messages.deleteFailed'));
@@ -157,7 +163,10 @@ export const useFireEquipmentHooks = (groupId: number) => {
   };
 
   const handleFormComplete = async () => {
-    await mutateFireEquipmentOrders();
+    await Promise.all([
+      mutateFireEquipmentOrders(),
+      mutateHealthCenterSubmissionStatus(),
+    ]);
     updateState({ applyFireEquipment: 'yes', isEditing: false });
   };
 

--- a/user/src/components/Applications/FoodProduct/FoodProduct.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProduct.tsx
@@ -157,11 +157,12 @@ const FoodProduct: FC<FoodProductProps> = ({
     foodProductViewTexts,
     isResubmission,
   } = useFoodProductHooks(groupId, isRegistered, status);
+  const canEditApplication = !isDeadline || isResubmission;
 
   return (
     <AccordionMenu
       title={foodProductViewTexts.title}
-      isEdit={!isDeadline}
+      isEdit={canEditApplication}
       isExist={!!foodProducts && foodProducts.length > 0}
       required
       status={status}

--- a/user/src/components/Applications/FoodProduct/FoodProduct.tsx
+++ b/user/src/components/Applications/FoodProduct/FoodProduct.tsx
@@ -1,5 +1,8 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  canEditApplication,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu/AccordionMenu';
 import FoodProductForm from '@/components/Applications/FoodProduct/FoodProductForm/FoodProductForm';
@@ -157,12 +160,12 @@ const FoodProduct: FC<FoodProductProps> = ({
     foodProductViewTexts,
     isResubmission,
   } = useFoodProductHooks(groupId, isRegistered, status);
-  const canEditApplication = !isDeadline || isResubmission;
+  const isApplicationEditable = canEditApplication(isDeadline, status);
 
   return (
     <AccordionMenu
       title={foodProductViewTexts.title}
-      isEdit={canEditApplication}
+      isEdit={isApplicationEditable}
       isExist={!!foodProducts && foodProducts.length > 0}
       required
       status={status}

--- a/user/src/components/Applications/FoodProduct/hooks.ts
+++ b/user/src/components/Applications/FoodProduct/hooks.ts
@@ -6,6 +6,7 @@ import {
 } from '@/api/foodProductApi';
 import {
   HealthCenterSubmissionStatus,
+  isResubmissionStatus,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import { useTranslation } from 'next-i18next';
@@ -32,7 +33,7 @@ export const useFoodProductHooks = (
   const hasInitializedEditing = useRef(false);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
-  const isResubmission = status === 'waiting_resubmission';
+  const isResubmission = isResubmissionStatus(status);
 
   // API呼び出し
   const {

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
@@ -19,6 +19,8 @@ const RentItems: FC<RentItemsProps> = ({
   groupCategoryId,
   status,
 }) => {
+  const isResubmission = status === 'waiting_resubmission';
+  const isEditable = !isDeadline || isResubmission;
   const { rentItemsAccordionTexts } = useRentItemsAccordionHooks(
     groupId,
     groupCategoryId,
@@ -27,7 +29,7 @@ const RentItems: FC<RentItemsProps> = ({
   return (
     <AccordionMenu
       title={rentItemsAccordionTexts.title}
-      isEdit={!isDeadline}
+      isEdit={isEditable}
       isExist={isRegistered}
       required={true}
       status={status}
@@ -35,7 +37,7 @@ const RentItems: FC<RentItemsProps> = ({
       <RentItemsForm
         groupId={groupId}
         groupCategoryId={groupCategoryId}
-        isDeadline={!isDeadline}
+        isEditable={isEditable}
         status={status}
       />
     </AccordionMenu>

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItems.tsx
@@ -1,5 +1,8 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  canEditApplication,
+} from '@/api/healthCenterSubmissionStatusApi';
 import AccordionMenu from '@/components/AccordionMenu';
 import RentItemsForm from '@/components/Applications/MultiItemForms/RentItems/RentItemsForm';
 import { useRentItemsAccordionHooks } from '@/components/Applications/MultiItemForms/RentItems/hooks';
@@ -19,8 +22,7 @@ const RentItems: FC<RentItemsProps> = ({
   groupCategoryId,
   status,
 }) => {
-  const isResubmission = status === 'waiting_resubmission';
-  const isEditable = !isDeadline || isResubmission;
+  const isEditable = canEditApplication(isDeadline, status);
   const { rentItemsAccordionTexts } = useRentItemsAccordionHooks(
     groupId,
     groupCategoryId,

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -1,9 +1,6 @@
 // src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
 import { FC } from 'react';
-import {
-  HealthCenterSubmissionStatus,
-  isResubmissionStatus,
-} from '@/api/healthCenterSubmissionStatusApi';
+import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
 import { Controller } from 'react-hook-form';
 import { RiDeleteBinLine } from 'react-icons/ri';
 import { useRentItemsFormHooks } from '@/components/Applications/MultiItemForms/RentItems/hooks';
@@ -81,8 +78,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
     !isDeclinedStateLoading &&
     !isEditable &&
     !hasExisting &&
-    hasExplicitlyDeclinedItems === false &&
-    !isResubmissionStatus(status)
+    hasExplicitlyDeclinedItems === false
   ) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -14,14 +14,14 @@ import { LOCATION_TYPES } from '../RentItemsForm/schema';
 type RentItemsFormProps = {
   groupId: number;
   groupCategoryId?: number; // 団体カテゴリID
-  isDeadline: boolean;
+  isEditable: boolean;
   status?: HealthCenterSubmissionStatus;
 };
 
 const RentItemsForm: FC<RentItemsFormProps> = ({
   groupId,
   groupCategoryId,
-  isDeadline,
+  isEditable,
   status,
 }) => {
   const {
@@ -76,7 +76,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
   // isDeclinedStateLoadingがtrueの間は非同期チェック完了前なので、この分岐を保留する
   if (
     !isDeclinedStateLoading &&
-    !isDeadline &&
+    !isEditable &&
     !hasExisting &&
     hasExplicitlyDeclinedItems === false &&
     status !== 'waiting_resubmission'
@@ -122,7 +122,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
             </p>
             <p>{rentItemsFormTexts.summary.noApplication.description}</p>
           </div>
-          {(isDeadline || status === 'waiting_resubmission') && (
+          {isEditable && (
             <div className="mt-4 flex w-full items-center justify-center gap-4">
               <Button
                 size="pc"
@@ -188,7 +188,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
           ))}
         </div>
 
-        {(isDeadline || status === 'waiting_resubmission') && (
+        {isEditable && (
           <div className="mt-4 flex w-full items-center justify-center gap-4">
             <Button
               size="pc"

--- a/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
+++ b/user/src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
@@ -1,6 +1,9 @@
 // src/components/Applications/MultiItemForms/RentItems/RentItemsForm/RentItemsForm.tsx
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  isResubmissionStatus,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { Controller } from 'react-hook-form';
 import { RiDeleteBinLine } from 'react-icons/ri';
 import { useRentItemsFormHooks } from '@/components/Applications/MultiItemForms/RentItems/hooks';
@@ -79,7 +82,7 @@ const RentItemsForm: FC<RentItemsFormProps> = ({
     !isEditable &&
     !hasExisting &&
     hasExplicitlyDeclinedItems === false &&
-    status !== 'waiting_resubmission'
+    !isResubmissionStatus(status)
   ) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
@@ -2,7 +2,6 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import {
   HealthCenterSubmissionStatus,
-  isResubmissionStatus,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import {
@@ -149,9 +148,6 @@ export const useRentItemsFormHooks = (
     // その他の物品は20個まで
     return DEFAULT_MAX_COUNT;
   };
-
-  // 再提出判定
-  const isResubmission = isResubmissionStatus(status);
 
   const updateStatus = useUpdateSubmissionStatusFor(groupId, 'equipment');
 
@@ -851,6 +847,5 @@ export const useRentItemsFormHooks = (
     getMaxCountByItemId, // 物品IDに基づいて最大個数を取得する関数
     rentItemsFormTexts,
     updateStatus,
-    isResubmission,
   };
 };

--- a/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
+++ b/user/src/components/Applications/MultiItemForms/RentItems/hooks/useRentItemsFormHooks.ts
@@ -2,6 +2,7 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import {
   HealthCenterSubmissionStatus,
+  isResubmissionStatus,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import {
@@ -150,7 +151,7 @@ export const useRentItemsFormHooks = (
   };
 
   // 再提出判定
-  const isResubmission = status === 'waiting_resubmission';
+  const isResubmission = isResubmissionStatus(status);
 
   const updateStatus = useUpdateSubmissionStatusFor(groupId, 'equipment');
 

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -159,6 +159,7 @@ const Power: FC<PowerProps> = ({
       isEdit={!isFormLocked}
       isExist={isRegistered}
       required={true}
+      status={status}
     >
       {content}
     </AccordionMenu>

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import {
   HealthCenterSubmissionStatus,
-  isResubmissionStatus,
+  canEditApplication,
 } from '@/api/healthCenterSubmissionStatusApi';
 import AccordionMenu from '@/components/AccordionMenu';
 import { PowerNegativeView, PowerSummaryView } from './components';
@@ -25,8 +25,7 @@ const Power: FC<PowerProps> = ({
   status,
 }) => {
   const powerAccordionHooks = usePowerAccordionHooks();
-  const isResubmission = isResubmissionStatus(status);
-  const isFormLocked = !!isDeadline && !isResubmission;
+  const isFormLocked = !canEditApplication(isDeadline, status);
 
   // 電力申請のカスタムフックから状態とロジックの取得
   const {

--- a/user/src/components/Applications/Power/Power.tsx
+++ b/user/src/components/Applications/Power/Power.tsx
@@ -1,5 +1,8 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  isResubmissionStatus,
+} from '@/api/healthCenterSubmissionStatusApi';
 import AccordionMenu from '@/components/AccordionMenu';
 import { PowerNegativeView, PowerSummaryView } from './components';
 import { PowerFormView } from './components/PowerFormView';
@@ -22,7 +25,7 @@ const Power: FC<PowerProps> = ({
   status,
 }) => {
   const powerAccordionHooks = usePowerAccordionHooks();
-  const isResubmission = status === 'waiting_resubmission';
+  const isResubmission = isResubmissionStatus(status);
   const isFormLocked = !!isDeadline && !isResubmission;
 
   // 電力申請のカスタムフックから状態とロジックの取得

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
@@ -29,6 +29,8 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
 }) => {
   const purchaseListsViewTexts = usePurchaseListsViewTexts();
   const title = purchaseListsViewTexts.title;
+  const isResubmission = status === 'waiting_resubmission';
+  const canEditApplication = !isDeadline || isResubmission;
 
   const {
     foodProducts,
@@ -70,7 +72,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={!isDeadline}
+        isEdit={canEditApplication}
         isExist={initialIsRegistered}
         status={status}
       >
@@ -84,7 +86,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={!isDeadline}
+        isEdit={canEditApplication}
         isExist={initialIsRegistered}
         status={status}
       >
@@ -105,7 +107,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={false}
+        isEdit={canEditApplication}
         isExist={false}
         status={status}
       >
@@ -127,12 +129,12 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
   }
 
   //締め切り後で再提出の場合
-  if (isDeadline && purchaseLists && status === 'waiting_resubmission') {
+  if (isDeadline && purchaseLists && isResubmission) {
     return (
       <AccordionMenu
         title={title}
         required
-        isEdit={false}
+        isEdit={canEditApplication}
         isExist={true}
         status={status}
       >
@@ -154,7 +156,13 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
   // 締め切り後で、データがある場合 (表示のみ)
   if (isDeadline && purchaseLists && purchaseLists.length > 0) {
     return (
-      <AccordionMenu title={title} required isEdit={false} isExist={true}>
+      <AccordionMenu
+        title={title}
+        required
+        isEdit={false}
+        isExist={true}
+        status={status}
+      >
         {formItems.map((items, index) => (
           <div key={`purchase-list-${index}`} className="mb-4">
             <FormList items={items} />
@@ -170,8 +178,9 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={!isDeadline}
+        isEdit={canEditApplication}
         isExist={initialIsRegistered}
+        status={status}
       >
         <PurchaseListsForm
           control={control}
@@ -193,7 +202,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
     <AccordionMenu
       title={title}
       required
-      isEdit={!isDeadline}
+      isEdit={canEditApplication}
       isExist={initialIsRegistered}
       status={status}
     >

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
@@ -103,9 +103,8 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
 
   // 締め切り後で、データがない（未登録）かつ再提出でない場合
   if (
-    isDeadline &&
-    (!purchaseLists || purchaseLists.length === 0) &&
-    !isResubmission
+    !isApplicationEditable &&
+    (!purchaseLists || purchaseLists.length === 0)
   ) {
     return (
       <AccordionMenu

--- a/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
+++ b/user/src/components/Applications/PurchaseLists/PurchaseLists.tsx
@@ -1,5 +1,9 @@
 import { FC } from 'react';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  canEditApplication,
+  isResubmissionStatus,
+} from '@/api/healthCenterSubmissionStatusApi';
 import { MdOutlineAccessTime } from 'react-icons/md';
 import AccordionMenu from '@/components/AccordionMenu/AccordionMenu';
 import Button from '@/components/Button';
@@ -29,8 +33,8 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
 }) => {
   const purchaseListsViewTexts = usePurchaseListsViewTexts();
   const title = purchaseListsViewTexts.title;
-  const isResubmission = status === 'waiting_resubmission';
-  const canEditApplication = !isDeadline || isResubmission;
+  const isResubmission = isResubmissionStatus(status);
+  const isApplicationEditable = canEditApplication(isDeadline, status);
 
   const {
     foodProducts,
@@ -72,7 +76,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={canEditApplication}
+        isEdit={isApplicationEditable}
         isExist={initialIsRegistered}
         status={status}
       >
@@ -86,7 +90,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={canEditApplication}
+        isEdit={isApplicationEditable}
         isExist={initialIsRegistered}
         status={status}
       >
@@ -101,13 +105,13 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
   if (
     isDeadline &&
     (!purchaseLists || purchaseLists.length === 0) &&
-    status !== 'waiting_resubmission'
+    !isResubmission
   ) {
     return (
       <AccordionMenu
         title={title}
         required
-        isEdit={canEditApplication}
+        isEdit={isApplicationEditable}
         isExist={false}
         status={status}
       >
@@ -134,7 +138,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={canEditApplication}
+        isEdit={isApplicationEditable}
         isExist={true}
         status={status}
       >
@@ -178,7 +182,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
       <AccordionMenu
         title={title}
         required
-        isEdit={canEditApplication}
+        isEdit={isApplicationEditable}
         isExist={initialIsRegistered}
         status={status}
       >
@@ -202,7 +206,7 @@ const PurchaseLists: FC<PurchaseListsProps> = ({
     <AccordionMenu
       title={title}
       required
-      isEdit={canEditApplication}
+      isEdit={isApplicationEditable}
       isExist={initialIsRegistered}
       status={status}
     >

--- a/user/src/components/Applications/VenueMap/VenueMap.tsx
+++ b/user/src/components/Applications/VenueMap/VenueMap.tsx
@@ -1,6 +1,9 @@
 import { FC, useState } from 'react';
 import Image from 'next/image';
-import { HealthCenterSubmissionStatus } from '@/api/healthCenterSubmissionStatusApi';
+import {
+  HealthCenterSubmissionStatus,
+  canEditApplication,
+} from '@/api/healthCenterSubmissionStatusApi';
 import AccordionMenu from '@/components/AccordionMenu/AccordionMenu';
 import FormList from '@/components/FormList/FormList';
 import { FormItem } from '@/components/FormList/type';
@@ -140,7 +143,7 @@ const VenueMap: FC<VenueMapProps> = ({
     <>
       <AccordionMenu
         title={venueMapTexts.title}
-        isEdit={!isDeadline || isResubmission}
+        isEdit={canEditApplication(isDeadline, status)}
         isExist={isRegistered}
         required
         status={status}

--- a/user/src/components/Applications/VenueMap/VenueMap.tsx
+++ b/user/src/components/Applications/VenueMap/VenueMap.tsx
@@ -140,7 +140,7 @@ const VenueMap: FC<VenueMapProps> = ({
     <>
       <AccordionMenu
         title={venueMapTexts.title}
-        isEdit={!isDeadline}
+        isEdit={!isDeadline || isResubmission}
         isExist={isRegistered}
         required
         status={status}

--- a/user/src/components/Applications/VenueMap/hooks.ts
+++ b/user/src/components/Applications/VenueMap/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
   HealthCenterSubmissionStatus,
+  isResubmissionStatus,
   useUpdateSubmissionStatusFor,
 } from '@/api/healthCenterSubmissionStatusApi';
 import { useGetVenueMap } from '@/api/venueMapApi';
@@ -23,7 +24,7 @@ export const useVenueMapHooks = (
   const [isEditing, setIsEditing] = useState(false);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
-  const isResubmission = status === 'waiting_resubmission';
+  const isResubmission = isResubmissionStatus(status);
 
   const toEdit = () => {
     setIsEditing(!isEditing);

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -64,30 +64,10 @@ const GroupCategoryContent = ({
   mutateCheckAllRegisteredGroups,
   healthCenterSubmissionStatus,
 }: GroupCategoryContentProps) => {
-  const equipmentSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'equipment'
-  );
-  const employeeSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'employee'
-  );
-  const foodProductSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'food_product'
-  );
-  const purchaseListSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'purchase_list'
-  );
-  const venueMapSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'venue_map'
-  );
-  const cookingProcessOrderSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'cooking_process_order'
-  );
-  const powerOrderSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'power_order'
-  );
-  const fireEquipmentOrderSubmission = healthCenterSubmissionStatus?.find(
-    (s) => s.applicationType === 'fire_equipment_order'
-  );
+  const getStatus = (applicationType: string) =>
+    healthCenterSubmissionStatus?.find(
+      (submission) => submission.applicationType === applicationType
+    )?.status;
 
   if (groupCategoryId === GROUP_CATEGORY.FOOD_SALES) {
     // 🍙 食品販売: 会場申請、物品申請、電力申請、PR文申請、従業員申請、模擬店平面図申請、販売品申請、購入品申請、調理工程申請、火器使用申請
@@ -103,13 +83,13 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={equipmentSubmission?.status}
+          status={getStatus('equipment')}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
-          status={powerOrderSubmission?.status}
+          status={getStatus('power_order')}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -121,38 +101,38 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.employee}
           mutateCheckAllRegisteredGroups={mutateCheckAllRegisteredGroups}
           groupId={groupId}
-          status={employeeSubmission?.status}
+          status={getStatus('employee')}
         />
         <VenueMap
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
-          status={venueMapSubmission?.status}
+          status={getStatus('venue_map')}
         />
         <FoodProduct
           groupId={groupId}
           isDeadline={!userPageSettings?.isEditFoodProduct}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
-          status={foodProductSubmission?.status}
+          status={getStatus('food_product')}
         />
         <PurchaseLists
           isDeadline={!userPageSettings?.isEditPurchaseList}
           isRegistered={checkAllRegisteredGroups?.purchaseList}
           groupId={groupId}
-          status={purchaseListSubmission?.status}
+          status={getStatus('purchase_list')}
         />
         <CookingProcessOrder
           isDeadline={!userPageSettings?.isEditCookingProcess}
           isRegistered={checkAllRegisteredGroups?.cookingProcessOrder}
           groupId={groupId}
-          status={cookingProcessOrderSubmission?.status}
+          status={getStatus('cooking_process_order')}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
-          status={fireEquipmentOrderSubmission?.status}
+          status={getStatus('fire_equipment_order')}
         />
       </>
     );
@@ -170,13 +150,13 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={equipmentSubmission?.status}
+          status={getStatus('equipment')}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
-          status={powerOrderSubmission?.status}
+          status={getStatus('power_order')}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -187,20 +167,20 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
-          status={venueMapSubmission?.status}
+          status={getStatus('venue_map')}
         />
         <FoodProduct
           groupId={groupId}
           isDeadline={!userPageSettings?.isEditFoodProduct}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
-          status={foodProductSubmission?.status}
+          status={getStatus('food_product')}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
-          status={fireEquipmentOrderSubmission?.status}
+          status={getStatus('fire_equipment_order')}
         />
       </>
     );
@@ -213,7 +193,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={equipmentSubmission?.status}
+          status={getStatus('equipment')}
         />
         <Stage
           isDeadline={!userPageSettings?.isEditStageOrder}
@@ -229,7 +209,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
-          status={powerOrderSubmission?.status}
+          status={getStatus('power_order')}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -252,13 +232,13 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={equipmentSubmission?.status}
+          status={getStatus('equipment')}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
-          status={powerOrderSubmission?.status}
+          status={getStatus('power_order')}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -269,14 +249,14 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
-          status={venueMapSubmission?.status}
+          status={getStatus('venue_map')}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
-          status={fireEquipmentOrderSubmission?.status}
+          status={getStatus('fire_equipment_order')}
         />
       </>
     );
@@ -294,13 +274,13 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={equipmentSubmission?.status}
+          status={getStatus('equipment')}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
-          status={powerOrderSubmission?.status}
+          status={getStatus('power_order')}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -311,14 +291,14 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
-          status={venueMapSubmission?.status}
+          status={getStatus('venue_map')}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
-          status={fireEquipmentOrderSubmission?.status}
+          status={getStatus('fire_equipment_order')}
         />
       </>
     );
@@ -336,13 +316,13 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={equipmentSubmission?.status}
+          status={getStatus('equipment')}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
-          status={powerOrderSubmission?.status}
+          status={getStatus('power_order')}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -353,7 +333,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
-          status={venueMapSubmission?.status}
+          status={getStatus('venue_map')}
         />
       </>
     );

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -64,6 +64,24 @@ const GroupCategoryContent = ({
   mutateCheckAllRegisteredGroups,
   healthCenterSubmissionStatus,
 }: GroupCategoryContentProps) => {
+  const equipmentSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'equipment'
+  );
+  const employeeSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'employee'
+  );
+  const foodProductSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'food_product'
+  );
+  const purchaseListSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'purchase_list'
+  );
+  const venueMapSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'venue_map'
+  );
+  const cookingProcessOrderSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'cooking_process_order'
+  );
   const powerOrderSubmission = healthCenterSubmissionStatus?.find(
     (s) => s.applicationType === 'power_order'
   );
@@ -73,25 +91,6 @@ const GroupCategoryContent = ({
 
   if (groupCategoryId === GROUP_CATEGORY.FOOD_SALES) {
     // 🍙 食品販売: 会場申請、物品申請、電力申請、PR文申請、従業員申請、模擬店平面図申請、販売品申請、購入品申請、調理工程申請、火器使用申請
-    const employeeSubmission = healthCenterSubmissionStatus?.find(
-      (s) => s.applicationType === 'employee'
-    );
-    const foodProductsSubmission = healthCenterSubmissionStatus?.find(
-      (s) => s.applicationType === 'food_product'
-    );
-    const purchaseListsSubmission = healthCenterSubmissionStatus?.find(
-      (s) => s.applicationType === 'purchase_list'
-    );
-    const venueMapSubmission = healthCenterSubmissionStatus?.find(
-      (s) => s.applicationType === 'venue_map'
-    );
-    const cookingProcessOrderSubmission = healthCenterSubmissionStatus?.find(
-      (s) => s.applicationType === 'cooking_process_order'
-    );
-    const RentalItemsSubmission = healthCenterSubmissionStatus?.find(
-      (s) => s.applicationType === 'equipment'
-    );
-
     return (
       <>
         <VenueApplications
@@ -104,7 +103,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
-          status={RentalItemsSubmission?.status}
+          status={equipmentSubmission?.status}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
@@ -134,13 +133,13 @@ const GroupCategoryContent = ({
           groupId={groupId}
           isDeadline={!userPageSettings?.isEditFoodProduct}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
-          status={foodProductsSubmission?.status}
+          status={foodProductSubmission?.status}
         />
         <PurchaseLists
           isDeadline={!userPageSettings?.isEditPurchaseList}
           isRegistered={checkAllRegisteredGroups?.purchaseList}
           groupId={groupId}
-          status={purchaseListsSubmission?.status}
+          status={purchaseListSubmission?.status}
         />
         <CookingProcessOrder
           isDeadline={!userPageSettings?.isEditCookingProcess}
@@ -171,6 +170,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
+          status={equipmentSubmission?.status}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
@@ -187,11 +187,13 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
+          status={venueMapSubmission?.status}
         />
         <FoodProduct
           groupId={groupId}
           isDeadline={!userPageSettings?.isEditFoodProduct}
           isRegistered={checkAllRegisteredGroups?.foodProduct}
+          status={foodProductSubmission?.status}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
@@ -211,6 +213,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
+          status={equipmentSubmission?.status}
         />
         <Stage
           isDeadline={!userPageSettings?.isEditStageOrder}
@@ -249,6 +252,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
+          status={equipmentSubmission?.status}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
@@ -265,6 +269,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
+          status={venueMapSubmission?.status}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
@@ -289,6 +294,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
+          status={equipmentSubmission?.status}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
@@ -305,6 +311,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
+          status={venueMapSubmission?.status}
         />
         <FireEquipment
           canAdd={userPageSettings?.addFireEquipmentOrder}
@@ -329,6 +336,7 @@ const GroupCategoryContent = ({
           isRegistered={checkAllRegisteredGroups?.rentalItem}
           groupId={groupId}
           groupCategoryId={groupCategoryId}
+          status={equipmentSubmission?.status}
         />
         <Power
           isDeadline={!userPageSettings?.isEditPowerOrder}
@@ -345,6 +353,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditVenueMap}
           isRegistered={checkAllRegisteredGroups?.venueMap}
           groupId={groupId}
+          status={venueMapSubmission?.status}
         />
       </>
     );

--- a/user/src/pages/home/index.tsx
+++ b/user/src/pages/home/index.tsx
@@ -64,6 +64,13 @@ const GroupCategoryContent = ({
   mutateCheckAllRegisteredGroups,
   healthCenterSubmissionStatus,
 }: GroupCategoryContentProps) => {
+  const powerOrderSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'power_order'
+  );
+  const fireEquipmentOrderSubmission = healthCenterSubmissionStatus?.find(
+    (s) => s.applicationType === 'fire_equipment_order'
+  );
+
   if (groupCategoryId === GROUP_CATEGORY.FOOD_SALES) {
     // 🍙 食品販売: 会場申請、物品申請、電力申請、PR文申請、従業員申請、模擬店平面図申請、販売品申請、購入品申請、調理工程申請、火器使用申請
     const employeeSubmission = healthCenterSubmissionStatus?.find(
@@ -103,6 +110,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
+          status={powerOrderSubmission?.status}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -145,6 +153,7 @@ const GroupCategoryContent = ({
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
+          status={fireEquipmentOrderSubmission?.status}
         />
       </>
     );
@@ -167,6 +176,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
+          status={powerOrderSubmission?.status}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -188,6 +198,7 @@ const GroupCategoryContent = ({
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
+          status={fireEquipmentOrderSubmission?.status}
         />
       </>
     );
@@ -215,6 +226,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
+          status={powerOrderSubmission?.status}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -242,6 +254,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
+          status={powerOrderSubmission?.status}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -258,6 +271,7 @@ const GroupCategoryContent = ({
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
+          status={fireEquipmentOrderSubmission?.status}
         />
       </>
     );
@@ -280,6 +294,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
+          status={powerOrderSubmission?.status}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}
@@ -296,6 +311,7 @@ const GroupCategoryContent = ({
           canEdit={userPageSettings?.isEditFireEquipmentOrder}
           isRegistered={checkAllRegisteredGroups?.fireEquipmentOrder}
           groupId={groupId}
+          status={fireEquipmentOrderSubmission?.status}
         />
       </>
     );
@@ -318,6 +334,7 @@ const GroupCategoryContent = ({
           isDeadline={!userPageSettings?.isEditPowerOrder}
           isRegistered={checkAllRegisteredGroups?.powerOrder}
           groupId={groupId}
+          status={powerOrderSubmission?.status}
         />
         <PublicRelations
           isDeadline={!userPageSettings?.isEditPublicRelation}


### PR DESCRIPTION
## 課題と解決策

管理者画面で電力申請・火気使用申請を「再提出待ち」に変更しても、ユーザー画面にステータスが反映されず、締切後に編集できない問題を修正しました。

調査の結果、既存の保健所関連申請でも団体カテゴリによってステータスの受け渡しが欠けていたため、以下もあわせて統一しています。

- 申請ステータス参照を `getStatus(applicationType)` に集約し、各カテゴリで必要なものだけ取得
- 表示対象となる全団体カテゴリへ再提出ステータスを連携
- 「通常受付中または再提出待ち」の場合に編集可能となるよう統一
- 再提出完了後に `unapproved` へ戻し、締切後は再びロック
- 再提出中の受付表示を「受付中」に統一
- 物品申請の反転していた期限判定を `isEditable` に整理
- 全申請種別のSlack通知とカテゴリ横断表示の回帰テストを追加

## レビュー対応

- 火気申請の権限を、新規登録用の `canRegisterNewFireEquipmentApplication` と既存編集用の `canEditExistingFireEquipmentApplication` に分離し、どちらかを受け付ける状態は `canSubmit` に集約（他申請の複数登録対応後に共通化予定）
- `canAdd=true / canEdit=false` の場合、既存申請の修正・削除・「申請なし」解除を許可しないよう修正
- 再提出待ちの場合のみ、新規登録・既存操作の両方を許可
- 再提出の直接比較と等価な期限判定を整理し、`isResubmissionStatus` / `canEditApplication` に共通化
- `home/index.tsx` のステータス検索を `getStatus(applicationType)` に整理
- 上記の火気申請権限を確認する回帰E2Eを追加

## 関連 Issue

Close #2138

## 検証結果

- `pnpm run lint`: 成功
- `pnpm exec tsc --noEmit --incremental false`: 成功
- Playwright 再提出UIテスト: 12件成功
- Rails 再提出関連テスト: 48件 / 178 assertions 成功
- 管理画面で再提出待ちに変更し、ユーザー画面で再提出・保存後ロックまでローカル確認済み

## 導入手順

DBマイグレーションや追加設定はありません。

## スクリーンショット

UIデザイン自体の変更はなく、ステータス表示と編集可否の挙動修正です。

## ローカルテスト手順

  ## 1. 環境を起動
  make build-gm3
  docker compose up -d

  アクセス先:

  - ユーザー画面: http://localhost:8003
  - 管理画面: http://localhost:8000
  - API: http://localhost:3000

  ## 2. 締切状態を作る

  管理画面へログインします。

  - メール: nutfes-taro@email.com
  - パスワード: gidaifes

  http://localhost:8000/user_page_setting を開き、確認対象の申請を「受付終了」にします。
  2020が対象年度です。

  - 物品申請
  - 電力申請
  - 従業員申請
  - 販売品申請
  - 購入品申請
  - 調理工程申請
  - 模擬店平面図
  - 火気使用申請

  最後に「保存」を押してください。

  ## 3. 管理画面で再提出にする

  食品販売団体の確認にはSeedの団体ID 1 が使えます。

  http://localhost:8000/order_status_check/1

  各申請のステータスを「再提出待ち」へ変更します。選択時に自動保存されます。

  ## 4. ユーザー画面で確認

  別タブで http://localhost:8003 にログインします。

  - メール: nutfes-taro@email.com
  - パスワード: gidaifes

  対象申請で以下を確認します。

  1. ステータスが「再提出」になっている
  2. 受付設定が終了していても「受付中」と表示される
  3. アコーディオンを開くと修正・入力できる
  4. 内容を変更して保存できる
  5. 保存後に「再提出」表示が消える
  6. 再び「受付終了」になり、修正ボタンが消える
  7. 管理画面を再読み込みするとステータスが「未確認」になっている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 再提出待ちの申請で、締切後でも対象フォームの編集・保存可否が再提出状況に応じて制御されます。  
  * 電力・火気・従業員・食品・レンタル品・地図など、各申請画面に再提出対応の判定が反映されました。  
  * 火気の更新（登録/削除/完了）後に、申請ステータス更新も同時に反映されます。
* **改善**
  * 再提出判定と編集可否のロジックを共通化し、画面挙動を統一しました。
  * 再提出フローのE2Eを調整しました。
* **テスト**
  * 再提出完了時のSlack通知を検証するテストとスタブ用ヘルパーを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->