### PR TITLE
groupsのDBにシークレット値を追加する

### DIFF
--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -45,6 +45,7 @@ class Group < ApplicationRecord
   has_many :fire_equipment_orders, dependent: :destroy
   has_many :health_center_submission_statuses, dependent: :destroy
   has_many :comments, as: :commentable, dependent: :destroy
+  has_secure_token :secret, length: 24
 
   scope :with_order_status_check_relations, -> { includes(*ORDER_STATUS_CHECK_INCLUDES) }
 

--- a/api/db/migrate/20260804073713_add_secret_to_groups.rb
+++ b/api/db/migrate/20260804073713_add_secret_to_groups.rb
@@ -1,0 +1,23 @@
+
+class AddSecretToGroups < ActiveRecord::Migration[6.1]
+  class MigrationGroup < ActiveRecord::Base
+    self.table_name = 'groups'
+  end
+
+  def up
+    add_column :groups, :secret, :string
+
+    MigrationGroup.reset_column_information
+    MigrationGroup.find_each do |group|
+      group.update_columns(secret: SecureRandom.base58(24))
+    end
+
+    change_column_null :groups, :secret, false
+    add_index :groups, :secret, unique: true
+  end
+
+  def down
+    remove_index :groups, :secret
+    remove_column :groups, :secret
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_07_23_000001) do
+ActiveRecord::Schema.define(version: 2026_08_04_073713) do
 
   create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "group_id"
@@ -177,6 +177,8 @@ ActiveRecord::Schema.define(version: 2026_07_23_000001) do
     t.boolean "is_external"
     t.bigint "uses_place_id"
     t.boolean "is_health_center_submission_target", default: true, null: false
+    t.string "secret", null: false
+    t.index ["secret"], name: "index_groups_on_secret", unique: true
     t.index ["uses_place_id"], name: "index_groups_on_uses_place_id"
   end
 

--- a/api/test/fixtures/groups.yml
+++ b/api/test/fixtures/groups.yml
@@ -7,6 +7,7 @@ one:
   user_id: 1
   group_category_id: 1
   fes_year_id: 1
+  secret: fixture_secret_one_00001
 
 two:
   name: MyString
@@ -15,3 +16,4 @@ two:
   user_id: 1
   group_category_id: 1
   fes_year_id: 1
+  secret: fixture_secret_two_00002

--- a/api/test/models/group_test.rb
+++ b/api/test/models/group_test.rb
@@ -59,4 +59,75 @@ class GroupTest < ActiveSupport::TestCase
     assert_not group.valid?
     assert group.errors[:uses_place].present?
   end
+
+  test 'should generate a 24-character secret on create' do
+    group = Group.create!(
+      name: 'Group One',
+      project_name: 'Project One',
+      activity: 'Activity One',
+      user: @user,
+      group_category: @group_category,
+      fes_year: @fes_year
+    )
+    assert_equal 24, group.secret.length
+  end
+
+  test 'regenerate_secret should replace the secret with a new value' do
+    group = Group.create!(
+      name: 'Group One',
+      project_name: 'Project One',
+      activity: 'Activity One',
+      user: @user,
+      group_category: @group_category,
+      fes_year: @fes_year
+    )
+    old_secret = group.secret
+
+    group.regenerate_secret
+
+    assert_equal 24, group.secret.length
+    assert_not_equal old_secret, group.secret
+  end
+
+  test 'should raise a not-null violation when secret is cleared at the database level' do
+    group = Group.create!(
+      name: 'Group One',
+      project_name: 'Project One',
+      activity: 'Activity One',
+      user: @user,
+      group_category: @group_category,
+      fes_year: @fes_year
+    )
+
+    assert_raises(ActiveRecord::NotNullViolation) do
+      # rubocop:disable Rails/SkipsModelValidations
+      group.update_column(:secret, nil)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+
+  test 'should raise a uniqueness violation when secret duplicates another group at the database level' do
+    group_one = Group.create!(
+      name: 'Group One',
+      project_name: 'Project One',
+      activity: 'Activity One',
+      user: @user,
+      group_category: @group_category,
+      fes_year: @fes_year
+    )
+    group_two = Group.create!(
+      name: 'Group Two',
+      project_name: 'Project Two',
+      activity: 'Activity Two',
+      user: @user,
+      group_category: @group_category,
+      fes_year: @fes_year
+    )
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      # rubocop:disable Rails/SkipsModelValidations
+      group_two.update_column(:secret, group_one.secret)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
 end


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue

<!-- 対応したIssue番号を記載 -->
resolve [#2155](https://github.com/NUTFes/group-manager-2/issues/2145?issue=NUTFes%7Cgroup-manager-2%7C2155)

# 概要
-  groupsテーブルに、認証なしでリンク共有されたユーザー専用ページを安全に発行するための、推測不可能なランダム値secretカラムを追加した。


# 実装詳細
- 1.  マイグレーション (api/db/migrate/20260804073713_add_secret_to_groups.rb)
既存行があるテーブルにNOT NULLのstringカラムを一度に追加すると失敗する(MySQLのstrict modeでデフォルト値なしNOT NULLを許さない)ため、3段階に分けて実施:
  - 1.  NULL許可でsecretカラムを追加
  - 2.  既存行を1件ずつSecureRandom.base58(24)で生成したユニークな値で埋める
  - 3.  change_column_nullでNOT NULL制約を付与し、unique: trueのインデックスを追加

ロールバック(down)では、削除前にNOT NULL制約を外す必要がある点に注意(先にindex・columnを削除する順序は問題なし)。

- 2. モデル (api/app/models/group.rb:48)
has_secure_token :secret, length: 24
これにより新規Group作成時にも自動でユニークなsecret(24byte, 約144bitエントロピー)が生成される。group.regenerate_secretも無料で使えるようになり、リンク漏洩時の再発行に利用可能。

- 3. 設計判断
- 平文保存: パスワードと異なり使い回しの心配がないシステム生成トークンのため、ハッシュ化不要(かつWHERE secret = ?で照合する必要があるため平文が必須)。運用上 の露出に注意。
- 強度: 128bit以上のエントロピーが基準。has_secure_tokenのデフォルト24byteがちょうど良い落としどころ。

- 

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="815" height="310" alt="image" src="https://github.com/user-attachments/assets/c0f69892-9675-4c07-9c43-ba03669d79da" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] migrateが失敗しないか
- [x] データが正しく格納できるか

# 備考
<!-- 実装していて困った箇所・質問など -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * グループごとに一意の24文字セキュアトークンを追加しました。
  * 既存のグループにもトークンを自動設定しました。
  * 必要に応じてトークンを再生成できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->