### PR TITLE
[fix] ログインモーダルが一部端末で収まりきらない問題を修正

### DIFF
--- a/user/src/components/Form/TextBox/TextBox.tsx
+++ b/user/src/components/Form/TextBox/TextBox.tsx
@@ -48,7 +48,7 @@ const TextBox: FC<TextBoxProps> = ({
             value={value}
             onChange={handleChange}
             onBlur={onBlur}
-            className={`h-12 w-[400px] rounded-[10px] border-2 p-4 text-font ${error ? 'border-alert' : 'border-main'}`}
+            className={`h-12 w-full max-w-[400px] rounded-[10px] border-2 p-4 text-font ${error ? 'border-alert' : 'border-main'}`}
           />
           {isPassword && (
             <button

--- a/user/src/components/LoginModal/LoginModal.tsx
+++ b/user/src/components/LoginModal/LoginModal.tsx
@@ -18,9 +18,9 @@ const LoginModal: FC<LoginModalProps> = ({ isOpen, onClose }) => {
     <Modal isOpen={isOpen} onClose={onClose}>
       <form
         onSubmit={handleSignInSubmit}
-        className="flex flex-col items-center gap-12 rounded-[30px] bg-white px-60 py-20 shadow-2xl"
+        className="flex flex-col items-center gap-12 rounded-[30px] bg-white px-8 py-10 shadow-2xl md:px-60 md:py-20"
       >
-        <div className="flex w-96 flex-col items-center justify-center gap-12">
+        <div className="flex w-full max-w-96 flex-col items-center justify-center gap-12">
           <TextBox
             label={loginModalTexts.labels.email}
             type="email"

--- a/user/src/components/Modal/Modal.tsx
+++ b/user/src/components/Modal/Modal.tsx
@@ -9,9 +9,9 @@ type ModalProps = {
 const Modal: FC<ModalProps> = ({ isOpen, onClose, children }) => {
   if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden">
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto">
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative z-10 flex max-w-[880px] items-center justify-center">
+      <div className="relative z-10 flex max-h-[90vh] max-w-[880px] items-center justify-center overflow-y-auto">
         {children}
       </div>
     </div>


### PR DESCRIPTION
# 対応Issue
resolve #2152

# 概要
- ユーザー画面のログインモーダルが一部スマートフォン(OPPO Reno7A等)ではみ出す問題を修正

# 実装詳細
- Modal.tsx: 外側/内側コンテナに`overflow-y-auto`を付与し、内側に`max-h-[90vh]`を設定。画面に収まらない場合でも切れずにスクロールできるように変更
- LoginModal.tsx: フォームのpadding(`px-60 py-20`)をモバイル用に`px-8 py-10`へ縮小し、`md:`以上で元のサイズに戻すようレスポンシブ化。内側コンテナの幅も`w-96`固定から`w-full max-w-96`に変更
- TextBox.tsx: inputに固定幅`w-[400px]`が指定されており、上記の修正だけでは狭い画面(412px程度)で依然としてオーバーフローする根本原因だったため、`w-full max-w-[400px]`に変更(他フォームでも共通利用されているコンポーネントのため影響範囲を確認済み)

# 画面スクリーンショット等
<img width="381" height="833" alt="image" src="https://github.com/user-attachments/assets/e9d5932a-16ff-4666-a28c-89bd87f4d6cd" />


# テスト項目
- [ ] スマートフォン(幅412px程度、OPPO Reno7A等)でログインモーダルが横にはみ出さず表示されること
- [ ] 画面が低い端末でモーダルの内容が画面に収まらない場合、スクロールで全項目にアクセスできること
- [ ] PC(md以上)でのログインモーダルの表示が従来通り崩れていないこと
- [ ] TextBoxコンポーネントを利用する他フォーム(会員登録・各種申請フォーム等)の表示が崩れていないこと

# 備考
- 開発環境の権限問題によりローカルでの実機/ブラウザでの表示確認ができておらず、CSSのボックスモデル計算による確認にとどまっています。マージ前にレビュアーの方で実機またはDevToolsでの確認をお願いします。