### PR TITLE
物品貸出場所調整で物品ごとに異なる貸出場所を割り当て可能に

### DIFF
--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -57,7 +57,7 @@
       <div class="delete-modal-content">
         <h2>割り当ての削除</h2>
         <h4>
-          本当にこの団体の割り当てを削除しますか？<br>
+          本当にこの場所からこの団体の割り当てを削除しますか？<br>
         </h4>
         <div class="modal-actions">
           <YesButton v-if="$role(roleID).assign_items.delete" iconName="delete" :on_click="confirmDelete">削除する</YesButton>
@@ -85,18 +85,22 @@
         </div>
         <div class="order-group-content">
           <template v-for="group in activeAssignedGroups">
-            <template v-for="[rentalPlaceId, sourceBreakdown] in [[getGroupRentalPlace(group.id), getGroupSourceBreakdown(group.id)]]">
+            <template v-for="[sourceBreakdown] in [[getGroupSourceBreakdown(group.id)]]">
             <div
-              :key="group.id" 
+              :key="group.id"
               draggable="true"
               @dragstart="handleDragStartGroup($event, group)"
               class="group-card"
-              :class="{ 'is-fulfilled': rentalPlaceId }"
+              :class="{ 'is-fulfilled': isGroupFullyAssigned(group.id) }"
             >
                 <div class="group-name">
                   {{ group.name }}
-                  <span class="assigned" v-if="rentalPlaceId">
-                    {{ getPlaceName(rentalPlaceId) }}へ
+                </div>
+                <!-- チェックボックスで有効化されている物品はまとめて1枚のカードに表示 -->
+                <div class="item-summary">
+                  <span v-for="itemId in activeItemIdsForGroup(group.id)" :key="itemId" class="item-chip">
+                    {{ getItemName(itemId) }}: {{ getGroupTotalItem(group.id, itemId) }}
+                    <template v-if="getGroupItemPlace(group.id, itemId)">({{ getPlaceName(getGroupItemPlace(group.id, itemId)) }})</template>
                   </span>
                 </div>
                 <!-- 左側にも搬入元内訳を簡易表示 -->
@@ -204,17 +208,17 @@
                     割り当て済み団体をここにドロップ
                   </div>
                   <template v-else>
-                    <div 
+                    <div
                       v-for="group in groupsInPlace"
-                      :key="group.id" 
+                      :key="group.id"
                       class="assignment-item"
                     >
-                      <template v-for="[groupSourceBreakdown] in [[getGroupSourceBreakdown(group.id)]]">
+                      <template v-for="[groupSourceBreakdown] in [[getGroupSourceBreakdownForPlace(group.id, place.id)]]">
                         <div class="assign-group-name">
                           {{ group.name }}
                           <div class="import-source">
                             <span v-for="source in groupSourceBreakdown" :key="source.id">
-                              {{ source.name }}より: 
+                              {{ source.name }}より:
                               <template v-for="itemId in activeItemIds">
                                 <span v-if="source.items[itemId] > 0" :key="itemId" style="margin-right: 8px;">
                                   {{ getItemName(itemId) }}{{ source.items[itemId] }}
@@ -225,13 +229,13 @@
                         </div>
                       </template>
                       <div class="assign-inputs">
-                        <div v-for="itemId in activeItemIds" :key="itemId" class="assign-input-group">
+                        <div v-for="itemId in itemIdsAssignedAtPlace(group.id, place.id)" :key="itemId" class="assign-input-group">
                           <span class="input-label">
-                            {{ getItemName(itemId) }} {{ getGroupTotalItem(group.id, itemId) }}
+                            {{ getItemName(itemId) }} {{ getGroupItemTotalAtPlace(group.id, itemId, place.id) }}
                           </span>
                         </div>
                       </div>
-                      <button v-if="$role(roleID).assign_items.delete" class="btn-delete" @click="openDeleteModal(group.id)">✕</button>
+                      <button v-if="$role(roleID).assign_items.delete" class="btn-delete" @click="openDeleteModal(group.id, place.id)">✕</button>
                     </div>
                   </template>
                   </div>
@@ -256,6 +260,7 @@ export default {
       isModalOpen: false,
       isDeleteModalOpen: false,
       targetDeleteGroupId: null,
+      targetDeletePlaceId: null,
       items: [],
       groups: [],
       places: [],
@@ -412,11 +417,13 @@ export default {
 
       const type = e.dataTransfer.getData('type');
       if (type !== 'GROUP_LOCATION') return;
-      
+
       const groupId = e.dataTransfer.getData('groupId');
       if (!groupId) return;
 
-      const groupAssignments = this.getAssignmentsBy('group_id', groupId);
+      const groupAssignments = this.assignments.filter(
+        a => Number(a.group_id) === Number(groupId) && this.activeItemIds.includes(Number(a.rental_item_id))
+      );
       if (groupAssignments.length === 0) return;
 
       try {
@@ -430,25 +437,29 @@ export default {
     // ----------------------------
     // 削除確認モーダルの制御
     // ----------------------------
-    openDeleteModal(groupId) {
+    openDeleteModal(groupId, placeId) {
       if (!this.$role(this.roleID).assign_items.delete) return;
       this.targetDeleteGroupId = groupId;
+      this.targetDeletePlaceId = placeId;
       this.isDeleteModalOpen = true;
     },
     closeDeleteModal() {
       this.isDeleteModalOpen = false;
       this.targetDeleteGroupId = null;
+      this.targetDeletePlaceId = null;
     },
     async confirmDelete() {
       if (!this.$role(this.roleID).assign_items.delete) return;
-      if (!this.targetDeleteGroupId) return;
-      await this.removeGroupFromPlace(this.targetDeleteGroupId);
+      if (!this.targetDeleteGroupId || !this.targetDeletePlaceId) return;
+      await this.removeGroupFromPlace(this.targetDeleteGroupId, this.targetDeletePlaceId);
       this.closeDeleteModal();
     },
 
-    async removeGroupFromPlace(groupId) {
+    async removeGroupFromPlace(groupId, placeId) {
       if (!this.$role(this.roleID).assign_items.delete) return;
-      const groupAssignments = this.assignments.filter(a => Number(a.group_id) === Number(groupId) && a.rental_place_id);
+      const groupAssignments = this.assignments.filter(
+        a => Number(a.group_id) === Number(groupId) && Number(a.rental_place_id) === Number(placeId)
+      );
       try {
         await this.updateAssignmentsPlace(groupAssignments, null);
       } catch (error) {
@@ -485,9 +496,35 @@ export default {
       return this.getNameById(this.places, placeId);
     },
 
-    getGroupRentalPlace(groupId) {
-      const assign = this.getAssignmentsBy('group_id', groupId).find(a => a.rental_place_id);
+    getGroupItemPlace(groupId, itemId) {
+      const assign = this.assignments.find(
+        a => Number(a.group_id) === Number(groupId) && Number(a.rental_item_id) === Number(itemId) && a.rental_place_id
+      );
       return assign ? assign.rental_place_id : null;
+    },
+
+    activeItemIdsForGroup(groupId) {
+      return this.activeItemIds.filter(itemId => this.getGroupTotalItem(groupId, itemId) > 0);
+    },
+
+    isGroupFullyAssigned(groupId) {
+      const itemIds = this.activeItemIdsForGroup(groupId);
+      if (itemIds.length === 0) return false;
+      return itemIds.every(itemId => this.getGroupItemPlace(groupId, itemId));
+    },
+
+    getGroupItemTotalAtPlace(groupId, itemId, placeId) {
+      return this.assignments
+        .filter(
+          a => Number(a.group_id) === Number(groupId) &&
+            Number(a.rental_item_id) === Number(itemId) &&
+            Number(a.rental_place_id) === Number(placeId)
+        )
+        .reduce((sum, a) => sum + Number(a.num || 0), 0);
+    },
+
+    itemIdsAssignedAtPlace(groupId, placeId) {
+      return this.activeItemIds.filter(itemId => this.getGroupItemTotalAtPlace(groupId, itemId, placeId) > 0);
     },
 
     getGroupsInPlace(placeId) {
@@ -515,6 +552,14 @@ export default {
 
     getPlaceSourceBreakdown(placeId) {
       return this.calculateSourceBreakdown(this.getAssignmentsBy('rental_place_id', placeId));
+    },
+
+    getGroupSourceBreakdownForPlace(groupId, placeId) {
+      return this.calculateSourceBreakdown(
+        this.assignments.filter(
+          a => Number(a.group_id) === Number(groupId) && Number(a.rental_place_id) === Number(placeId)
+        )
+      );
     },
 
     calculateSourceBreakdown(assignRecords) {
@@ -822,6 +867,18 @@ export default {
   border-color: #16a34a;
   opacity: 0.6;
 }
+.item-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.item-chip {
+  font-size: 12px;
+  background-color: #f1f5f9;
+  border-radius: 10px;
+  padding: 4px 8px;
+}
 .group-name {
   font-weight: bold;
   margin-bottom: 12px;
@@ -864,13 +921,6 @@ export default {
   padding-top: 8px;
   padding-bottom: 4px;
   padding-left: 8px;
-}
-.assigned {  
-  font-size: 12px;
-  background-color: #e2e8f0;
-  border-radius: 10px;
-  padding: 4px 8px;
-  color: #000000;
 }
 .stock-area {
   flex: 1;

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -323,15 +323,36 @@ export default {
         this.validPlaceCategoryIds.includes(Number(place.place_category_id))
       );
     },
+    // 団体ID・貸出場所IDごとに割当をあらかじめ振り分けておき、
+    // 全件走査を繰り返さずに済むようにする(assignmentsが変わった時だけ再計算される)
+    assignmentsByGroupId() {
+      const map = new Map();
+      this.assignments.forEach(a => {
+        const groupId = Number(a.group_id);
+        if (!map.has(groupId)) map.set(groupId, []);
+        map.get(groupId).push(a);
+      });
+      return map;
+    },
+    assignmentsByPlaceId() {
+      const map = new Map();
+      this.assignments.forEach(a => {
+        if (a.rental_place_id == null) return;
+        const placeId = Number(a.rental_place_id);
+        if (!map.has(placeId)) map.set(placeId, []);
+        map.get(placeId).push(a);
+      });
+      return map;
+    },
     activeAssignedGroups() {
       return this.groups.filter(g => {
         // 年度での絞り込み
         if (this.refYearID !== 0 && Number(g.fes_year_id) !== this.refYearID) return false;
-        
+
         // 団体のカテゴリーでの絞り込み
         if (this.refCategoryID !== 0 && Number(g.group_category_id) !== this.refCategoryID) return false;
 
-        const groupAssigns = this.assignments.filter(a => Number(a.group_id) === Number(g.id));
+        const groupAssigns = this.getGroupAssignments(g.id);
         if (groupAssigns.length === 0) return false;
 
         return this.activeItemIds.some(itemId => {
@@ -392,13 +413,27 @@ export default {
       if (!this.$role(this.roleID).assign_items.update) return;
       if (groupAssignments.length === 0) return;
 
-      // 途中で失敗した場合に不整合な書き込みを広げないよう、直列に更新する
-      for (const assign of groupAssignments) {
-        await this.$axios.$put(`/assign_rental_items/${assign.id}`, { rental_place_id: rentalPlaceId });
-        assign.rental_place_id = rentalPlaceId;
-      }
+      const previousPlaceIds = groupAssignments.map(a => a.rental_place_id);
 
+      // 体感速度のため先に画面へ反映し、サーバー側は直列に更新する
+      groupAssignments.forEach(a => { a.rental_place_id = rentalPlaceId; });
       this.assignments = [...this.assignments];
+
+      try {
+        for (const assign of groupAssignments) {
+          await this.$axios.$put(`/assign_rental_items/${assign.id}`, { rental_place_id: rentalPlaceId });
+        }
+      } catch (error) {
+        // 途中で失敗した場合は、既にサーバーへ反映済みの分も含めて元の場所へ補償的に戻す
+        await Promise.allSettled(
+          groupAssignments.map((assign, i) =>
+            this.$axios.$put(`/assign_rental_items/${assign.id}`, { rental_place_id: previousPlaceIds[i] })
+          )
+        );
+        groupAssignments.forEach((a, i) => { a.rental_place_id = previousPlaceIds[i]; });
+        this.assignments = [...this.assignments];
+        throw error;
+      }
     },
 
     async handleDropOnPlace(e, rentalPlace) {
@@ -410,8 +445,8 @@ export default {
       const groupId = e.dataTransfer.getData('groupId');
       if (!groupId) return;
 
-      const groupAssignments = this.assignments.filter(
-        a => Number(a.group_id) === Number(groupId) && this.activeItemIds.includes(Number(a.rental_item_id))
+      const groupAssignments = this.getGroupAssignments(groupId).filter(
+        a => this.activeItemIds.includes(Number(a.rental_item_id))
       );
       if (groupAssignments.length === 0) return;
 
@@ -439,15 +474,15 @@ export default {
     },
     async confirmDelete() {
       if (!this.$role(this.roleID).assign_items.delete) return;
-      if (!this.targetDeleteGroupId || !this.targetDeletePlaceId) return;
+      if (this.targetDeleteGroupId == null || this.targetDeletePlaceId == null) return;
       await this.removeGroupFromPlace(this.targetDeleteGroupId, this.targetDeletePlaceId);
       this.closeDeleteModal();
     },
 
     async removeGroupFromPlace(groupId, placeId) {
       if (!this.$role(this.roleID).assign_items.delete) return;
-      const groupAssignments = this.assignments.filter(
-        a => Number(a.group_id) === Number(groupId) && Number(a.rental_place_id) === Number(placeId)
+      const groupAssignments = this.getGroupAssignments(groupId).filter(
+        a => Number(a.rental_place_id) === Number(placeId)
       );
       try {
         await this.updateAssignmentsPlace(groupAssignments, null);
@@ -464,8 +499,12 @@ export default {
       return record ? record.name : '不明';
     },
 
-    getAssignmentsBy(key, value) {
-      return this.assignments.filter(a => Number(a[key]) === Number(value));
+    getGroupAssignments(groupId) {
+      return this.assignmentsByGroupId.get(Number(groupId)) || [];
+    },
+
+    getPlaceAssignments(placeId) {
+      return this.assignmentsByPlaceId.get(Number(placeId)) || [];
     },
 
     getTotalItem(assignRecords, itemId) {
@@ -486,8 +525,8 @@ export default {
     },
 
     getGroupItemPlace(groupId, itemId) {
-      const assign = this.assignments.find(
-        a => Number(a.group_id) === Number(groupId) && Number(a.rental_item_id) === Number(itemId) && a.rental_place_id
+      const assign = this.getGroupAssignments(groupId).find(
+        a => Number(a.rental_item_id) === Number(itemId) && a.rental_place_id
       );
       return assign ? assign.rental_place_id : null;
     },
@@ -504,12 +543,8 @@ export default {
     },
 
     getGroupItemTotalAtPlace(groupId, itemId, placeId) {
-      return this.assignments
-        .filter(
-          a => Number(a.group_id) === Number(groupId) &&
-            Number(a.rental_item_id) === Number(itemId) &&
-            Number(a.rental_place_id) === Number(placeId)
-        )
+      return this.getGroupAssignments(groupId)
+        .filter(a => Number(a.rental_item_id) === Number(itemId) && Number(a.rental_place_id) === Number(placeId))
         .reduce((sum, a) => sum + Number(a.num || 0), 0);
     },
 
@@ -519,9 +554,9 @@ export default {
 
     getGroupsInPlace(placeId) {
       const groupIdsInPlace = [...new Set(
-        this.getAssignmentsBy('rental_place_id', placeId).map(a => Number(a.group_id))
+        this.getPlaceAssignments(placeId).map(a => Number(a.group_id))
       )];
-      
+
       return this.groups.filter(g => {
         if (!groupIdsInPlace.includes(Number(g.id))) return false;
         return this.activeItemIds.some(itemId => this.getGroupTotalItem(g.id, itemId) > 0);
@@ -529,26 +564,24 @@ export default {
     },
 
     getGroupTotalItem(groupId, itemId) {
-      return this.getTotalItem(this.getAssignmentsBy('group_id', groupId), itemId);
+      return this.getTotalItem(this.getGroupAssignments(groupId), itemId);
     },
 
     getPlaceTotalItem(placeId, itemId) {
-      return this.getTotalItem(this.getAssignmentsBy('rental_place_id', placeId), itemId);
+      return this.getTotalItem(this.getPlaceAssignments(placeId), itemId);
     },
 
     getGroupSourceBreakdown(groupId) {
-      return this.calculateSourceBreakdown(this.getAssignmentsBy('group_id', groupId));
+      return this.calculateSourceBreakdown(this.getGroupAssignments(groupId));
     },
 
     getPlaceSourceBreakdown(placeId) {
-      return this.calculateSourceBreakdown(this.getAssignmentsBy('rental_place_id', placeId));
+      return this.calculateSourceBreakdown(this.getPlaceAssignments(placeId));
     },
 
     getGroupSourceBreakdownForPlace(groupId, placeId) {
       return this.calculateSourceBreakdown(
-        this.assignments.filter(
-          a => Number(a.group_id) === Number(groupId) && Number(a.rental_place_id) === Number(placeId)
-        )
+        this.getGroupAssignments(groupId).filter(a => Number(a.rental_place_id) === Number(placeId))
       );
     },
 

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -261,6 +261,7 @@ export default {
       isDeleteModalOpen: false,
       targetDeleteGroupId: null,
       targetDeletePlaceId: null,
+      updatingGroupIds: new Set(),
       items: [],
       groups: [],
       places: [],
@@ -413,6 +414,12 @@ export default {
       if (!this.$role(this.roleID).assign_items.update) return;
       if (groupAssignments.length === 0) return;
 
+      // 同一団体への操作が処理中に重複して走ると、後発の正常な更新を
+      // 先発のロールバックが上書きしてしまうため、団体単位で多重実行を防ぐ
+      const groupId = Number(groupAssignments[0].group_id);
+      if (this.updatingGroupIds.has(groupId)) return;
+      this.updatingGroupIds.add(groupId);
+
       const previousPlaceIds = groupAssignments.map(a => a.rental_place_id);
 
       // 体感速度のため先に画面へ反映し、サーバー側は直列に更新する
@@ -433,6 +440,8 @@ export default {
         groupAssignments.forEach((a, i) => { a.rental_place_id = previousPlaceIds[i]; });
         this.assignments = [...this.assignments];
         throw error;
+      } finally {
+        this.updatingGroupIds.delete(groupId);
       }
     },
 
@@ -488,6 +497,7 @@ export default {
         await this.updateAssignmentsPlace(groupAssignments, null);
       } catch (error) {
         alert("割り当ての解除に失敗しました。");
+        await this.fetchDataFromDB();
       }
     },
 
@@ -559,7 +569,7 @@ export default {
 
       return this.groups.filter(g => {
         if (!groupIdsInPlace.includes(Number(g.id))) return false;
-        return this.activeItemIds.some(itemId => this.getGroupTotalItem(g.id, itemId) > 0);
+        return this.activeItemIds.some(itemId => this.getGroupItemTotalAtPlace(g.id, itemId, placeId) > 0);
       });
     },
 

--- a/admin_view/nuxt-project/pages/rental_item_location/index.vue
+++ b/admin_view/nuxt-project/pages/rental_item_location/index.vue
@@ -388,26 +388,15 @@ export default {
       e.dataTransfer.setData('groupId', group.id);
     },
 
-    async updateAssignmentsPlace(groupAssignments, rentalPlaceId) { 
+    async updateAssignmentsPlace(groupAssignments, rentalPlaceId) {
       if (!this.$role(this.roleID).assign_items.update) return;
       if (groupAssignments.length === 0) return;
 
-      const promises = groupAssignments.map(assign => {
-        const payload = {
-          group_id: assign.groupId,
-          rentalItemId: assign.rentalItemId,
-          num: assign.num,
-          stockerPlaceId: assign.stockerPlaceId,
-          rental_place_id: rentalPlaceId
-        };
-        return this.$axios.$put(`/assign_rental_items/${assign.id}`, payload);
-      });
-
-      await Promise.all(promises);
-
-      groupAssignments.forEach(a => {
-        a.rental_place_id = rentalPlaceId;
-      });
+      // 途中で失敗した場合に不整合な書き込みを広げないよう、直列に更新する
+      for (const assign of groupAssignments) {
+        await this.$axios.$put(`/assign_rental_items/${assign.id}`, { rental_place_id: rentalPlaceId });
+        assign.rental_place_id = rentalPlaceId;
+      }
 
       this.assignments = [...this.assignments];
     },
@@ -508,6 +497,7 @@ export default {
     },
 
     isGroupFullyAssigned(groupId) {
+      // 場所が団体内でバラバラでもよく、各物品がどこかしらに割り当て済みかどうかを見る
       const itemIds = this.activeItemIdsForGroup(groupId);
       if (itemIds.length === 0) return false;
       return itemIds.every(itemId => this.getGroupItemPlace(groupId, itemId));


### PR DESCRIPTION
resolve #2149 
# 概要
物品貸出場所調整画面で、団体全体でしか貸出場所を設定できなかった仕様を見直し、有効化されている物品単位で場所を割り当てられるようにしました。既存データで物品ごとに異なる場所が登録されている場合は、そのまま複数の貸出場所カードに分かれて表示されます。

# 実装詳細
- 削除ボタンのスコープを団体単位から「団体×貸出場所」単位に修正(以前は1箇所から外すつもりが団体の全拠点の割当を消していた)
- 貸出場所カード内の団体表示・数量・削除操作を、その場所に実際に置かれている物品分だけに絞り込み
- ドラッグ&ドロップは団体カード単位のまま、更新対象を「対象物品を設定」で有効化されている物品のみに限定
- `updateAssignmentsPlace` を楽観的更新+直列PUT+失敗時の補償ロールバックに変更し、体感速度と整合性を両立
- `assignments` を団体ID・貸出場所IDで振り分けたcomputed Mapを導入し、テンプレート内のネストしたループで全件走査を繰り返さないようにした

# テスト項目
- [ ] 同一団体の異なる物品を、別々の貸出場所へドラッグ&ドロップで割り当てられるか
- [ ] 既存データで物品ごとに異なる場所が登録されている団体が、複数の貸出場所カードにまたがって表示されるか
- [ ] 貸出場所カードの「✕」ボタンで、その場所からの割当だけが解除され、他の場所の割当は残るか
- [ ] 更新途中でAPIエラーが起きた場合に、画面がおかしな中間状態のまま残らないか

# 備考
テストコードは未整備のままです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 割り当て編集画面で、有効化した物品ごとの合計数と貸出場所を団体カード内に表示します。
  * 貸出場所カードで、選択中の物品に関する団体別・搬入元別の内訳を確認できます。
  * 割り当ての削除対象を、団体と貸出場所の組み合わせ単位で指定できるようになりました。

* **バグ修正**
  * ドラッグ＆ドロップによる場所変更に失敗した際、画面表示を元の状態へ正しく戻します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->